### PR TITLE
Log interpolation

### DIFF
--- a/metpy/calc/tests/test_tools.py
+++ b/metpy/calc/tests/test_tools.py
@@ -7,10 +7,11 @@ import numpy as np
 import numpy.ma as ma
 import pytest
 
-from metpy.calc import (find_intersections, interpolate_nans, nearest_intersection_idx,
-                        reduce_point_density, resample_nn_1d)
+from metpy.calc import (find_intersections, interpolate_nans, log_interp,
+                        nearest_intersection_idx, reduce_point_density, resample_nn_1d)
 from metpy.calc.tools import _next_non_masked_element, delete_masked_points
 from metpy.testing import assert_array_almost_equal, assert_array_equal
+from metpy.units import units
 
 
 def test_resample_nn():
@@ -166,3 +167,23 @@ def test_delete_masked_points():
     a, b = delete_masked_points(a, b)
     assert_array_equal(a, expected)
     assert_array_equal(b, expected)
+
+
+def test_log_interp():
+    """Test interpolating with log x-scale."""
+    x_log = np.array([1e3, 1e4, 1e5, 1e6])
+    y_log = np.log(x_log) * 2 + 3
+    x_interp = np.array([5e3, 5e4, 5e5])
+    y_interp_truth = np.array([20.0343863828, 24.6395565688, 29.2447267548])
+    y_interp = log_interp(x_interp, x_log, y_log)
+    assert_array_almost_equal(y_interp, y_interp_truth, 7)
+
+
+def test_log_interp_units():
+    """Test interpolating with log x-scale with units."""
+    x_log = np.array([1e3, 1e4, 1e5, 1e6]) * units.hPa
+    y_log = (np.log(x_log.m) * 2 + 3) * units.degC
+    x_interp = np.array([5e3, 5e4, 5e5]) * units.hPa
+    y_interp_truth = np.array([20.0343863828, 24.6395565688, 29.2447267548]) * units.degC
+    y_interp = log_interp(x_interp, x_log, y_log)
+    assert_array_almost_equal(y_interp, y_interp_truth, 7)

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -283,3 +283,42 @@ def reduce_point_density(points, radius, priority=None):
             keep[ind] = True
 
     return keep
+
+
+@exporter.export
+def log_interp(x, xp, fp, **kwargs):
+    r"""Interpolates data with logarithmic x-scale.
+
+    Interpolation on a logarithmic x-scale for interpolation values in pressure coordintates.
+
+    Parameters
+    ----------
+    x : array-like
+        The x-coordinates of the interpolated values.
+
+    xp : array-like
+        The x-coordinates of the data points.
+
+    fp : array-like
+        The y-coordinates of the data points, same length as cp.
+
+    Returns
+    -------
+    array-like
+        The interpolated values, same shape as x.
+
+    """
+    sort_args = np.argsort(xp)
+
+    if hasattr(x, 'units'):
+        x = x.m
+
+    if hasattr(xp, 'units'):
+        xp = xp.m
+
+    interpolated_vals = np.interp(np.log(x), np.log(xp[sort_args]), fp[sort_args], **kwargs)
+
+    if hasattr(fp, 'units'):
+        interpolated_vals = interpolated_vals * fp.units
+
+    return interpolated_vals

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -300,12 +300,20 @@ def log_interp(x, xp, fp, **kwargs):
         The x-coordinates of the data points.
 
     fp : array-like
-        The y-coordinates of the data points, same length as cp.
+        The y-coordinates of the data points, same length as xp.
 
     Returns
     -------
     array-like
         The interpolated values, same shape as x.
+
+    Examples
+    --------
+    >>> x_log = np.array([1e3, 1e4, 1e5, 1e6])
+    >>> y_log = np.log(x_log) * 2 + 3
+    >>> x_interp = np.array([5e3, 5e4, 5e5])
+    >>> metpy.calc.log_interp(x_interp, x_log, y_log)
+    array([ 20.03438638,  24.63955657,  29.24472675])
 
     """
     sort_args = np.argsort(xp)


### PR DESCRIPTION
Adds a log interpolation function to make interpolating things in pressure coordinates easier. This is needed for the layer helper functions being developed, but that PR was already getting rather huge.

I don't like all the unit checking and munging here. Interpolate drops units silently and log throws errors. Open to suggestions on if we should force unit usage here or not.