### PR TITLE
Be better about closing file handles

### DIFF
--- a/metpy/gridding/tests/test_gridding_functions.py
+++ b/metpy/gridding/tests/test_gridding_functions.py
@@ -122,6 +122,7 @@ def test_interpolate(method, test_coords):
 
     _, _, img = interpolate(xp, yp, z, hres=10, interp_type=method, **extra_kw)
 
-    truth = np.load(get_test_data('{0}_test.npz'.format(method)))['img']
+    with get_test_data('{0}_test.npz'.format(method)) as fobj:
+        truth = np.load(fobj)['img']
 
     assert_array_almost_equal(truth, img)

--- a/metpy/gridding/tests/test_interpolation.py
+++ b/metpy/gridding/tests/test_interpolation.py
@@ -37,10 +37,9 @@ def test_data():
 @pytest.fixture()
 def test_grid():
     r"""Return grid locations used for tests in this file."""
-    xg = np.load(get_test_data('interpolation_test_grid.npz'))['xg']
-    yg = np.load(get_test_data('interpolation_test_grid.npz'))['yg']
-
-    return xg, yg
+    with get_test_data('interpolation_test_grid.npz') as fobj:
+        data = np.load(fobj)
+        return data['xg'], data['yg']
 
 
 def test_natural_neighbor(test_data, test_grid):
@@ -50,7 +49,8 @@ def test_natural_neighbor(test_data, test_grid):
 
     img = natural_neighbor(xp, yp, z, xg, yg)
 
-    truth = np.load(get_test_data('nn_bbox0to100.npz'))['img']
+    with get_test_data('nn_bbox0to100.npz') as fobj:
+        truth = np.load(fobj)['img']
 
     assert_array_almost_equal(truth, img)
 
@@ -76,7 +76,8 @@ def test_inverse_distance(method, test_data, test_grid):
 
     img = inverse_distance(xp, yp, z, xg, yg, kind=method, **extra_kw)
 
-    truth = np.load(get_test_data(test_file))['img']
+    with get_test_data(test_file) as fobj:
+        truth = np.load(fobj)['img']
 
     assert_array_almost_equal(truth, img)
 

--- a/metpy/io/gini.py
+++ b/metpy/io/gini.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Tools to process GINI-formatted products."""
 
+import contextlib
 from datetime import datetime
 try:
     from enum import Enum
@@ -159,7 +160,8 @@ class GiniFile(object):
             self.filename = 'No Filename'
 
         # Just read in the entire set of data at once
-        self._buffer = IOBuffer.fromfile(fobj)
+        with contextlib.closing(fobj):
+            self._buffer = IOBuffer.fromfile(fobj)
 
         # Pop off the WMO header if we find it
         self.wmo_code = ''

--- a/metpy/io/nexrad.py
+++ b/metpy/io/nexrad.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 
 import bz2
 from collections import defaultdict, namedtuple, OrderedDict
+import contextlib
 import datetime
 import gzip
 import logging
@@ -180,7 +181,9 @@ class Level2File(object):
         else:
             fobj = filename
 
-        self._buffer = IOBuffer.fromfile(fobj)
+        with contextlib.closing(fobj):
+            self._buffer = IOBuffer.fromfile(fobj)
+
         self._read_volume_header()
         start = self._buffer.set_mark()
 
@@ -1530,7 +1533,8 @@ class Level3File(object):
             self.filename = 'No Filename'
 
         # Just read in the entire set of data at once
-        self._buffer = IOBuffer.fromfile(fobj)
+        with contextlib.closing(fobj):
+            self._buffer = IOBuffer.fromfile(fobj)
 
         # Pop off the WMO header if we find it
         self._process_wmo_header()

--- a/metpy/io/upperair.py
+++ b/metpy/io/upperair.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Read upper air data from remote archives."""
 
+import contextlib
 from io import BytesIO
 import json
 try:
@@ -145,8 +146,8 @@ class WyomingUpperAir(object):
         url = ('http://weather.uwyo.edu/cgi-bin/sounding?region={region}&TYPE=TEXT%3ALIST'
                '&YEAR={time:%Y}&MONTH={time:%m}&FROM={time:%d%H}&TO={time:%d%H}'
                '&STNM={stid}').format(region=region, time=time, stid=site_id)
-        fobj = urlopen(url)
-        data = fobj.read()
+        with contextlib.closing(urlopen(url)) as fobj:
+            data = fobj.read()
 
         # See if the return is valid, but has no data
         if data.find(b'Can\'t') != -1:
@@ -237,7 +238,8 @@ class IAStateUpperAir(object):
         url = ('http://mesonet.agron.iastate.edu/json/raob.py?ts={time:%Y%m%d%H}00'
                '&station={stid}').format(time=time, stid=site_id)
 
-        json_data = json.loads(urlopen(url).read().decode('utf-8'))['profiles'][0]['profile']
+        with contextlib.closing(urlopen(url)) as fobj:
+            json_data = json.loads(fobj.read().decode('utf-8'))['profiles'][0]['profile']
 
         # See if the return is valid, but has no data
         if not json_data:

--- a/metpy/plots/ctables.py
+++ b/metpy/plots/ctables.py
@@ -40,6 +40,7 @@ specific set of constraints (e.g. step size) for mapping.
 from __future__ import division
 
 import ast
+import contextlib
 import glob
 import logging
 import os.path
@@ -135,8 +136,10 @@ class ColortableRegistry(dict):
         """
         for fname in resource_listdir(pkg, path):
             if fname.endswith(TABLE_EXT):
-                self.add_colortable(resource_stream(pkg, posixpath.join(path, fname)),
-                                    posixpath.splitext(posixpath.basename(fname))[0])
+                table_path = posixpath.join(path, fname)
+                with contextlib.closing(resource_stream(pkg, table_path)) as stream:
+                    self.add_colortable(stream,
+                                        posixpath.splitext(posixpath.basename(fname))[0])
 
     def scan_dir(self, path):
         r"""Scan a directory on disk for color table files and add them to the registry.

--- a/metpy/plots/tests/test_station_plot.py
+++ b/metpy/plots/tests/test_station_plot.py
@@ -158,7 +158,7 @@ def test_simple_layout():
     return fig
 
 
-@pytest.mark.mpl_image_compare(tolerance={'1.5': 0.1474, '1.4': 7.02}.get(MPL_VERSION, 0.0113),
+@pytest.mark.mpl_image_compare(tolerance={'1.4': 7.02}.get(MPL_VERSION, 0.1848),
                                savefig_kwargs={'dpi': 300}, remove_text=True)
 def test_nws_layout():
     """Test metpy's NWS layout for station plots."""


### PR DESCRIPTION
PyTest 3.1 handles warnings now, which means that it now unsilences `ResourceWarning`s about unclosed file handles (added in Python 3.2). This cleans up our IO code to explicitly close any file objects they use, as well as makes sure that tests are using `with` blocks to handle reading from files.

Also finally fix the false alarm I get locally on my mac with one of the image tests by raising the threshold slightly.