### PR TITLE
Small bug fixes

### DIFF
--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -13,11 +13,10 @@ These include:
 from __future__ import division
 
 import numpy as np
-from numpy.ma import masked_array
 
 from ..constants import g, omega, Rd
 from ..package_tools import Exporter
-from ..units import atleast_1d, units
+from ..units import atleast_1d, masked_array, units
 
 exporter = Exporter(globals())
 
@@ -232,7 +231,7 @@ def heat_index(temperature, rh, mask_undefined=True):
     if mask_undefined:
         mask = np.array((temperature < 80. * units.degF) | (rh < 40 * units.percent))
         if mask.any():
-            hi = units.Quantity(masked_array(hi, mask=mask), hi.units)
+            hi = masked_array(hi, mask=mask)
 
     return hi
 

--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -112,7 +112,8 @@ def get_wind_components(speed, wdir):
 def windchill(temperature, speed, face_level_winds=False, mask_undefined=True):
     r"""Calculate the Wind Chill Temperature Index (WCTI).
 
-    Calculates WCTI from the current temperature and wind speed.
+    Calculates WCTI from the current temperature and wind speed using the formula
+    outlined by the FCM [4]_.
 
     Specifically, these formulas assume that wind speed is measured at
     10m.  If, instead, the speeds are measured at face level, the winds
@@ -179,7 +180,8 @@ def windchill(temperature, speed, face_level_winds=False, mask_undefined=True):
 def heat_index(temperature, rh, mask_undefined=True):
     r"""Calculate the Heat Index from the current temperature and relative humidity.
 
-    The implementation uses the formula outlined in [6].
+    The implementation uses the formula outlined in [6]_. This equation is a multi-variable
+    least-squares regression of the values obtained in [5]_.
 
     Parameters
     ----------
@@ -240,7 +242,7 @@ def heat_index(temperature, rh, mask_undefined=True):
 def pressure_to_height_std(pressure):
     r"""Convert pressure data to heights using the U.S. standard atmosphere.
 
-    The implementation uses the formula outlined in [7].
+    The implementation uses the formula outlined in [7]_.
 
     Parameters
     ----------
@@ -271,7 +273,7 @@ def pressure_to_height_std(pressure):
 def coriolis_parameter(latitude):
     r"""Calculate the coriolis parameter at each point.
 
-    The implementation uses the formula outlined in [8].
+    The implementation uses the formula outlined in [8]_.
 
     Parameters
     ----------

--- a/metpy/calc/tests/test_basic.py
+++ b/metpy/calc/tests/test_basic.py
@@ -107,7 +107,10 @@ def test_windchill_invalid():
     speed = np.array([4, 4, 3, 1, 10, 39]) * units.mph
 
     wc = windchill(temp, speed)
+    # We don't care about the masked values
+    truth = np.array([2.6230789, np.nan, np.nan, np.nan, np.nan, np.nan]) * units.degF
     mask = np.array([False, True, True, True, True, True])
+    assert_array_almost_equal(truth, wc)
     assert_array_equal(wc.mask, mask)
 
 

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -393,7 +393,7 @@ def dewpoint(e):
 
 
 @exporter.export
-def mixing_ratio(part_press, tot_press):
+def mixing_ratio(part_press, tot_press, molecular_weight_ratio=epsilon):
     r"""Calculate the mixing ratio of a gas.
 
     This calculates mixing ratio given its partial pressure and the total pressure of
@@ -406,6 +406,10 @@ def mixing_ratio(part_press, tot_press):
         Partial pressure of the constituent gas
     tot_press : `pint.Quantity`
         Total air pressure
+    molecular_weight_ratio : `pint.Quantity` or float, optional
+        The ratio of the molecular weight of the constituent gas to that assumed
+        for air. Defaults to the ratio for water vapor to dry air
+        (:math:`\epsilon\approx0.622`).
 
     Returns
     -------
@@ -416,7 +420,7 @@ def mixing_ratio(part_press, tot_press):
     --------
     vapor_pressure
     """
