### PR TITLE
MNT: Refactor `lcl` to use `scipy.optimize`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ script:
   - if [[ $TASK == "docs" ]]; then
       export TEST_DATA_DIR=${TRAVIS_BUILD_DIR}/testdata;
       pushd docs;
-      make clean html;
+      make clean html linkcheck;
       export DOC_BUILD_RESULT=$?;
       popd;
       if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -250,8 +250,8 @@ def test_el():
     temperatures = np.array([22.2, 14.6, 12., 9.4, 7., -38.]) * units.celsius
     dewpoints = np.array([19., -11.2, -10.8, -10.4, -10., -53.2]) * units.celsius
     el_pressure, el_temperature = el(levels, temperatures, dewpoints)
-    assert_almost_equal(el_pressure, 520.8420 * units.mbar, 3)
-    assert_almost_equal(el_temperature, -11.7055 * units.degC, 3)
+    assert_almost_equal(el_pressure, 520.8700 * units.mbar, 3)
+    assert_almost_equal(el_temperature, -11.7027 * units.degC, 3)
 
 
 def test_no_el():


### PR DESCRIPTION
Instead of our own fixed point iteration code, use the code in
`scipy.optimize`. While this is measurably slower, we're still only
talking tens of milliseconds for 90000-element arrays. This slowdown is
outweighed by leveraging a re-usable algorithm, and we were likely to encounter similar performance when we refactored to make our own implementation re-usable for other calculations.

This also fixes a minor bug in lcl where we were returning the dewpoint
corresponding to the next-to-last pressure value from the iteration. In
practice, we're talking about differences in the thousandth of a degree.