### PR TITLE
fix get_wind_components see also doc string

### DIFF
--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -93,7 +93,8 @@ def get_wind_components(speed, wdir):
 
     See Also
     --------
-    get_speed_dir
+    get_wind_speed
+    get_wind_dir
 
     Examples
     --------


### PR DESCRIPTION
The [get_wind_components](http://metpy.readthedocs.io/en/latest/api/basic.html#metpy.calc.basic.get_wind_components) doc string's `See Also` section points to a non existent function. Here's a quick fix. Feel free to edit as you like.