### PR TITLE
Fix tests on windows

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,5 +30,4 @@ dependencies:
   - pyproj
   - cartopy
   - pip
-  - freetype=2.6
   - doc8


### PR DESCRIPTION
Looks like conda packages updating to numpy 1.13 somehow broke us on Windows.