### PR TITLE
Array ordering for 2D calculations

### DIFF
--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -44,9 +44,9 @@ def v_vorticity(u, v, dx, dy):
 
     Parameters
     ----------
-    u : (X, Y) ndarray
+    u : (M, N) ndarray
         x component of the wind
-    v : (X, Y) ndarray
+    v : (M, N) ndarray
         y component of the wind
     dx : float
         The grid spacing in the x-direction
@@ -55,7 +55,7 @@ def v_vorticity(u, v, dx, dy):
 
     Returns
     -------
-    (X, Y) ndarray
+    (M, N) ndarray
         vertical vorticity
 
     See Also
@@ -74,9 +74,9 @@ def h_convergence(u, v, dx, dy):
 
     Parameters
     ----------
-    u : (X, Y) ndarray
+    u : (M, N) ndarray
         x component of the wind
-    v : (X, Y) ndarray
+    v : (M, N) ndarray
         y component of the wind
     dx : float
         The grid spacing in the x-direction
@@ -85,7 +85,7 @@ def h_convergence(u, v, dx, dy):
 
     Returns
     -------
-    (X, Y) ndarray
+    (M, N) ndarray
         The horizontal convergence
 
     See Also
@@ -104,9 +104,9 @@ def convergence_vorticity(u, v, dx, dy):
 
     Parameters
     ----------
-    u : (X, Y) ndarray
+    u : (M, N) ndarray
         x component of the wind
-    v : (X, Y) ndarray
+    v : (M, N) ndarray
         y component of the wind
     dx : float
         The grid spacing in the x-direction
@@ -115,7 +115,7 @@ def convergence_vorticity(u, v, dx, dy):
 
     Returns
     -------
-    convergence, vorticity : tuple of (X, Y) ndarrays
+    convergence, vorticity : tuple of (M, N) ndarrays
         The horizontal convergence and vertical vorticity, respectively
 
     See Also
@@ -177,9 +177,9 @@ def geostrophic_wind(heights, f, dx, dy):
 
     Parameters
     ----------
-    heights : (x,y) ndarray
-        The height field, given with leading dimensions of x by y.  There
-        can be trailing dimensions on the array.
+    heights : (M, N) ndarray
+        The height field, with either leading dimensions of (x, y) or trailing dimensions
+        of (y, x), depending on the value of ``dim_order``.
     f : array_like
         The coriolis parameter.  This can be a scalar to be applied
         everywhere or an array of values.

--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -2,11 +2,14 @@
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Contains calculation of kinematic parameters (e.g. divergence or vorticity)."""
-
 from __future__ import division
+
+import functools
+import warnings
 
 import numpy as np
 
+from ..cbook import is_string_like, iterable
 from ..constants import g
 from ..package_tools import Exporter
 from ..units import atleast_2d, concatenate, units
@@ -31,12 +34,78 @@ def _stack(arrs):
 
 def _get_gradients(u, v, dx, dy):
     """Helper function for getting convergence and vorticity from 2D arrays."""
-    dudx, dudy = _gradient(u, dx, dy)
-    dvdx, dvdy = _gradient(v, dx, dy)
+    dudy, dudx = _gradient(u, dy, dx)
+    dvdy, dvdx = _gradient(v, dy, dx)
     return dudx, dudy, dvdx, dvdy
 
 
+def _is_x_first_dim(dim_order):
+    """Determine whether x is the first dimension based on the value of dim_order."""
+    if dim_order is None:
+        warnings.warn('dim_order is using the default setting (currently "xy"). This will '
+                      'change to "yx" in the next version. It is recommended that you '
+                      'specify the appropriate ordering ("xy", "yx") for your data by '
+                      'passing the `dim_order` argument to the calculation.', FutureWarning)
+        dim_order = 'xy'
+    return dim_order == 'xy'
+
+
+def _check_and_flip(arr):
+    """Transpose array or list of arrays if they are 2D."""
+    if hasattr(arr, 'ndim'):
+        if arr.ndim >= 2:
+            return arr.T
+        else:
+            return arr
+    elif not is_string_like(arr) and iterable(arr):
+        return tuple(_check_and_flip(a) for a in arr)
+    else:
+        return arr
+
+
+def ensure_yx_order(func):
+    """Wrap a function to ensure all array arguments are y, x ordered, based on kwarg."""
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        # Check what order we're given
+        dim_order = kwargs.pop('dim_order', None)
+        x_first = _is_x_first_dim(dim_order)
+
+        # If x is the first dimension, flip (transpose) every array within the function args.
+        if x_first:
+            args = tuple(_check_and_flip(arr) for arr in args)
+            for k, v in kwargs:
+                kwargs[k] = _check_and_flip(v)
+
+        ret = func(*args, **kwargs)
+
+        # If we flipped on the way in, need to flip on the way out so that output array(s)
+        # match the dimension order of the original input.
+        if x_first:
+            return _check_and_flip(ret)
+        else:
+            return ret
+
+    # Inject a docstring for the dim_order argument into the function's docstring.
+    dim_order_doc = '''
+    dim_order : str or ``None``, optional
+        The ordering of dimensions in passed in arrays. Can be one of ``None``, ``'xy'``,
+        or ``'yx'``. ``'xy'`` indicates that the dimension corresponding to x is the leading
+        dimension, followed by y. ``'yx'`` indicates that x is the last dimension, preceded
+        by y. ``None`` indicates that the default ordering should be assumed,
+        which will change in version 0.6 from 'xy' to 'yx'. Can only be passed as a keyword
+        argument, i.e. func(..., dim_order='xy').'''
+
+    # Find the first blank line after the start of the parameters section
+    params = wrapper.__doc__.find('Parameters')
+    blank = wrapper.__doc__.find('\n\n', params)
+    wrapper.__doc__ = wrapper.__doc__[:blank] + dim_order_doc + wrapper.__doc__[blank:]
+
+    return wrapper
+
+
 @exporter.export
+@ensure_yx_order
 def v_vorticity(u, v, dx, dy):
     r"""Calculate the vertical vorticity of the horizontal wind.
 
