### PR TITLE
IA State masked arrays

### DIFF
--- a/metpy/io/tests/test_upperair.py
+++ b/metpy/io/tests/test_upperair.py
@@ -30,13 +30,13 @@ def test_iastate():
     with UseSampleData():
         data = get_upper_air_data(datetime(2016, 7, 30, 12), 'KDEN', source='iastate')
 
-    assert_almost_equal(data.variables['pressure'][3], 838.0 * units('hPa'), 2)
-    assert_almost_equal(data.variables['temperature'][3], 17.0 * units.degC, 2)
-    assert_almost_equal(data.variables['dewpoint'][3], 15.2 * units.degC, 2)
-    assert_almost_equal(data.variables['u_wind'][3], 1.72 * units.knot, 2)
-    assert_almost_equal(data.variables['v_wind'][3], 2.46 * units.knot, 2)
-    assert_almost_equal(data.variables['speed'][3], 3.0 * units.knot, 1)
-    assert_almost_equal(data.variables['direction'][3], 215.0 * units.deg, 1)
+    assert_almost_equal(data.variables['pressure'][0], 838.0 * units('hPa'), 2)
+    assert_almost_equal(data.variables['temperature'][0], 17.0 * units.degC, 2)
+    assert_almost_equal(data.variables['dewpoint'][0], 15.2 * units.degC, 2)
+    assert_almost_equal(data.variables['u_wind'][0], 1.72 * units.knot, 2)
+    assert_almost_equal(data.variables['v_wind'][0], 2.46 * units.knot, 2)
+    assert_almost_equal(data.variables['speed'][0], 3.0 * units.knot, 1)
+    assert_almost_equal(data.variables['direction'][0], 215.0 * units.deg, 1)
 
 
 def test_high_alt_wyoming():

--- a/metpy/io/upperair.py
+++ b/metpy/io/upperair.py
@@ -11,6 +11,7 @@ except ImportError:
     from urllib2 import urlopen
 
 import numpy as np
+import numpy.ma as ma
 
 from ._tools import UnitLinker
 from .cdm import Dataset
@@ -254,8 +255,10 @@ class IAStateUpperAir(object):
         # Make sure that the first entry has a valid temperature and dewpoint
         idx = np.argmax(~(np.isnan(data['tmpc']) | np.isnan(data['tmpc'])))
 
-        ret = dict(p=(np.array(data['pres'][idx:]), 'mbar'), t=(np.array(data['tmpc'][idx:]), 'degC'),
-                   td=(np.array(data['dwpc'][idx:]), 'degC'),
-                   wind=(np.array(data['drct'][idx:]), np.array(data['sknt'][idx:]), 'knot'))
+        ret = dict(p=(ma.masked_invalid(data['pres'][idx:]), 'mbar'),
+                   t=(ma.masked_invalid(data['tmpc'][idx:]), 'degC'),
+                   td=(ma.masked_invalid(data['dwpc'][idx:]), 'degC'),
+                   wind=(ma.masked_invalid(data['drct'][idx:]),
+                         ma.masked_invalid(data['sknt'][idx:]), 'knot'))
 
         return ret

--- a/metpy/io/upperair.py
+++ b/metpy/io/upperair.py
@@ -251,8 +251,11 @@ class IAStateUpperAir(object):
             for field in ('drct', 'dwpc', 'pres', 'sknt', 'tmpc'):
                 data.setdefault(field, []).append(np.nan if pt[field] is None else pt[field])
 
-        ret = dict(p=(np.array(data['pres']), 'mbar'), t=(np.array(data['tmpc']), 'degC'),
-                   td=(np.array(data['dwpc']), 'degC'),
-                   wind=(np.array(data['drct']), np.array(data['sknt']), 'knot'))
+        # Make sure that the first entry has a valid temperature and dewpoint
+        idx = np.argmax(~(np.isnan(data['tmpc']) | np.isnan(data['tmpc'])))
+
+        ret = dict(p=(np.array(data['pres'][idx:]), 'mbar'), t=(np.array(data['tmpc'][idx:]), 'degC'),
+                   td=(np.array(data['dwpc'][idx:]), 'degC'),
+                   wind=(np.array(data['drct'][idx:]), np.array(data['sknt'][idx:]), 'knot'))
 
         return ret


### PR DESCRIPTION
Return masked arrays from the IA State archive and make sure that the first row returned has temperature and dewpoint so thermo calculations that use a surface parcel don't break.