### PR TITLE
LFC and EL NaN returns

### DIFF
--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -13,7 +13,7 @@ from metpy.calc import (density, dewpoint, dewpoint_rh, dry_lapse, el,
                         saturation_mixing_ratio, saturation_vapor_pressure, vapor_pressure,
                         virtual_potential_temperature, virtual_temperature)
 
-from metpy.testing import assert_almost_equal, assert_array_almost_equal
+from metpy.testing import assert_almost_equal, assert_array_almost_equal, assert_nan
 from metpy.units import units
 
 
@@ -186,8 +186,8 @@ def test_no_lfc():
     temperatures = np.array([22.2, 17.4, 14.6, 1.4, -17.6, -39.4, -52.5]) * units.celsius
     dewpoints = np.array([9., 4.3, -21.2, -26.7, -31., -53.3, -66.7]) * units.celsius
     lfc_pressure, lfc_temperature = lfc(levels, temperatures, dewpoints)
-    assert lfc_pressure is None
-    assert lfc_temperature is None
+    assert assert_nan(lfc_pressure, levels.units)
+    assert assert_nan(lfc_temperature, temperatures.units)
 
 
 def test_lfc_inversion():
@@ -260,8 +260,8 @@ def test_no_el():
     temperatures = np.array([22.2, 17.4, 14.6, 1.4, -17.6, -39.4, -52.5]) * units.celsius
     dewpoints = np.array([19., 14.3, -11.2, -16.7, -21., -43.3, -56.7]) * units.celsius
     el_pressure, el_temperature = el(levels, temperatures, dewpoints)
-    assert el_pressure is None
-    assert el_temperature is None
+    assert assert_nan(el_pressure, levels.units)
+    assert assert_nan(el_temperature, temperatures.units)
 
 
 def test_wet_psychrometric_vapor_pressure():

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -219,7 +219,7 @@ def lfc(pressure, temperature, dewpt):
     Returns
     -------
     `pint.Quantity`
-        The LFC
+        The LFC pressure and temperature
 
     See Also
     --------
@@ -232,7 +232,7 @@ def lfc(pressure, temperature, dewpt):
     x, y = find_intersections(pressure[1:], ideal_profile[1:], temperature[1:],
                               direction='increasing')
     if len(x) == 0:
-        return None, None
+        return np.nan * pressure.units, np.nan * temperature.units
     else:
         return x[0], y[0]
 
@@ -269,7 +269,7 @@ def el(pressure, temperature, dewpt):
 
     # If there is only one intersection, it's the LFC and we return None.
     if len(x) <= 1:
-        return None, None
+        return np.nan * pressure.units, np.nan * temperature.units
     else:
         return x[-1], y[-1]
 

--- a/metpy/testing.py
+++ b/metpy/testing.py
@@ -62,6 +62,15 @@ def check_and_drop_units(actual, desired):
     return actual, desired
 
 
+def assert_nan(value, units):
+    """Helper to check for nan with proper units."""
+    if not np.isnan(value):
+        pytest.fail('{} is not np.nan'.format(value))
+
+    check_and_drop_units(value, np.nan * units)
+    return True
+
+
 def assert_almost_equal(actual, desired, decimal=7):
     """Check that values are almost equal, including units.
 


### PR DESCRIPTION
If the LFC or EL do not exist, return `np.nan` instead of `None`. Had to add a test helper since `np.nan != np.nan` and we want to verify units.