### PR TITLE
Add pytest-flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ env:
   matrix:
     - TASK="coverage"
     - TASK="examples"
-    - TASK="lint"
 
 matrix:
   include:
@@ -59,9 +58,7 @@ matrix:
 
 before_install:
   - pip install --upgrade pip;
-  - if [[ $TASK == "lint" ]]; then
-      pip install flake8 pep8-naming flake8-quotes;
-    elif [[ $TASK == "docs" ]]; then
+  - if [[ $TASK == "docs" ]]; then
         pip install -r docs/requirements.txt -f $WHEELHOUSE;
     else
       if [[ $TASK == "examples" ]]; then
@@ -79,8 +76,7 @@ before_install:
         pkg-config --modversion proj;
         popd;
       else
-        export TEST_OPTS="--mpl";
-        pip install pytest-mpl;
+        export TEST_OPTS="--flake8 --mpl";
         if [[ $TASK == "coverage" ]]; then
           export TEST_OPTS="$TEST_OPTS --cov=metpy";
           pip install pytest-cov;
@@ -96,7 +92,7 @@ before_install:
     fi
 
 install:
-  - if [[ $TASK != "lint" && $TASK != "docs" ]]; then
+  - if [[ $TASK != "docs" ]]; then
       pip install ".[$EXTRA_INSTALLS]" --upgrade --no-index $PRE -f file://$PWD/$WHEELDIR $VERSIONS;
       if [[ $TASK == "examples" ]]; then
         python setup.py examples;
@@ -104,9 +100,7 @@ install:
     fi
 
 script:
-  - if [[ $TASK == "lint" ]]; then
-      flake8 metpy;
-    elif [[ $TASK == "docs" ]]; then
+  - if [[ $TASK == "docs" ]]; then
       pushd docs;
       make html 2>../docs.log;
       popd;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ build: off
 test_script:
     - cmd: set TEST_DATA_DIR=%APPVEYOR_BUILD_FOLDER%\\testdata
     - cmd: if %PYTHON_VERSION% == 2.7 find examples\notebooks -name "*.ipynb" -exec sed -i -e s/python3/python2/ {} ;
-    - cmd: python setup.py test --addopts "--junitxml=tests.xml --mpl --cov=metpy"
+    - cmd: python setup.py test --addopts "--junitxml=tests.xml --flake8 --mpl --cov=metpy"
     - ps: $wc = New-Object 'System.Net.WebClient'
     - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\tests.xml))
     - cmd: find examples\notebooks\ -name "*.ipynb" -print0 | xargs -0 -n1 jupyter nbconvert --execute --ExecutePreprocessor.timeout=200 --ExecutePreprocessor.kernel_name=devel --inplace

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - sphinx
   - pytest
   - pytest-cov
+  - pytest-flake8
   - pytest-mpl
   - pytest-runner
   - flake8

--- a/metpy/plots/skewt.py
+++ b/metpy/plots/skewt.py
@@ -181,12 +181,12 @@ class SkewXAxes(Axes):
 
     @property
     def lower_xlim(self):
-        r"The data limits for the x-axis along the bottom of the axes"
+        r'The data limits for the x-axis along the bottom of the axes'
         return self.axes.viewLim.intervalx
 
     @property
     def upper_xlim(self):
-        r"The data limits for the x-axis along the top of the axes"
+        r'The data limits for the x-axis along the top of the axes'
         return self.transDataToAxes.inverted().transform([[0., 1.], [1., 1.]])[:, 0]
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-norecursedirs = examples docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,12 @@ ignore = F405
 max-line-length = 95
 exclude = metpy/_version.py
 
+[tool:pytest]
+norecursedirs = build examples docs
+flake8-ignore = *.py F405
+                versioneer.py ALL
+flake8-max-line-length = 95
+
 [doc8]
 ignore-path = docs/source/examples/generated
 max-line-length = 95

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import versioneer
 
 class MakeExamples(Command):
     description = 'Create example scripts from IPython notebooks'
-    user_options=[]
+    user_options = []
 
     def initialize_options(self):
         pass

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,8 @@ setup(
         'dev': ['ipython[all]>=3.1'],
         'doc': ['sphinx>=1.3', 'ipython[all]>=3.1'],
         'examples': ['cartopy>=0.13.1'],
-        'test': ['pytest', 'pytest-runner']
+        'test': ['pytest', 'pytest-runner', 'pytest-mpl', 'pytest-flake8',
+                 'flake8-quotes', 'pep8-naming']
     },
 
     cmdclass=commands,


### PR DESCRIPTION
Instead of running flake8 manually, add it as another plugin to pytest. It's simpler and more automatic, and this way there's only one test to run. It also allows us to simplify our Travis config and shorten the build matrix (~2 minutes of build time).