### PR TITLE
BUG: Fix windchill when given kelvin temperatures (Fixes #385)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ script:
       make clean html linkcheck;
       export DOC_BUILD_RESULT=$?;
       popd;
-      doc8 README.rst docs/;
+      doc8 --file-encoding utf8 README.rst docs/;
       if [[ $DOC_BUILD_RESULT -ne 0 || $? -ne 0 ]]; then
         false;
       fi;

--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -156,9 +156,8 @@ def windchill(temperature, speed, face_level_winds=False, mask_undefined=True):
 
     temp_limit, speed_limit = 10. * units.degC, 3 * units.mph
     speed_factor = speed.to('km/hr').magnitude ** 0.16
-    delta = temperature - 0. * units.degC
-    wcti = (13.12 * units.degC + 0.6215 * delta -
-            11.37 * units.delta_degC * speed_factor + 0.3965 * delta * speed_factor)
+    wcti = units.Quantity((0.6215 + 0.3965 * speed_factor) * temperature.to('degC').magnitude -
+                          11.37 * speed_factor + 13.12, units.degC).to(temperature.units)
 
     # See if we need to mask any undefined values
     if mask_undefined:

--- a/metpy/calc/tests/test_basic.py
+++ b/metpy/calc/tests/test_basic.py
@@ -101,6 +101,12 @@ def test_windchill_basic():
     assert_array_almost_equal(wc, values, 0)
 
 
+def test_windchill_kelvin():
+    """Test wind chill when given Kelvin temperatures."""
+    wc = windchill(268.15 * units.kelvin, 35 * units('m/s'))
+    assert_almost_equal(wc, -18.9357 * units.degC, 0)
+
+
 def test_windchill_invalid():
     """Test windchill for values that should be masked."""
     temp = np.array([10, 51, 49, 60, 80, 81]) * units.degF


### PR DESCRIPTION
Windchill formula uses direct values of Celsius. The hack we had in
there to make that work with units did not work properly with Kelvin.
Instead, just convert to Celsius, drop units, and attach proper units
after calc.