### PR TITLE
MNT: Fix for gradient change in numpy 1.12

### DIFF
--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -15,7 +15,7 @@ def _gradient(f, *args, **kwargs):
     if len(args) < f.ndim:
         args = list(args)
         args.extend([units.Quantity(1., 'dimensionless')] * (f.ndim - len(args)))
-    grad = np.gradient(f, *args, **kwargs)
+    grad = np.gradient(f, *(a.magnitude for a in args), **kwargs)
     if f.ndim == 1:
         return units.Quantity(grad, f.units / args[0].units)
     return [units.Quantity(g, f.units / dx.units) for dx, g in zip(args, grad)]


### PR DESCRIPTION
Numpy added an extra check to gradient (#7618), so we can't pass in pint
Quantities any more. We're already wrapping gradient, so it's no big
deal to make sure to pass actual scalar values.