### PR TITLE
Use operating system agnostic path separators

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ import metpy
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('.'))
-sys.path.insert(0, os.path.abspath('../..'))
+sys.path.insert(0, os.path.abspath(os.path.join('..', '..')))
 
 # -- General configuration ------------------------------------------------
 
@@ -51,11 +51,11 @@ sphinx_gallery_conf = {
         'matplotlib': 'http://matplotlib.org',
         'numpy': 'http://docs.scipy.org/doc/numpy/',
         'scipy': 'http://docs.scipy.org/doc/scipy/reference'},
-    'examples_dirs': ['../examples', '../tutorials'],
+    'examples_dirs': [os.path.join('..', 'examples'), os.path.join('..', 'tutorials')],
     'gallery_dirs': ['examples', 'tutorials'],
-    'filename_pattern': '/',
-    'mod_example_dir': 'api/generated',
-    'default_thumb_file': '_static/metpy_150x150_white_bg.png'
+    'filename_pattern': os.path.join('.', '*'),
+    'mod_example_dir': os.path.join('api', 'generated'),
+    'default_thumb_file': os.path.join('_static', 'metpy_150x150_white_bg.png')
 }
 
 # Turn off code and image links for embedded mpl plots
@@ -179,12 +179,12 @@ def setup(app):
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = '_static/metpy_150x150.png'
+html_logo = os.path.join('_static', 'metpy_150x150.png')
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = '_static/metpy_32x32.ico'
+html_favicon = os.path.join('_static', 'metpy_32x32.ico')
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -323,4 +323,4 @@ texinfo_documents = [
 # -----------------------------------------------------------------------------
 
 import glob
-autosummary_generate = glob.glob("api/*.rst")
+autosummary_generate = glob.glob(os.path.join('api', '*.rst'))


### PR DESCRIPTION
Helps get us ready for the Windows example and doc builds. Will need to be rebased and merged post #364. 