### PR TITLE
BUG: Fix mapping values for several products (Fixes #253)

### DIFF
--- a/metpy/io/nexrad.py
+++ b/metpy/io/nexrad.py
@@ -799,12 +799,15 @@ class GenericDigitalMapper(DataMapper):
         max_data_val = prod.thresholds[5]
         leading_flags = prod.thresholds[6]
         trailing_flags = prod.thresholds[7]
-        self.lut = [self.MISSING] * max_data_val
+
+        # Values will be [0, max] inclusive, so need to add 1 to max value to get proper size.
+        self.lut = [self.MISSING] * (max_data_val + 1)
 
         if leading_flags > 1:
             self.lut[1] = self.RANGE_FOLD
 
-        for i in range(leading_flags, max_data_val - trailing_flags):
+        # Need to add 1 to the end of the range so that it's inclusive
+        for i in range(leading_flags, max_data_val - trailing_flags + 1):
             self.lut[i] = (i - offset) / scale
 
         self.lut = np.array(self.lut)

--- a/metpy/io/tests/test_nexrad.py
+++ b/metpy/io/tests/test_nexrad.py
@@ -53,7 +53,14 @@ nexrad_nids_files = glob.glob(os.path.join(get_test_data('nids', as_file_obj=Fal
 @pytest.mark.parametrize('fname', nexrad_nids_files)
 def test_level3_files(fname):
     'Test opening a NEXRAD NIDS file'
-    Level3File(fname)
+    f = Level3File(fname)
+
+    # If we have some raster data in the symbology block, feed it into the mapper to make
+    # sure it's working properly (Checks for #253)
+    if hasattr(f, 'sym_block'):
+        block = f.sym_block[0][0]
+        if 'data' in block:
+            f.map_data(block['data'])
 
 
 tdwr_nids_files = glob.glob(os.path.join(get_test_data('nids', as_file_obj=False),


### PR DESCRIPTION
GenericDigitialMapper was incorrectly using the maximum level as the
size of the table and as the end point for range. This is a valid value,
so the size/end of range needs to be this +1.

Test this by trying to map data out of the products that have data.