### PR TITLE
Unit message helper

### DIFF
--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from ..constants import g, omega, Rd
 from ..package_tools import Exporter
-from ..units import atleast_1d, masked_array, units
+from ..units import atleast_1d, check_units, masked_array, units
 
 exporter = Exporter(globals())
 
@@ -109,6 +109,7 @@ def get_wind_components(speed, wdir):
 
 
 @exporter.export
+@check_units(temperature='[temperature]', speed='[speed]')
 def windchill(temperature, speed, face_level_winds=False, mask_undefined=True):
     r"""Calculate the Wind Chill Temperature Index (WCTI).
 
@@ -169,6 +170,7 @@ def windchill(temperature, speed, face_level_winds=False, mask_undefined=True):
 
 
 @exporter.export
+@check_units('[temperature]')
 def heat_index(temperature, rh, mask_undefined=True):
     r"""Calculate the Heat Index from the current temperature and relative humidity.
 
@@ -221,6 +223,7 @@ def heat_index(temperature, rh, mask_undefined=True):
 
 
 @exporter.export
+@check_units('[pressure]')
 def pressure_to_height_std(pressure):
     r"""Convert pressure data to heights using the U.S. standard atmosphere.
 

--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -243,7 +243,7 @@ def pressure_to_height_std(pressure):
     t0 = 288. * units.kelvin
     gamma = 6.5 * units('K/km')
     p0 = 1013.25 * units.mbar
-    return (t0 / gamma) * (1 - (pressure / p0)**(Rd * gamma / g))
+    return (t0 / gamma) * (1 - (pressure / p0).to('dimensionless')**(Rd * gamma / g))
 
 
 @exporter.export

--- a/metpy/calc/tests/test_basic.py
+++ b/metpy/calc/tests/test_basic.py
@@ -228,6 +228,11 @@ def test_pressure_to_heights_basic():
     assert_almost_equal(heights, values, 1)
 
 
+def test_pressure_to_heights_units():
+    """Test that passing non-mbar units works."""
+    assert_almost_equal(pressure_to_height_std(29 * units.inHg), 262.859 * units.meter, 3)
+
+
 def test_coriolis_force():
     """Test basic coriolis force calculation."""
     lat = np.array([-90., -30., 0., 30., 90.]) * units.degrees

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -695,11 +695,11 @@ def psychrometric_vapor_pressure_wet(dry_bulb_temperature, wet_bulb_temperature,
     ----------
     dry_bulb_temperature: `pint.Quantity`
         Dry bulb temperature
-    web_bulb_temperature: `pint.Quantity`
+    wet_bulb_temperature: `pint.Quantity`
         Wet bulb temperature
     pressure: `pint.Quantity`
         Total atmospheric pressure
-    psychrometer coefficient: `pint.Quantity`
+    psychrometer_coefficient: `pint.Quantity`
         Psychrometer coefficient
 
     Returns

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -11,7 +11,7 @@ import scipy.integrate as si
 from .tools import find_intersections
 from ..constants import Cp_d, epsilon, kappa, Lv, P0, Rd
 from ..package_tools import Exporter
-from ..units import atleast_1d, concatenate, units
+from ..units import atleast_1d, check_units, concatenate, units
 
 exporter = Exporter(globals())
 
@@ -19,6 +19,7 @@ sat_pressure_0c = 6.112 * units.millibar
 
 
 @exporter.export
+@check_units('[pressure]', '[temperature]')
 def potential_temperature(pressure, temperature):
     r"""Calculate the potential temperature.
 
@@ -58,6 +59,7 @@ def potential_temperature(pressure, temperature):
 
 
 @exporter.export
+@check_units('[pressure]', '[temperature]')
 def dry_lapse(pressure, temperature):
     r"""Calculate the temperature at a level assuming only dry processes.
 
@@ -88,6 +90,7 @@ def dry_lapse(pressure, temperature):
 
 
 @exporter.export
+@check_units('[pressure]', '[temperature]')
 def moist_lapse(pressure, temperature):
     r"""Calculate the temperature at a level assuming liquid saturation processes.
 
@@ -135,6 +138,7 @@ def moist_lapse(pressure, temperature):
 
 
 @exporter.export
