### PR TITLE
Convert quantities to scalars before formatting

### DIFF
--- a/metpy/plots/station_plot.py
+++ b/metpy/plots/station_plot.py
@@ -279,7 +279,7 @@ class StationPlot(object):
             def formatter(s):
                 """Turn a format string into a callable."""
                 if hasattr(s, 'units'):
-                    s = np.asscalar(s.magnitude)
+                    s = np.asscalar(s)
                 return format(s, fmt)
         else:
             formatter = fmt

--- a/metpy/plots/station_plot.py
+++ b/metpy/plots/station_plot.py
@@ -278,6 +278,8 @@ class StationPlot(object):
         if not callable(fmt):
             def formatter(s):
                 """Turn a format string into a callable."""
+                if hasattr(s, 'units'):
+                    s = np.asscalar(s.magnitude)
                 return format(s, fmt)
         else:
             formatter = fmt

--- a/metpy/plots/tests/test_station_plot.py
+++ b/metpy/plots/tests/test_station_plot.py
@@ -32,7 +32,7 @@ def test_stationplot_api():
     sp = StationPlot(fig.add_subplot(1, 1, 1), x, y, fontsize=16)
     sp.plot_barb([20, 0], [0, -50])
     sp.plot_text('E', ['KOKC', 'ICT'], color='blue')
-    sp.plot_parameter('NW', [10.5, 15], color='red')
+    sp.plot_parameter('NW', [10.5, 15] * units.degC, color='red')
     sp.plot_symbol('S', [5, 7], high_clouds, color='green')
 
     sp.ax.set_xlim(0, 6)


### PR DESCRIPTION
The pint implementation of format will not take a non empty format string, so this would fail when units were included (#307). Currently solution is to check if there is a units attribute and turn it into a scalar.