### PR TITLE
Fix bug in Hodograph Object

### DIFF
--- a/metpy/plots/skewt.py
+++ b/metpy/plots/skewt.py
@@ -555,9 +555,9 @@ class Hodograph(object):
             self.ax = plt.figure().add_subplot(1, 1, 1)
         else:
             self.ax = ax
-        ax.set_aspect('equal', 'box')
-        ax.set_xlim(-component_range, component_range)
-        ax.set_ylim(-component_range, component_range)
+        self.ax.set_aspect('equal', 'box')
+        self.ax.set_xlim(-component_range, component_range)
+        self.ax.set_ylim(-component_range, component_range)
 
         # == sqrt(2) * max_range, which is the distance at the corner
         self.max_range = 1.4142135 * component_range

--- a/metpy/plots/tests/test_skewt.py
+++ b/metpy/plots/tests/test_skewt.py
@@ -78,6 +78,9 @@ def test_hodograph_units():
     hodo.plot_colormapped(u, v, np.sqrt(u * u + v * v), cmap='Greys')
     return fig
 
+
 def test_hodograph_alone():
-    hodo = Hodograph()
+    """Test to create Hodograph without specifying axes"""
+    Hodograph()
+
 

--- a/metpy/plots/tests/test_skewt.py
+++ b/metpy/plots/tests/test_skewt.py
@@ -80,7 +80,5 @@ def test_hodograph_units():
 
 
 def test_hodograph_alone():
-    """Test to create Hodograph without specifying axes"""
+    """Test to create Hodograph without specifying axes."""
     Hodograph()
-
-

--- a/metpy/plots/tests/test_skewt.py
+++ b/metpy/plots/tests/test_skewt.py
@@ -77,3 +77,7 @@ def test_hodograph_units():
     hodo.plot(u, v)
     hodo.plot_colormapped(u, v, np.sqrt(u * u + v * v), cmap='Greys')
     return fig
+
+def test_hodograph_alone():
+    hodo = Hodograph()
+


### PR DESCRIPTION
Revised the syntax in the skewt.py script so that way instances of `ax` are replaced with `self.ax` when classifying the `Hodograph` object. 

The test_skewt.py script was also tweaked so that way it can catch bugs introduced when `ax` is not explicitly defined in the `Hodograph` object.

Thank you for allowing me to make some changes! I apologize for taking so long, it took me a few hours to learn how to use Git properly.