+@check_units('[pressure]', '[temperature]', '[temperature]')
 def lcl(pressure, temperature, dewpt, max_iters=50, eps=1e-2):
     r"""Calculate the lifted condensation level (LCL) using from the starting point.
 
@@ -196,6 +200,7 @@ def lcl(pressure, temperature, dewpt, max_iters=50, eps=1e-2):
 
 
 @exporter.export
+@check_units('[pressure]', '[temperature]', '[temperature]')
 def lfc(pressure, temperature, dewpt):
     r"""Calculate the level of free convection (LFC).
 
@@ -233,6 +238,7 @@ def lfc(pressure, temperature, dewpt):
 
 
 @exporter.export
+@check_units('[pressure]', '[temperature]', '[temperature]')
 def el(pressure, temperature, dewpt):
     r"""Calculate the equilibrium level.
 
@@ -269,6 +275,7 @@ def el(pressure, temperature, dewpt):
 
 
 @exporter.export
+@check_units('[pressure]', '[temperature]', '[temperature]')
 def parcel_profile(pressure, temperature, dewpt):
     r"""Calculate the profile a parcel takes through the atmosphere.
 
@@ -313,6 +320,7 @@ def parcel_profile(pressure, temperature, dewpt):
 
 
 @exporter.export
+@check_units('[pressure]', '[dimensionless]')
 def vapor_pressure(pressure, mixing):
     r"""Calculate water vapor (partial) pressure.
 
@@ -347,6 +355,7 @@ def vapor_pressure(pressure, mixing):
 
 
 @exporter.export
+@check_units('[temperature]')
 def saturation_vapor_pressure(temperature):
     r"""Calculate the saturation water vapor (partial) pressure.
 
@@ -381,6 +390,7 @@ def saturation_vapor_pressure(temperature):
 
 
 @exporter.export
+@check_units('[temperature]', '[dimensionless]')
 def dewpoint_rh(temperature, rh):
     r"""Calculate the ambient dewpoint given air temperature and relative humidity.
 
@@ -404,6 +414,7 @@ def dewpoint_rh(temperature, rh):
 
 
 @exporter.export
+@check_units('[pressure]')
 def dewpoint(e):
     r"""Calculate the ambient dewpoint given the vapor pressure.
 
@@ -435,6 +446,7 @@ def dewpoint(e):
 
 
 @exporter.export
+@check_units('[pressure]', '[pressure]', '[dimensionless]')
 def mixing_ratio(part_press, tot_press, molecular_weight_ratio=epsilon):
     r"""Calculate the mixing ratio of a gas.
 
@@ -473,6 +485,7 @@ def mixing_ratio(part_press, tot_press, molecular_weight_ratio=epsilon):
 
 
 @exporter.export
+@check_units('[pressure]', '[temperature]')
 def saturation_mixing_ratio(tot_press, temperature):
     r"""Calculate the saturation mixing ratio of water vapor.
 
@@ -495,6 +508,7 @@ def saturation_mixing_ratio(tot_press, temperature):
 
 
 @exporter.export
+@check_units('[pressure]', '[temperature]')
 def equivalent_potential_temperature(pressure, temperature):
     r"""Calculate equivalent potential temperature.
 
@@ -524,6 +538,7 @@ def equivalent_potential_temperature(pressure, temperature):
 
 
 @exporter.export
+@check_units('[temperature]', '[dimensionless]', '[dimensionless]')
 def virtual_temperature(temperature, mixing, molecular_weight_ratio=epsilon):
     r"""Calculate virtual temperature.
 
@@ -555,6 +570,7 @@ def virtual_temperature(temperature, mixing, molecular_weight_ratio=epsilon):
 
 
 @exporter.export
+@check_units('[pressure]', '[temperature]', '[dimensionless]', '[dimensionless]')
 def virtual_potential_temperature(pressure, temperature, mixing,
                                   molecular_weight_ratio=epsilon):
     r"""Calculate virtual potential temperature.
@@ -589,6 +605,7 @@ def virtual_potential_temperature(pressure, temperature, mixing,
 
 
 @exporter.export
+@check_units('[pressure]', '[temperature]', '[dimensionless]', '[dimensionless]')
 def density(pressure, temperature, mixing, molecular_weight_ratio=epsilon):
     r"""Calculate density.
 
@@ -622,6 +639,7 @@ def density(pressure, temperature, mixing, molecular_weight_ratio=epsilon):
 
 
 @exporter.export
