### PR TITLE
Raise exception if LCL does not converge

### DIFF
--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -4,6 +4,7 @@
 """Test the `thermo` module."""
 
 import numpy as np
+import pytest
 
 from metpy.calc import (dewpoint, dewpoint_rh, dry_lapse, equivalent_potential_temperature,
                         lcl, lfc, mixing_ratio, moist_lapse, parcel_profile,
@@ -158,6 +159,12 @@ def test_lcl():
     lcl_pressure, lcl_temperature = lcl(1000. * units.mbar, 30. * units.degC, 20. * units.degC)
     assert_almost_equal(lcl_pressure, 864.761 * units.mbar, 2)
     assert_almost_equal(lcl_temperature, 17.676 * units.degC, 2)
+
+
+def test_lcl_convergence():
+    """Test LCL calculation convergence failure."""
+    with pytest.raises(RuntimeError):
+        lcl(1000. * units.mbar, 30. * units.degC, 20. * units.degC, max_iters=2)
 
 
 def test_lfc_basic():

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -193,6 +193,10 @@ def lcl(pressure, temperature, dewpt, max_iters=50, eps=1e-2):
         p = new_p
         max_iters -= 1
 
+    else:
+        # We have not converged
+        raise RuntimeError('LCL calculation has not converged.')
+
     return new_p, td
 
 


### PR DESCRIPTION
If we don't converge in `max_iter` we should fail loudly. Addresses #317 