### PR TITLE
Convert and Drop Units

### DIFF
--- a/metpy/calc/tests/test_tools.py
+++ b/metpy/calc/tests/test_tools.py
@@ -7,7 +7,8 @@ import numpy as np
 import numpy.ma as ma
 import pytest
 
-from metpy.calc import (find_intersections, interpolate_nans, log_interp,
+from metpy.calc import (convert_and_drop_units, find_intersections, interpolate_nans,
+                        log_interp,
                         nearest_intersection_idx, reduce_point_density, resample_nn_1d)
 from metpy.calc.tools import _next_non_masked_element, delete_masked_points
 from metpy.testing import assert_array_almost_equal, assert_array_equal
@@ -187,3 +188,37 @@ def test_log_interp_units():
     y_interp_truth = np.array([20.0343863828, 24.6395565688, 29.2447267548]) * units.degC
     y_interp = log_interp(x_interp, x_log, y_log)
     assert_array_almost_equal(y_interp, y_interp_truth, 7)
+
+
+def test_convert_and_drop_units():
+    """Test of conversion to common units and drop units."""
+    x = 100000. * units.Pa
+    y = 1000. * units.hPa
+    z = 1000. * units.hPa
+    x1, y1, z1, = convert_and_drop_units(x, y, z, units='hPa')
+    truth = 1000.
+    assert_array_almost_equal(x1, truth, 7)
+    assert_array_almost_equal(y1, truth, 7)
+    assert_array_almost_equal(z1, truth, 7)
+
+
+def test_convert_and_drop_units_none_specified():
+    """Test of conversion to common units and drop units with no unit specified."""
+    x = 100000. * units.Pa
+    y = 1000. * units.hPa
+    z = 1000. * units.hPa
+    x1, y1, z1, = convert_and_drop_units(x, y, z)
+    truth = 100000.
+    assert_array_almost_equal(x1, truth, 7)
+    assert_array_almost_equal(y1, truth, 7)
+    assert_array_almost_equal(z1, truth, 7)
+
+
+def test_convert_and_drop_units_no_units():
+    """Test of conversion to common units and drop units with no units attached."""
+    x = 100000.
+    y = 100000.
+    x1, y1 = convert_and_drop_units(x, y)
+    truth = 100000.
+    assert_array_almost_equal(x1, truth, 7)
+    assert_array_almost_equal(y1, truth, 7)

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -330,3 +330,50 @@ def log_interp(x, xp, fp, **kwargs):
         interpolated_vals = interpolated_vals * fp.units
 
     return interpolated_vals
+
+
+@exporter.export
+def convert_and_drop_units(x, *args, **kwargs):
+    r"""Convert to common units and drop units.
+
+    Check if multiple inputs has units and convert to common units.
+
+    Parameters
+    ----------
+    x : array-like
+        Input value to check.
+
+    args : array-like
+        Additional values to check
+
+    units : string, optional
+        Desired output units. If None, will convert to the units of x.
+
+    Returns
+    -------
+    array-like
+        The magnitude of the input values converted to common units
+
+    """
+    # Check for desired unit to convert to.
+    unit = kwargs.pop('units', None)
+    ret = []
+    if (unit is not None) and hasattr(x, 'units'):
+        x = x.to(unit)
+        ret.append(x.m)
+        for arr in args:
+            arr = arr.to(unit)
+            arr = arr.m
+            ret.append(arr)
+
+    elif hasattr(x, 'units'):
+        ret.append(x.m)
+        for arr in args:
+            arr = arr.to(x.units)
+            arr = arr.m
+            ret.append(arr)
+    else:
+        ret.append(x)
+        [ret.append(arr) for arr in args]
+
+    return ret


### PR DESCRIPTION
In working on #468 and #454 as well as others, it has become apparent that there is a need for a function that will convert inputs to common units and then remove units, returning just the magnitudes. Based on comments from @dopplershift in #468 , this is a stab at solving that problem with the hope that it can shorten some existing code doing the same operations in other functions.