### PR TITLE
Relative humidity 

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -47,6 +47,8 @@ References
            Division, NWS Southern Region Headquarters, 1990.
            `SR90-23 <http://www.weather.gov/media/ffc/ta_htindx.PDF>`_
 
+.. [Salby1996] Salby, Murray L., 1996: Fundamentals of Atmospheric Physics.
+
 .. [Steadman1979] Steadman, R.G., 1979: The assessment of sultriness. Part I: A
            temperature-humidity index based on human physiology and clothing
            science. J. Appl. Meteor., 18, 861-873.

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -10,9 +10,11 @@ from metpy.calc import (density, dewpoint, dewpoint_rh, dry_lapse, el,
                         equivalent_potential_temperature, lcl, lfc, mixing_ratio,
                         mixing_ratio_from_specific_humidity, moist_lapse,
                         parcel_profile, potential_temperature,
-                        psychrometric_vapor_pressure_wet, relative_humidity_wet_psychrometric,
+                        psychrometric_vapor_pressure_wet,
                         relative_humidity_from_mixing_ratio,
-                        relative_humidity_from_specific_humidity, saturation_mixing_ratio,
+                        relative_humidity_from_specific_humidity,
+                        relative_humidity_wet_psychrometric,
+                        saturation_mixing_ratio,
                         saturation_vapor_pressure, vapor_pressure,
                         virtual_potential_temperature, virtual_temperature)
 
@@ -300,23 +302,23 @@ def test_wet_psychrometric_rh_kwargs():
 
 
 def test_rh_mixing_ratio():
-    """Test calculation of relative humidity from mixing ratio, temperature, and
-    pressure."""
+    """Tests relative humidity from mixing ratio."""
     p = 1013.25 * units.mbar
     temperature = 20. * units.degC
     w = 0.012
     rh = relative_humidity_from_mixing_ratio(w, temperature, p)
     assert_almost_equal(rh, 81.7219 * units.percent, 3)
 
+
 def test_mixing_ratio_from_specific_humidity():
-    """Test calculation of relative humidity from mixing ratio, temperature, and
-    pressure."""
+    """Tests mixing ratio from specific humidity."""
     q = 0.012
     w = mixing_ratio_from_specific_humidity(q)
     assert_almost_equal(w, 0.01215, 3)
+
+
 def test_rh_specific_humidity():
-    """Test calculation of relative humidity from mixing ratio, temperature, and
-    pressure."""
+    """Tests relative humidity from specific humidity."""
     p = 1013.25 * units.mbar
     temperature = 20. * units.degC
     q = 0.012

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -7,10 +7,13 @@ import numpy as np
 import pytest
 
 from metpy.calc import (density, dewpoint, dewpoint_rh, dry_lapse, el,
-                        equivalent_potential_temperature, lcl, lfc, mixing_ratio, moist_lapse,
+                        equivalent_potential_temperature, lcl, lfc, mixing_ratio,
+                        mixing_ratio_from_specific_humidity, moist_lapse,
                         parcel_profile, potential_temperature,
                         psychrometric_vapor_pressure_wet, relative_humidity_wet_psychrometric,
-                        saturation_mixing_ratio, saturation_vapor_pressure, vapor_pressure,
+                        relative_humidity_from_mixing_ratio,
+                        relative_humidity_from_specific_humidity, saturation_mixing_ratio,
+                        saturation_vapor_pressure, vapor_pressure,
                         virtual_potential_temperature, virtual_temperature)
 
 from metpy.testing import assert_almost_equal, assert_array_almost_equal, assert_nan
@@ -294,3 +297,28 @@ def test_wet_psychrometric_rh_kwargs():
                                                            wet_bulb_temperature, p,
                                                            psychrometer_coefficient=coeff)
     assert_almost_equal(psychrometric_rh, 82.9701 * units.percent, 3)
