### PR TITLE
Add height to pressure conversion

### DIFF
--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -255,6 +255,34 @@ def pressure_to_height_std(pressure):
 
 
 @exporter.export
+@check_units('[length]')
+def height_to_pressure_std(height):
+    r"""Convert height data to pressures using the U.S. standard atmosphere.
+
+    The implementation inverts the formula outlined in [Hobbs1977]_ pg.60-61.
+
+    Parameters
+    ----------
+    height : `pint.Quantity`
+        Atmospheric height
+
+    Returns
+    -------
+    `pint.Quantity`
+        The corresponding pressure value(s)
+
+    Notes
+    -----
+    .. math:: p = p_0 e^{\frac{g}{R \Gamma} \text{ln}(1-\frac{Z \Gamma}{T_0})}
+
+    """
+    t0 = 288. * units.kelvin
+    gamma = 6.5 * units('K/km')
+    p0 = 1013.25 * units.mbar
+    return p0 * (1 - (gamma / t0) * height) ** (g / (Rd * gamma))
+
+
+@exporter.export
 def coriolis_parameter(latitude):
     r"""Calculate the coriolis parameter at each point.
 

--- a/metpy/calc/tests/test_basic.py
+++ b/metpy/calc/tests/test_basic.py
@@ -6,7 +6,7 @@
 import numpy as np
 
 from metpy.calc import (coriolis_parameter, get_wind_components, get_wind_dir, get_wind_speed,
-                        heat_index, pressure_to_height_std, windchill)
+                        heat_index, height_to_pressure_std, pressure_to_height_std, windchill)
 from metpy.testing import assert_almost_equal, assert_array_almost_equal, assert_array_equal
 from metpy.units import units
 
@@ -232,6 +232,14 @@ def test_pressure_to_heights_basic():
     heights = pressure_to_height_std(pressures)
     values = np.array([321.5, 216.5, 487.6, 601.7]) * units.meter
     assert_almost_equal(heights, values, 1)
+
+
+def test_heights_to_pressure_basic():
+    """Test basic height to pressure calculation for standard atmosphere."""
+    heights = np.array([321.5, 216.5, 487.6, 601.7]) * units.meter
+    pressures = height_to_pressure_std(heights)
+    values = np.array([975.2, 987.5, 956., 943.]) * units.mbar
+    assert_almost_equal(pressures, values, 1)
 
 
 def test_pressure_to_heights_units():


### PR DESCRIPTION
We had the other way (pressure to height), but this will be useful when drawing scale bars, coloring things based on their height, etc. The equations smells like it could maybe be slightly simplified, but I haven't seen a way to do it that results in any fewer operations, just moves the logarithm around. Closes #407 