### PR TITLE
Isentropic pressure

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -79,6 +79,10 @@ References
 .. [Tsonis2008] Tsonis, A. A., 2008: An introduction to atmospheric thermodynamics.
            Cambridge Univ. Press, Cambridge.
 
+.. [Ziv1994] Ziv, B., and Alpert, P., 1994: Isobaric to Isentropic Interpolation Errors
+           and Implication to Potential Vorticity Analysis. *J. Appl. Meteor.*, **33**,
+           694-703, doi:`10.1175/1520-0450(1994)033%3C0694:ITIIEA%3E2.0.CO;2
+           <https://doi.org/10.1175/1520-0450(1994)033%3C0694:ITIIEA%3E2.0.CO;2>`_.
 
 .. [WMO8-2008] WMO, 2008: *Guide to Meteorological Instruments and Methods of Observation*.
            `WMO No.8 <https://www.wmo.int/pages/prog/gcos/documents/gruanmanuals/CIMO/CIMO_Guide-7th_Edition-2008.pdf>`_, 681 pp.

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -9,7 +9,8 @@ import numpy as np
 import scipy.integrate as si
 import scipy.optimize as so
 
-from .tools import _greater_or_close, _less_or_close, find_intersections, get_layer
+from .tools import _greater_or_close, _less_or_close, broadcast_indices, find_intersections, \
+    get_layer, interp
 from ..constants import Cp_d, epsilon, kappa, Lv, P0, Rd
 from ..package_tools import Exporter
 from ..units import atleast_1d, check_units, concatenate, units