-    return epsilon * part_press / (tot_press - part_press)
+    return molecular_weight_ratio * part_press / (tot_press - part_press)
 
 
 @exporter.export

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -125,7 +125,6 @@ def moist_lapse(pressure, temperature):
 
     References
     ----------
-
     .. [1] Bakhshaii, A. and R. Stull, 2013: Saturated Pseudoadiabats--A
            Noniterative Approximation. J. Appl. Meteor. Clim., 52, 5-15.
     """
@@ -176,11 +175,12 @@ def lcl(pressure, temperature, dewpt, max_iters=50, eps=1e-2):
     -----
     This function is implemented using an iterative approach to solve for the
     LCL. The basic algorithm is:
+
     1. Find the dew point from the LCL pressure and starting mixing ratio
     2. Find the LCL pressure from the starting temperature and dewpoint
     3. Iterate until convergence
 
-    The function is guaranteed to finish by virtue of the `maxIters` counter.
+    The function is guaranteed to finish by virtue of the `max_iters` counter.
     """
     w = mixing_ratio(saturation_vapor_pressure(dewpt), pressure)
     new_p = p = pressure
@@ -289,6 +289,18 @@ def vapor_pressure(pressure, mixing):
         The ambient water vapor (partial) pressure in the same units as
         `pressure`.
 
+    Notes
+    -----
+    This function is a straightforward implementation of the equation given in many places,
+    such as [2]_:
+
+    .. math:: e = p \frac{r}{r + \epsilon}
+
+    References
+    ----------
+    .. [2] Hobbs, Peter V. and Wallace, John M., 1977: Atmospheric Science, an Introductory
+           Survey. 71.
+
     See Also
     --------
     saturation_vapor_pressure, dewpoint
@@ -319,13 +331,13 @@ def saturation_vapor_pressure(temperature):
     Instead of temperature, dewpoint may be used in order to calculate
     the actual (ambient) water vapor (partial) pressure.
 
-    The formula used is that from Bolton 1980 [2] for T in degrees Celsius:
+    The formula used is that from Bolton 1980 [3]_ for T in degrees Celsius:
 
     .. math:: 6.112 e^\frac{17.67T}{T + 243.5}
 
     References
     ----------
-    .. [2] Bolton, D., 1980: The Computation of Equivalent Potential
+    .. [3] Bolton, D., 1980: The Computation of Equivalent Potential
            Temperature. Mon. Wea. Rev., 108, 1046-1053.
     """
     # Converted from original in terms of C to use kelvin. Using raw absolute values of C in
@@ -377,7 +389,7 @@ def dewpoint(e):
 
     Notes
     -----
-    This function inverts the Bolton 1980 [3] formula for saturation vapor
+    This function inverts the Bolton 1980 [4]_ formula for saturation vapor
     pressure to instead calculate the temperature. This yield the following
     formula for dewpoint in degrees Celsius:
 
@@ -385,7 +397,7 @@ def dewpoint(e):
 
     References
     ----------
-    .. [3] Bolton, D., 1980: The Computation of Equivalent Potential
+    .. [4] Bolton, D., 1980: The Computation of Equivalent Potential
            Temperature. Mon. Wea. Rev., 108, 1046-1053.
     """
     val = np.log(e / sat_pressure_0c)
@@ -416,9 +428,21 @@ def mixing_ratio(part_press, tot_press, molecular_weight_ratio=epsilon):
     `pint.Quantity`
         The (mass) mixing ratio, dimensionless (e.g. Kg/Kg or g/g)
 
+    Notes
+    -----
+    This function is a straightforward implementation of the equation given in many places,
+    such as [5]_:
+
+    .. math:: r = \epsilon \frac{e}{p - e}
+
+    References
+    ----------
+    .. [5] Hobbs, Peter V. and Wallace, John M., 1977: Atmospheric Science, an Introductory
+           Survey. 73.
+
     See Also
     --------
-    vapor_pressure
+    saturation_mixing_ratio, vapor_pressure
     """
     return molecular_weight_ratio * part_press / (tot_press - part_press)
 
@@ -428,7 +452,7 @@ def saturation_mixing_ratio(tot_press, temperature):
     r"""Calculate the saturation mixing ratio of water vapor.
 
     This calculation is given total pressure and the temperature. The implementation