+@check_units('[temperature]', '[temperature]', '[pressure]')
 def relative_humidity_wet_psychrometric(dry_bulb_temperature, web_bulb_temperature,
                                         pressure, **kwargs):
     r"""Calculate the relative humidity with wet bulb and dry bulb temperatures.
@@ -668,6 +686,7 @@ def relative_humidity_wet_psychrometric(dry_bulb_temperature, web_bulb_temperatu
 
 
 @exporter.export
+@check_units('[temperature]', '[temperature]', '[pressure]')
 def psychrometric_vapor_pressure_wet(dry_bulb_temperature, wet_bulb_temperature, pressure,
                                      psychrometer_coefficient=6.21e-4 / units.kelvin):
     r"""Calculate the vapor pressure with wet bulb and dry bulb temperatures.

--- a/metpy/tests/test_units.py
+++ b/metpy/tests/test_units.py
@@ -3,11 +3,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 r"""Tests the operation of MetPy's unit support code."""
 
+import sys
+
 import matplotlib.pyplot as plt
 import pytest
 
 from metpy.testing import set_agg_backend  # noqa: F401
-from metpy.units import units
+from metpy.units import check_units, units
 
 
 @pytest.mark.mpl_image_compare(tolerance=0, remove_text=True)
@@ -26,3 +28,57 @@ def test_axvline():
     ax.axvline(0 * units('degC'))
     ax.set_xlim(-1, 1)
     return fig
+
+#
+# Tests for unit-checking decorator
+#
+
+
+def unit_calc(temp, press, dens, mixing, unitless_const):
+    r"""Stub calculation for testing unit checking."""
+    pass
+
+
+test_funcs = [
+    check_units('[temperature]', '[pressure]', dens='[mass]/[volume]',
+                mixing='[dimensionless]')(unit_calc),
+    check_units(temp='[temperature]', press='[pressure]', dens='[mass]/[volume]',
+                mixing='[dimensionless]')(unit_calc),
+    check_units('[temperature]', '[pressure]', '[mass]/[volume]',
+                '[dimensionless]')(unit_calc)]
+
+
+@pytest.mark.parametrize('func', test_funcs, ids=['some kwargs', 'all kwargs', 'all pos'])
+def test_good_units(func):
+    r"""Test that unit checking passes good units regardless."""
+    func(30 * units.degC, 1000 * units.mbar, 1.0 * units('kg/m^3'), 1, 5.)
+
+
+test_params = [((30 * units.degC, 1000 * units.mb, 1 * units('kg/m^3'), 1, 5 * units('J/kg')),
+                {}, [('press', '[pressure]', 'millibarn')]),
+               ((30, 1000, 1.0, 1, 5.), {}, [('press', '[pressure]', 'none'),
+                                             ('temp', '[temperature]', 'none'),
+                                             ('dens', '[mass]/[volume]', 'none')]),
+               ((30, 1000 * units.mbar),
+                {'dens': 1.0 * units('kg / m'), 'mixing': 5 * units.m, 'unitless_const': 2},
+                [('temp', '[temperature]', 'none'),
+                 ('dens', '[mass]/[volume]', 'kilogram / meter'),
+                 ('mixing', '[dimensionless]', 'meter')])]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 3), reason='Unit checking requires Python >= 3.3')
+@pytest.mark.parametrize('func', test_funcs, ids=['some kwargs', 'all kwargs', 'all pos'])
+@pytest.mark.parametrize('args,kwargs,bad_parts', test_params,
+                         ids=['one bad arg', 'all args no units', 'mixed args'])
+def test_bad(func, args, kwargs, bad_parts):
+    r"""Test that unit checking flags appropriate arguments."""
+    with pytest.raises(ValueError) as exc:
+        func(*args, **kwargs)
+
+    message = str(exc.value)
+    assert func.__name__ in message
+    for param in bad_parts:
+        assert '`{}` requires "{}" but given "{}"'.format(*param) in message
+
+        # Should never complain about the const argument
+        assert 'unitless_const' not in message


### PR DESCRIPTION
This adds a decorator that allows us to decorate functions with the dimensionality of arguments (as positional or keyword arguments):

- Decorated arguments need to be passed with appropriate dimensionality (will catch missing units)
- Undecorated arguments pass through
- Dimensionless arguments can be dimensionless or just not have units

Sane handling of positional and keyword arguments relies on function signature arguments added to the `inspect` module in Python >= 3.3. Thus this isn't available on Python 2.7, and at run time this is a no-op there.

Closes #175.