@@ -1047,160 +1048,161 @@ def most_unstable_parcel(p, temperature, dewpoint, heights=None,
     return p_layer[max_idx], T_layer[max_idx], Td_layer[max_idx]
 
 
-def get_isentropic_pressure(lev, tmpk, isentlevs, max_iters=10, eps=1e-3):
-    r"""Compute the pressure on isentropic surfaces.
-
-    Parameters
-    ----------
-    levs : array
-        Pressure levels in hPa
-    tmpk : array
-        Temperature in Kelvin
-    isentlevs : array
-        Array of desired theta surfaces
-
-    Returns
-    -------
-    isentpr : array
-        Array of pressure at specified theta surfaces
-
-    Other Parameters
-    ----------------
-    max_iters : int, optional
-        The maximum number of iterations to use in calculation, defaults to 10.
-    eps : float, optional
-        The desired absolute error in the calculated value, defaults to 1e-3.
-    See Also
-    --------
-    potential_temperature
-
-    """
-    levs = np.repeat(np.repeat(np.repeat(lev[:, np.newaxis],
-                     tmpk.shape[2], axis=1)[:, :, np.newaxis],
-                     tmpk.shape[3], axis=2)[np.newaxis, :, :, :],
-                     tmpk.shape[0], axis=0)
-    # exponent to Poisson's Equation, which is imported above
-    ka = kappa * 1000 * units('g/kg')
-    # Assumes temp in K and pres in hPa
-    thtalevs = potential_temperature(levs * units.hPa, tmpk * units.K)
-    ithtalevs = thtalevs.magnitude
-    isentprs3 = np.empty((tmpk.shape[0], isentlevs.size, tmpk.shape[2], tmpk.shape[3]))
-    pk = np.log(lev)
-    pok = 1000.**(ka)
-    for tlev in range(isentlevs.size):
-        for i in range(tmpk.shape[3]):
-            for j in range(tmpk.shape[2]):
-                test = np.where(np.array(thtalevs[0, :, j, i]) >= float(isentlevs[tlev]))
-                minv = np.min(test[0]) - 1
-                if (minv > 0):
-                    # Implementation of GEMPAK routine for computing pressure of a theta level:
-                    # The method solves an implicit equation derived by combining the      *
-                    # definition of potential temperature and the assumption that tem-     *
-                    # perature varies linearly with ln (p).  Newton iteration is used to   *
-                    # solve for ln (p). Code from Kevin Goebbert.
-                    a = (tmpk[0, minv + 1, j, i] - tmpk[0, minv, j, i]) / (pk[minv + 1] -
-                                                                           pk[minv])
-                    b = tmpk[0, minv + 1, j, i] - a * pk[minv + 1]
-                    if (ithtalevs[0, minv + 1, j, i] != ithtalevs[0, minv, j, i]):
-                        rm = (isentlevs[tlev] - ithtalevs[0, minv, j, i]) / (ithtalevs
-                                                                             [0, minv + 1, j,
-                                                                              i] - ithtalevs
-                                                                             [0, minv, j, i])
-                    else:
-                        rm = 0.5
-                    pk1 = pk[minv] + rm * (pk[minv + 1] - pk[minv])
-#                    res = 1.
-#                    k = 1
-                    while max_iters:
-                        ekp = np.exp((-ka) * pk1)
-                        t = a * pk1 + b
-                        f = isentlevs[tlev] - pok * t * ekp
-                        fp = pok * ekp * ((ka) * t - a)
-                        pin = pk1 - (f / fp)
-                        if np.abs(pk1 - pin) < eps:
-                            break
-                        pk1 = pin
-                        max_iters -= 1
-                    isentprs3[0, tlev, j, i] = np.exp(pk1)
-                else:
-                    isentprs3[0, tlev, j, i] = 'nan'
-    return isentprs3
-
-
 @exporter.export
-def get_isentropic_pressure2(lev, tmpk, isentlevs, max_iters=10, eps=1e-3):
-    r"""Compute the pressure on isentropic surfaces.
-        Uses Scipy fixed_point method
+@check_units('[temperature]', '[pressure]', '[temperature]')
+def isentropic_interpolation(theta_levels, pressure, temperature, *args, **kwargs):
+    r"""Interpolate data in isobaric coordinates to isentropic coordinates.
+
     Parameters
     ----------
-    levs : array
-        Pressure levels in hPa
-    tmpk : array
-        Temperature in Kelvin
-    isentlevs : array
-        Array of desired theta surfaces
+    theta_levels : array
+        One-dimensional array of desired theta surfaces
+    pressure : array
+        One-dimensional array of pressure levels
+    temperature : array
+        Array of temperature
+    args : array, optional
+        Any additional variables will be interpolated to each isentropic level.
 
     Returns
     -------
-    isentpr : array
-        Array of pressure at specified theta surfaces
+    list
+        List with pressure at each isentropic level, followed by each additional
+        argument interpolated to isentropic coordinates.
 
     Other Parameters
     ----------------
+    axis : int, optional
+        The axis corresponding to the vertical in the temperature array, defaults to 0.
+    tmpk_out : bool, optional
+        If true, will calculate temperature and output as the last item in the output list.
+        Defaults to False.
     max_iters : int, optional
-        The maximum number of iterations to use in calculation, defaults to 10.
+        The maximum number of iterations to use in calculation, defaults to 50.
     eps : float, optional
-        The desired absolute error in the calculated value, defaults to 1e-3.
+        The desired absolute error in the calculated value, defaults to 1e-6.
+
+    Notes
+    -----
+    Input variable arrays must have the same number of vertical levels as the pressure levels
+    array. Pressure is calculated on isentropic surfaces by assuming that temperature varies
+    linearly with the natural log of pressure. Linear interpolation is then used in the
+    vertical to find the pressure at each isentropic level. Interpolation method from
+    [Ziv1994]_. Any additional arguments are assumed to vary linearly with temperature and will
+    be linearly interpolated to the new isentropic levels.
+
     See Also
     --------
     potential_temperature
 
     """
-    def _isen_iter(pk1, isentlev, ka, a, b, pok):
-        ekp = np.exp((-ka) * pk1)
-        t = a * pk1 + b
-        f = isentlev - pok * t * ekp
-        fp = pok * ekp * ((ka) * t - a)
-        return pk1 - (f / fp)
+    # iteration function to be used later
+    # Calculates theta from linearly interpolated temperature and solves for pressure
+    def _isen_iter(iter_log_p, isentlevs_nd, ka, a, b, pok):
+        exner = pok * np.exp(-ka * iter_log_p)
+        t = a * iter_log_p + b
+        # Newton-Raphson iteration
+        f = isentlevs_nd - t * exner
+        fp = exner * (ka * t - a)
+        return iter_log_p - (f / fp)
 
-    levs = np.repeat(np.repeat(np.repeat(lev[:, np.newaxis],
-                     tmpk.shape[2], axis=1)[:, :, np.newaxis],
-                     tmpk.shape[3], axis=2)[np.newaxis, :, :, :],
-                     tmpk.shape[0], axis=0)
+    # Change when Python 2.7 no longer supported
+    # Pull out keyword arguments
+    tmpk_out = kwargs.pop('tmpk_out', False)
+    max_iters = kwargs.pop('max_iters', 50)
+    eps = kwargs.pop('eps', 1e-6)
+    axis = kwargs.pop('axis', 0)
+
+    # Get dimensions in temperature
+    ndim = temperature.ndim
+
+    # Convert units
+    pres = pressure.to('hPa')
+    temperature = temperature.to('kelvin')
+
+    slices = [np.newaxis] * ndim
+    slices[axis] = slice(None)
+    pres = pres[slices]
+    pres = np.broadcast_to(pres, temperature.shape) * pres.units
+
+    # Sort input data
+    sort_pres = np.argsort(pres.m, axis=axis)
+    sort_pres = np.swapaxes(np.swapaxes(sort_pres, 0, axis)[::-1], 0, axis)
+    sorter = broadcast_indices(pres, sort_pres, ndim, axis)
+    levs = pres[sorter]
+    theta_levels = np.asanyarray(theta_levels.to('kelvin')).reshape(-1)
+    sort_isentlevs = np.argsort(theta_levels)
+    tmpk = temperature[sorter]
+    isentlevels = theta_levels[sort_isentlevs]
+
+    # Make the desired isentropic levels the same shape as temperature
+    isentlevs_nd = isentlevels
+    isentlevs_nd = isentlevs_nd[slices]
+    shape = list(temperature.shape)
+    shape[axis] = isentlevels.size
+    isentlevs_nd = np.broadcast_to(isentlevs_nd, shape)
+
     # exponent to Poisson's Equation, which is imported above
-    ka = kappa * 1000 * units('g/kg')
-    # Assumes temp in K and pres in hPa
-    thtalevs = potential_temperature(levs * units.hPa, tmpk * units.K)
-    ithtalevs = thtalevs.magnitude
-    isentprs3 = np.empty((tmpk.shape[0], isentlevs.size, tmpk.shape[2], tmpk.shape[3]))
-    pk = np.log(lev)
-    pok = 1000.**(ka)
-    for tlev in range(isentlevs.size):
-        for i in range(tmpk.shape[3]):
-            for j in range(tmpk.shape[2]):
-                test = np.where(np.array(thtalevs[0, :, j, i]) >= float(isentlevs[tlev]))
-                minv = np.min(test[0]) - 1
-                if (minv > 0):
-                    # Implementation of GEMPAK routine for computing pressure of a theta level:
-                    # The method solves an implicit equation derived by combining the      *
-                    # definition of potential temperature and the assumption that tem-     *
-                    # perature varies linearly with ln (p).  Newton iteration is used to   *
-                    # solve for ln (p). Code from Kevin Goebbert.
-                    a = (tmpk[0, minv + 1, j, i] - tmpk[0, minv, j, i]) / (pk[minv + 1] -
-                                                                           pk[minv])
-                    b = tmpk[0, minv + 1, j, i] - a * pk[minv + 1]
-                    if (ithtalevs[0, minv + 1, j, i] != ithtalevs[0, minv, j, i]):
-                        rm = (isentlevs[tlev] - ithtalevs[0, minv, j, i]) / (ithtalevs
-                                                                             [0, minv + 1, j,
-                                                                              i] - ithtalevs
-                                                                             [0, minv, j, i])
-                    else:
-                        rm = 0.5
-                    pk1 = pk[minv] + rm * (pk[minv + 1] - pk[minv])
+    ka = kappa.to('dimensionless').m
 
-                    pk2 = so.fixed_point(_isen_iter, pk1, args=(isentlevs[tlev], ka, a, b, pok),
-                        xtol=eps, maxiter=max_iters, method='del2')
-                    isentprs3[0, tlev, j, i] = np.exp(pk2)
-                else:
-                    isentprs3[0, tlev, j, i] = 'nan'
-    return isentprs3
+    # calculate theta for each point
+    pres_theta = potential_temperature(levs, tmpk)
+
+    # Raise error if input theta level is larger than pres_theta max
+    if np.max(pres_theta.m) < np.max(theta_levels):
+        raise ValueError('Input theta level out of data bounds')
+
+    # Find log of pressure to implement assumption of linear temperature dependence on
+    # ln(p)
+    log_p = np.log(levs.m)
+
+    # Calculations for interpolation routine
+    pok = P0 ** ka
+
+    # index values for each point for the pressure level nearest to the desired theta level
+    minv = np.apply_along_axis(np.searchsorted, axis, pres_theta.m, theta_levels)
+
+    # Create index values for broadcasting arrays
+    above = broadcast_indices(tmpk, minv, ndim, axis)
+    below = broadcast_indices(tmpk, minv - 1, ndim, axis)
+
+    # calculate constants for the interpolation
+    a = (tmpk.m[above] - tmpk.m[below]) / (log_p[above] - log_p[below])
+    b = tmpk.m[above] - a * log_p[above]
+
+    # calculate first guess for interpolation
+    first_guess = 0.5 * (log_p[above] + log_p[below])
+
+    # iterative interpolation using scipy.optimize.fixed_point and _isen_iter defined above
+    log_p_solved = so.fixed_point(_isen_iter, first_guess, args=(isentlevs_nd, ka, a, b,
+                                                                 pok.m),
+                                  xtol=eps, maxiter=max_iters)
+
+    # get back pressure and assign nan for values with pressure greater than 1000 hPa
+    isentprs = np.exp(log_p_solved)
+    isentprs[isentprs > np.max(pressure.m)] = np.nan
+
+    # create list for storing output data
+    ret = []
+    ret.append(isentprs * units.hPa)
+
+    # if tmpk_out = true, calculate temperature and output as last item in list
+    if tmpk_out:
+        ret.append((isentlevs_nd / ((P0.m / isentprs) ** ka)) * units.kelvin)
+
+    # check to see if any additional arguments were given, if so, interpolate to
+    # new isentropic levels
+    try:
+        args[0]
+    except IndexError:
+        return ret
+    else:
+        # do an interpolation for each additional argument
+        for arr in args:
+            var = arr[sorter]
+            # interpolate to isentropic levels and add to temporary output array
+            arg_out = interp(isentlevels, pres_theta.m, var, axis=axis)
+            ret.append(arg_out)
+
+    # output values as a list
+    return ret


### PR DESCRIPTION
Adds calculation for isentropic surfaces from isobaric surfaces.  Assumes linear dependence of variables with respect to ln(p). Requires input data in three dimensions with units attached. Pressure on isentropic surfaces is calculated by determination of a first guess and iteration with spicy fixed point optimization. Other fields are linearly interpolated with numpy. Outputs a tuple of all data. Not sure how to write a test for this one.

Fixes #294.