-    uses the formula outlined in [4].
+    uses the formula outlined in [6]_.
 
     Parameters
     ----------
@@ -444,8 +468,8 @@ def saturation_mixing_ratio(tot_press, temperature):
 
     References
     ----------
-    .. [4] Hobbs, Peter V. and Wallace, John M., 1977: Atmospheric Science, an Introductory
-            Survey. 73.
+    .. [6] Hobbs, Peter V. and Wallace, John M., 1977: Atmospheric Science, an Introductory
+           Survey. 73.
     """
     return mixing_ratio(saturation_vapor_pressure(temperature), tot_press)
 
@@ -454,8 +478,8 @@ def saturation_mixing_ratio(tot_press, temperature):
 def equivalent_potential_temperature(pressure, temperature):
     r"""Calculate equivalent potential temperature.
 
-    This cacluation must be given an air parcel's pressure and temperature.
-    The implementation uses the formula outlined in [5]
+    This calculation must be given an air parcel's pressure and temperature.
+    The implementation uses the formula outlined in [7]_.
 
     Parameters
     ----------
@@ -475,8 +499,8 @@ def equivalent_potential_temperature(pressure, temperature):
 
     References
     ----------
-    .. [5] Hobbs, Peter V. and Wallace, John M., 1977: Atmospheric Science, an Introductory
-            Survey. 78-79.
+    .. [7] Hobbs, Peter V. and Wallace, John M., 1977: Atmospheric Science, an Introductory
+           Survey. 78-79.
     """
     pottemp = potential_temperature(pressure, temperature)
     smixr = saturation_mixing_ratio(pressure, temperature)

--- a/metpy/plots/tests/test_skewt.py
+++ b/metpy/plots/tests/test_skewt.py
@@ -53,6 +53,13 @@ def test_skewt_gridspec():
     return fig
 
 
+def test_skewt_with_grid_enabled():
+    """Test using SkewT when gridlines are already enabled (#271)."""
+    with plt.rc_context(rc={'axes.grid': True}):
+        # Also tests when we don't pass in Figure
+        SkewT()
+
+
 @pytest.mark.mpl_image_compare(tolerance=0, remove_text=True)
 def test_hodograph_api():
     """Basic test of Hodograph API."""

--- a/metpy/units.py
+++ b/metpy/units.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2015 MetPy Developers.
+# Copyright (c) 2008-2016 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 r"""Module to provide unit support.
@@ -113,6 +113,32 @@ def atleast_2d(*arrs):
     if len(mags) == 1:
         return units.Quantity(ret, orig_units[0])
     return [units.Quantity(m, u) for m, u in zip(ret, orig_units)]
+
+
+def masked_array(data, data_units=None, **kwargs):
+    """Create a :class:`numpy.ma.MaskedArray` with units attached.
+
+    This is a thin wrapper around :func:`numpy.ma.masked_array` that ensures that
+    units are properly attached to the result (otherwise units are silently lost). Units
+    are taken from the ``units`` argument, or if this is ``None``, the units on ``data``
+    are used.
+
+    Parameters
+    ----------
+    data : array_like
+        The source data. If ``units`` is `None`, this should be a `pint.Quantity` with
+        the desired units.
+    data_units : str or `pint.Unit`
+        The units for the resulting `pint.Quantity`
+    **kwargs : Arbitrary keyword arguments passed to `numpy.ma.masked_array`
+
+    Returns
+    -------
+    `pint.Quantity`
+    """
+    if data_units is None:
+        data_units = data.units
+    return units.Quantity(np.ma.masked_array(data, **kwargs), data_units)
 
 
 del pint


### PR DESCRIPTION
Fixes for a bunch of small issues in advance of 0.4.3:

- Fix `mixing_ratio` to match docstring #275 
- Add test for SkewT with gridlines pre-set #271 
- Fix units with masked array return from `windchill` #281 

Also did some docstring clean-up/improvement.