@@ -67,6 +136,7 @@ def v_vorticity(u, v, dx, dy):
 
 
 @exporter.export
+@ensure_yx_order
 def h_convergence(u, v, dx, dy):
     r"""Calculate the horizontal convergence of the horizontal wind.
 
@@ -97,6 +167,7 @@ def h_convergence(u, v, dx, dy):
 
 
 @exporter.export
+@ensure_yx_order
 def convergence_vorticity(u, v, dx, dy):
     r"""Calculate the horizontal convergence and vertical vorticity of the horizontal wind.
 
@@ -132,6 +203,7 @@ def convergence_vorticity(u, v, dx, dy):
 
 
 @exporter.export
+@ensure_yx_order
 def advection(scalar, wind, deltas):
     r"""Calculate the advection of a scalar field by the wind.
 
@@ -157,12 +229,19 @@ def advection(scalar, wind, deltas):
     N-dimensional array
         An N-dimensional array containing the advection at all grid points.
     """
-    # This allows passing in a list of wind components or an array
+    # This allows passing in a list of wind components or an array.
     wind = _stack(wind)
 
-    # Gradient returns a list of derivatives along each dimension.  We convert
-    # this to an array with dimension as the first index
-    grad = _stack(_gradient(scalar, *deltas))
+    # If we have more than one component, we need to reverse the order along the first
+    # dimension so that the wind components line up with the
+    # order of the gradients from the ..., y, x ordered array.
+    if wind.ndim > scalar.ndim:
+        wind = wind[::-1]
+
+    # Gradient returns a list of derivatives along each dimension. We convert
+    # this to an array with dimension as the first index. Reverse the deltas to line up
+    # with the order of the dimensions.
+    grad = _stack(_gradient(scalar, *deltas[::-1]))
 
     # Make them be at least 2D (handling the 1D case) so that we can do the
     # multiply and sum below
@@ -172,6 +251,7 @@ def advection(scalar, wind, deltas):
 
 
 @exporter.export
+@ensure_yx_order
 def geostrophic_wind(heights, f, dx, dy):
     r"""Calculate the geostrophic wind given from the heights or geopotential.
 
@@ -198,13 +278,13 @@ def geostrophic_wind(heights, f, dx, dy):
     else:
         norm_factor = g / f
 
-    # If heights is has more than 2 dimensions, we need to pass in some dummy
-    # grid deltas so that we can still use np.gradient.  It may be better to
+    # If heights has more than 2 dimensions, we need to pass in some dummy
+    # grid deltas so that we can still use np.gradient. It may be better to
     # to loop in this case, but that remains to be done.
-    deltas = [dx, dy]
+    deltas = [dy, dx]
     if heights.ndim > 2:
-        deltas = deltas + [units.Quantity(1., units.m)] * (heights.ndim - 2)
+        deltas = [units.Quantity(1., units.m)] * (heights.ndim - 2) + deltas
 
     grad = _gradient(heights, *deltas)
-    dx, dy = grad[0], grad[1]  # This throws away unused gradient components
+    dy, dx = grad[-2:]  # Throw away unused gradient components
     return -norm_factor * dy, norm_factor * dx

--- a/metpy/testing.py
+++ b/metpy/testing.py
@@ -49,8 +49,8 @@ def check_and_drop_units(actual, desired):
             if hasattr(actual, 'units'):
                 actual = actual.to('dimensionless')
     except DimensionalityError:
-        raise AssertionError('Units are not compatible: {} should be {}'.format(actual.units,
-                                                                                desired.units))
+        raise AssertionError('Units are not compatible: {} should be {}'.format(
+            actual.units, getattr(desired, 'units', 'dimensionless')))
     except AttributeError:
         pass
 


### PR DESCRIPTION
Closes #389 . Adds a kwarg `dim_order` that can be set to either `'xy'`, `'yx'`, or `None`, which uses the default. Currently the default is left to `'xy'`, but a warning is issued if the default is used. Refactor all the calculations to use yx ordering internally (to be most efficient for the common case), and added a decorator to flip all incoming arrays based on dim_order.

Also added some more tests to ensure that we're handling the transposes correctly (old tests had a lot of symmetric data).