### PR TITLE
BUG: Fix ordering of GINI y-coordinates

### DIFF
--- a/metpy/io/gini.py
+++ b/metpy/io/gini.py
@@ -340,7 +340,10 @@ def _add_projection_coords(ds, prod_desc, proj_var, dx, dy):
     y_var.units = 'm'
     y_var.long_name = 'y coordinate of projection'
     y_var.standard_name = 'projection_y_coordinate'
-    y_var[:] = y0 + np.arange(prod_desc.ny) * (1000. * dy)
+
+    # Need to flip y because we calculated from the lower left corner, but the raster data
+    # is stored with top row first.
+    y_var[::-1] = y0 + np.arange(prod_desc.ny) * (1000. * dy)
 
     # Get the two-D lon,lat grid as well
     x, y = np.meshgrid(x_var[:], y_var[:])

--- a/metpy/io/tests/test_gini.py
+++ b/metpy/io/tests/test_gini.py
@@ -102,9 +102,11 @@ def test_gini_dataset(filename, bounds, data_var, proj_attrs):
     assert_almost_equal(x[0], x0, 4)
     assert_almost_equal(x[-1], x1, 4)
 
+    # Because the actual data raster has the top row first, the maximum y value is y[0],
+    # while the the minimum y value is y[-1]
     y = ds.variables['y']
-    assert_almost_equal(y[0], y0, 4)
-    assert_almost_equal(y[-1], y1, 4)
+    assert_almost_equal(y[-1], y0, 4)
+    assert_almost_equal(y[0], y1, 4)
 
     xmin, xmax, ymin, ymax = ds.img_extent
     assert_almost_equal(xmin, x0, 4)
@@ -118,9 +120,9 @@ def test_gini_dataset(filename, bounds, data_var, proj_attrs):
     for attr, val in proj_attrs.items():
         assert getattr(proj_var, attr) == val, 'Values mismatch for ' + attr
 
-    # Check the lon/lat corner
-    assert_almost_equal(ds.variables['lon'][0, 0], f.prod_desc.lo1, 4)
-    assert_almost_equal(ds.variables['lat'][0, 0], f.prod_desc.la1, 4)
+    # Check the lower left lon/lat corner
+    assert_almost_equal(ds.variables['lon'][-1, 0], f.prod_desc.lo1, 4)
+    assert_almost_equal(ds.variables['lat'][-1, 0], f.prod_desc.la1, 4)
 
 
 def test_gini_mercator_upper_corner():
@@ -132,8 +134,8 @@ def test_gini_mercator_upper_corner():
 
     # 2nd corner lat/lon are at the "upper right" corner of the pixel, so need to add one
     # more grid point
-    assert_almost_equal(lon[-1, -1] + (lon[-1, -1] - lon[-1, -2]), f.proj_info.lo2, 4)
-    assert_almost_equal(lat[-1, -1] + (lat[-1, -1] - lat[-2, -1]), f.proj_info.la2, 4)
+    assert_almost_equal(lon[0, -1] + (lon[0, -1] - lon[0, -2]), f.proj_info.lo2, 4)
+    assert_almost_equal(lat[0, -1] + (lat[0, -1] - lat[1, -1]), f.proj_info.la2, 4)
 
 
 def test_gini_str():


### PR DESCRIPTION
GINI raster data come ordered with the top (i.e. highest latitude) row
first. Before this fix, y coordinates were calculated increasing from
the lower left corner--thus having the y-coordinates flipped from the
ordering of rows in the image. This was not enountered frequently due to
the use of imshow() with extents and origin.

This reverses the y coordinates and adjusts tests to match.