### PR TITLE
Backport matplotlib fill_betweenx

### DIFF
--- a/examples/Advanced_Sounding.py
+++ b/examples/Advanced_Sounding.py
@@ -56,8 +56,8 @@ skew.plot(p, prof, 'k', linewidth=2)
 
 # Example of coloring area between profiles
 greater = T >= prof
-skew.ax.fill_betweenx(p, T, prof, where=greater, facecolor='blue', alpha=0.4)
-skew.ax.fill_betweenx(p, T, prof, where=~greater, facecolor='red', alpha=0.4)
+skew.shade_cin(p, T, prof)
+skew.shade_cape(p, T, prof)
 
 # An example of a slanted line at constant T -- in this case the 0
 # isotherm

--- a/metpy/plots/skewt.py
+++ b/metpy/plots/skewt.py
@@ -574,7 +574,7 @@ class SkewT(object):
 
         arrs = delete_masked_points(*arrs)
 
-        return self.ax.fill_betweenx(*arrs, **fill_args)
+        return self.ax.fill_betweenx(interpolate=True, *arrs, **fill_args)
 
     def shade_cape(self, p, t, t_parcel, **kwargs):
         r"""Shade areas of CAPE.

--- a/tutorials/upperair_soundings.py
+++ b/tutorials/upperair_soundings.py
@@ -139,8 +139,8 @@ skew.plot(p, parcel_prof, 'k', linewidth=2)
 
 # Color regions of CAPE and CIN (the area between the actual temperature and
 # the parcel path).
-skew.ax.fill_betweenx(p, T, parcel_prof, where=T >= parcel_prof, facecolor='blue', alpha=0.4)
-skew.ax.fill_betweenx(p, T, parcel_prof, where=T < parcel_prof, facecolor='red', alpha=0.4)
+skew.shade_cin(p, T, parcel_prof)
+skew.shade_cape(p, T, parcel_prof)
 
 # Plot a zero degree isotherm
 l = skew.ax.axvline(0, color='c', linestyle='--', linewidth=2)
@@ -183,8 +183,8 @@ skew.plot(p, parcel_prof, 'k', linewidth=2)
 
 # Color regions of CAPE and CIN (the area between the actual temperature and
 # the parcel path).
-skew.ax.fill_betweenx(p, T, parcel_prof, where=T >= parcel_prof, facecolor='blue', alpha=0.4)
-skew.ax.fill_betweenx(p, T, parcel_prof, where=T < parcel_prof, facecolor='red', alpha=0.4)
+skew.shade_cin(p, T, parcel_prof)
+skew.shade_cape(p, T, parcel_prof)
 
 # Plot a zero degree isotherm
 l = skew.ax.axvline(0, color='c', linestyle='--', linewidth=2)


### PR DESCRIPTION
Matplotlib master has support for interpolating in `fill_betweenx`. Instead of waiting for 2.1 to release, just add that to our list of back ported functionality.