### PR TITLE
Add link to say thanks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,7 @@ Important Links
 - HTML Documentation : http://unidata.github.io/MetPy
 - Issue tracker: http://github.com/Unidata/MetPy/issues
 - Gitter chat room: https://gitter.im/Unidata/MetPy
+- Say Thanks: https://saythanks.io/to/unidata
 
 Dependencies
 ------------

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,0 +1,7 @@
+{% extends "!footer.html" %}
+{% block extrafooter %}
+<p>Do you enjoy using MetPy?
+  <a href="https://saythanks.io/to/unidata" class="btn btn-neutral" title="Installation Guide" accesskey="n">Say Thanks!</a>
+</p>
+    {{ super() }}
+{% endblock %}


### PR DESCRIPTION
Adds a link to "Say Thanks" under the "Important Links" section. Seemed an appropriate place, it was easy to loose underneath the badges and probably unseen at the bottom. Addresses #291, @dopplershift manages the account.