### PR TITLE
Find intersections directionality

### DIFF
--- a/metpy/calc/tests/test_tools.py
+++ b/metpy/calc/tests/test_tools.py
@@ -4,6 +4,7 @@
 """Tests for `calc.tools` module."""
 
 import numpy as np
+import pytest
 
 from metpy.calc import find_intersections, nearest_intersection_idx, resample_nn_1d
 from metpy.testing import assert_array_almost_equal, assert_array_equal
@@ -28,14 +29,35 @@ def test_nearest_intersection_idx():
     assert_array_equal(truth, nearest_intersection_idx(y1, y2))
 
 
-def test_find_intersections():
+@pytest.mark.parametrize('direction, expected', [
+    ('all', np.array([[8.88, 24.44], [238.84, 1794.53]])),
+    ('increasing', np.array([[24.44], [1794.53]])),
+    ('decreasing', np.array([[8.88], [238.84]]))
+])
+def test_find_intersections(direction, expected):
     """Test finding the intersection of two curves functionality."""
     x = np.linspace(5, 30, 17)
     y1 = 3 * x**2
     y2 = 100 * x - 650
-    # Truth is what we will get with this sampling,
-    # not the mathematical intersection
-    truth = np.array([[8.88, 24.44],
-                      [238.84, 1794.53]])
+    # Note: Truth is what we will get with this sampling, not the mathematical intersection
+    assert_array_almost_equal(expected, find_intersections(x, y1, y2, direction=direction), 2)
 
-    assert_array_almost_equal(truth, find_intersections(x, y1, y2), 2)
+
+def test_find_intersections_no_intersections():
+    """Test finding the intersection of two curves with no intersections."""
+    x = np.linspace(5, 30, 17)
+    y1 = 3 * x + 0
+    y2 = 5 * x + 5
+    # Note: Truth is what we will get with this sampling, not the mathematical intersection
+    truth = np.array([[],
+                      []])
+    assert_array_equal(truth, find_intersections(x, y1, y2))
+
+
+def test_find_intersections_invalid_direction():
+    """Test exception if an invalid direction is given."""
+    x = np.linspace(5, 30, 17)
+    y1 = 3 * x ** 2
+    y2 = 100 * x - 650
+    with pytest.raises(ValueError):
+        find_intersections(x, y1, y2, direction='increaing')

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -61,7 +61,7 @@ def nearest_intersection_idx(a, b):
 
 
 @exporter.export
-def find_intersections(x, a, b):
+def find_intersections(x, a, b, direction='all'):
     """Calculate the best estimate of intersection.
 
     Calculates the best estimates of the intersection of two y-value
@@ -75,6 +75,9 @@ def find_intersections(x, a, b):
         1-dimensional array of y-values for line 1
     b : array-like
         1-dimensional array of y-values for line 2
+    direction : string
+        specifies direction of crossing. 'all', 'increasing' (a becoming greater than b),
+        or 'decreasing' (b becoming greater than a).
 
     Returns
     -------
@@ -84,6 +87,9 @@ def find_intersections(x, a, b):
     # Find the index of the points just before the intersection(s)
     nearest_idx = nearest_intersection_idx(a, b)
     next_idx = nearest_idx + 1
+
+    # Determine the sign of the change
+    sign_change = np.sign(a[next_idx] - b[next_idx])
 
     # x-values around each intersection
     x0 = x[nearest_idx]
@@ -109,4 +115,13 @@ def find_intersections(x, a, b):
     # causes weirder unit behavior and seems a little less good numerically.
     intersect_y = ((intersect_x - x0) / (x1 - x0)) * (a1 - a0) + a0
 
-    return intersect_x, intersect_y
+    # Make a mask based on the direction of sign change desired
+    if direction == 'increasing':
+        mask = sign_change > 0
+    elif direction == 'decreasing':
+        mask = sign_change < 0
+    elif direction == 'all':
+        return intersect_x, intersect_y
+    else:
+        raise ValueError('Unknown option for direction: {0}'.format(str(direction)))
+    return intersect_x[mask], intersect_y[mask]


### PR DESCRIPTION
Add a directionality capability to `find_intersections` to filter on sign change for things like LFC calculations (see related #350). Significantly improves test coverage as well.