+
+
+def test_rh_mixing_ratio():
+    """Test calculation of relative humidity from mixing ratio, temperature, and
+    pressure."""
+    p = 1013.25 * units.mbar
+    temperature = 20. * units.degC
+    w = 0.012
+    rh = relative_humidity_from_mixing_ratio(w, temperature, p)
+    assert_almost_equal(rh, 81.7219 * units.percent, 3)
+
+def test_mixing_ratio_from_specific_humidity():
+    """Test calculation of relative humidity from mixing ratio, temperature, and
+    pressure."""
+    q = 0.012
+    w = mixing_ratio_from_specific_humidity(q)
+    assert_almost_equal(w, 0.01215, 3)
+def test_rh_specific_humidity():
+    """Test calculation of relative humidity from mixing ratio, temperature, and
+    pressure."""
+    p = 1013.25 * units.mbar
+    temperature = 20. * units.degC
+    q = 0.012
+    rh = relative_humidity_from_specific_humidity(q, temperature, p)
+    assert_almost_equal(rh, 82.7145 * units.percent, 3)

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -734,3 +734,106 @@ def psychrometric_vapor_pressure_wet(dry_bulb_temperature, wet_bulb_temperature,
     """
     return (saturation_vapor_pressure(wet_bulb_temperature) - psychrometer_coefficient *
             pressure * (dry_bulb_temperature - wet_bulb_temperature).to('kelvin'))
+
+
+@exporter.export
+@check_units('[dimensionless]', '[temperature]', '[pressure]')
+def relative_humidity_from_mixing_ratio(mixing_ratio, temperature, pressure):
+    r"""Calculate the relative humidity from mixing ratio, temperature, and pressure.
+
+    Parameters
+    ----------
+    mixing_ratio: `pint.Quantity`
+        Dimensionless mass mixing ratio
+    temperature: `pint.Quantity`
+        Air temperature
+    pressure: `pint.Quantity`
+        Total atmospheric pressure
+
+    Returns
+    -------
+    `pint.Quantity`
+        Relative humidity
+
+    Notes
+    -----
+    .. math:: RH = 100 \frac{w}{w_s}
+
+    * :math:`RH` is relative humidity
+    * :math:`w` is mxing ratio
+    * :math:`w_s` is the saturation mixing ratio
+
+    See Also
+    --------
+    saturation_mixing_ratio
+
+    """
+    return (100 * units.percent *
+            mixing_ratio / saturation_mixing_ratio(pressure, temperature))
+
+
+@exporter.export
+@check_units('[dimensionless]')
+def mixing_ratio_from_specific_humidity(specific_humidity):
+    r"""Calculate the mixing ratio from specific humidity.
+
+    Parameters
+    ----------
+    mixing_ratio: `pint.Quantity`
+        Dimensionless mass water vapor ratio
+
+    Returns
+    -------
+    `pint.Quantity`
+        Mixing ratio
+
+    Notes
+    -----
+    .. math:: w = \frac{q}{1-q}
+
+    * :math:`w` is mxing ratio
+    * :math:`q` is the specific humidity
+
+    See Also
+    --------
+    mixing_ratio
+
+    """
+    return (specific_humidity / (1 - specific_humidity))
+
+
+@exporter.export
+@check_units('[dimensionless]', '[temperature]', '[pressure]')
+def relative_humidity_from_specific_humidity(specific_humidity, temperature, pressure):
+    r"""Calculate the relative humidity from specific humidity, temperature, and pressure.
+
+    Parameters
+    ----------
+    specific_humidity: `pint.Quantity`
+        Dimensionless mass mixing ratio
+    temperature: `pint.Quantity`
+        Air temperature
+    pressure: `pint.Quantity`
+        Total atmospheric pressure
+
+    Returns
+    -------
+    `pint.Quantity`
+        Relative humidity
+
+    Notes
+    -----
+    .. math:: RH = 100 \frac{q}{(1-q)w_s}
+
+    * :math:`RH` is relative humidity
+    * :math:`q` is specific humidity
+    * :math:`w_s` is the saturation mixing ratio
+
+    See Also
+    --------
+    relative_humidity_from_mixing_ratio
+
+    """
+    return (100 * units.percent *
+            mixing_ratio_from_specific_humidity(specific_humidity) /
+            saturation_mixing_ratio(pressure, temperature))

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -757,6 +757,7 @@ def relative_humidity_from_mixing_ratio(mixing_ratio, temperature, pressure):
 
     Notes
     -----
+    Formula from [Hobbs 1977]_ pg. 74.
     .. math:: RH = 100 \frac{w}{w_s}
 
     * :math:`RH` is relative humidity
@@ -779,8 +780,8 @@ def mixing_ratio_from_specific_humidity(specific_humidity):
 
     Parameters
     ----------
-    mixing_ratio: `pint.Quantity`
-        Dimensionless mass water vapor ratio
+    specific_humidity: `pint.Quantity`
+        Specific humidity of air
 
     Returns
     -------
@@ -789,6 +790,7 @@ def mixing_ratio_from_specific_humidity(specific_humidity):
 
     Notes
     -----
+    Formula from [Salby1996]_ pg. 118.
     .. math:: w = \frac{q}{1-q}
 
     * :math:`w` is mxing ratio
@@ -799,7 +801,7 @@ def mixing_ratio_from_specific_humidity(specific_humidity):
     mixing_ratio
 
     """
-    return (specific_humidity / (1 - specific_humidity))
+    return specific_humidity / (1 - specific_humidity)
 
 
 @exporter.export
@@ -810,7 +812,7 @@ def relative_humidity_from_specific_humidity(specific_humidity, temperature, pre
     Parameters
     ----------
     specific_humidity: `pint.Quantity`
-        Dimensionless mass mixing ratio
+        Specific humidity of air
     temperature: `pint.Quantity`
         Air temperature
     pressure: `pint.Quantity`
@@ -823,6 +825,7 @@ def relative_humidity_from_specific_humidity(specific_humidity, temperature, pre
 
     Notes
     -----
+    Formula from [Hobbs 1977]_ pg. 74. and [Salby1996]_ pg. 118.
     .. math:: RH = 100 \frac{q}{(1-q)w_s}
 
     * :math:`RH` is relative humidity


### PR DESCRIPTION
 Adds calculation for relative humidity from mixing ratio or specific humidity, also ads conversion to mixing ratio from specific humidity. Mixing ratio and specific humidity are common model output variables, while relative humidity may be desired. 
#65 
* Added calculation for RH from w, w from q, and RH from q.