### PR TITLE
Adds new img_extent attribute to ginifile dataset

### DIFF
--- a/metpy/io/gini.py
+++ b/metpy/io/gini.py
@@ -352,3 +352,5 @@ def _add_projection_coords(ds, prod_desc, proj_var, dx, dy):
     lat_var = ds.createVariable('lat', np.float64, dimensions=('y', 'x'), wrap_array=lat)
     lat_var.long_name = 'latitude'
     lat_var.units = 'degrees_north'
+
+    ds.img_extent = (x_var[:].min(), x_var[:].max(), y_var[:].min(), y_var[:].max())

--- a/metpy/io/tests/test_gini.py
+++ b/metpy/io/tests/test_gini.py
@@ -106,6 +106,12 @@ def test_gini_dataset(filename, bounds, data_var, proj_attrs):
     assert_almost_equal(y[0], y0, 4)
     assert_almost_equal(y[-1], y1, 4)
 
+    xmin, xmax, ymin, ymax = ds.img_extent
+    assert_almost_equal(xmin, x0, 4)
+    assert_almost_equal(xmax, x1, 4)
+    assert_almost_equal(ymin, y0, 4)
+    assert_almost_equal(ymax, y1, 4)
+
     # Check the projection metadata
     proj_name = ds.variables[data_var].grid_mapping
     proj_var = ds.variables[proj_name]


### PR DESCRIPTION
This pull request adds an attribute 'img_extent' when using the to_dataset() function when using a gini satellite image file.

I was working on creating a satellite image and it seemed that a nice attribute to have for any gini file would be the extent of the image in image coordinates. This alleviates the need of the user to bring in the x and y coords simply to use it in the extent keyword within imshow. This also allows easier use to use Cartopy coordinate transformation with set_extent by being able to use lat/lon values and convert to projection coordinates.

I also added a test to test_gini.py for this new attribute.