### PR TITLE
Versioned docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -157,6 +157,13 @@ deploy:
       all_branches: true
       python: 3.6
       condition: '$TASK == "docs"'
+  - provider: script
+    script: ci/deploy_docs.sh
+    skip_cleanup: true
+    on:
+      tags: true
+      python: 3.6
+      condition: '$TASK == "docs"'
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ env:
     - EXTRA_INSTALLS="test,cdm"
     - MPLLOCALFREETYPE="1"
     - TEST_OUTPUT_CONTROL="-s"
+    - GH_PAGES_DIR="$HOME/gh-pages"
   matrix:
     - TASK="coverage"
     - TASK="docs"
@@ -132,7 +133,6 @@ after_script:
 before_deploy:
   # Remove unused, unminified javascript from sphinx
   - if [[ $TASK == "docs" ]]; then
-      touch docs/build/html/.nojekyll;
       rm -f docs/build/html/_static/jquery-*.js;
       rm -f docs/build/html/_static/underscore-*.js;
     fi
@@ -149,13 +149,11 @@ deploy:
       python: 3.6
       condition: '$TASK != "docs"'
       tags: true
-  - provider: pages
+  - provider: script
+    script: ci/deploy_docs.sh
     skip_cleanup: true
-    github_token: $GH_TOKEN
-    local_dir: docs/build/html
-    target_branch: gh-pages
     on:
-      branch: master
+      all_branches: true
       python: 3.6
       condition: '$TASK == "docs"'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,6 +135,7 @@ before_deploy:
   - if [[ $TASK == "docs" ]]; then
       rm -f docs/build/html/_static/jquery-*.js;
       rm -f docs/build/html/_static/underscore-*.js;
+      rm -f docs/build/html/.buildinfo;
     fi
 
 deploy:

--- a/ci/deploy_docs.sh
+++ b/ci/deploy_docs.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e # exit with nonzero exit code if anything fails
+
+# Clone *this* git repo, but only the gh-pages branch. We redirect any output to
+# /dev/null to hide any sensitive credential data that might otherwise be exposed.
+if [[ ! -d $GH_PAGES_DIR ]]; then
+    git clone -q -b gh-pages --single-branch https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git $GH_PAGES_DIR 2>&1 >/dev/null
+fi
+cd $GH_PAGES_DIR
+
+# inside this git repo we'll pretend to be a new user
+git config user.name "Travis CI"
+git config user.email "travis@nobody.org"
+
+if [[ "${TRAVIS_TAG}" != "" ]]; then
+    export VERSION=${TRAVIS_TAG%.*}
+else
+    export VERSION=dev
+fi
+
+# The first and only commit to this new Git repo contains all the
+# files present with the commit message "Deploy to GitHub Pages".
+rm -rf ${VERSION}
+cp -R ${TRAVIS_BUILD_DIR}/docs/build/html/ ${VERSION}/
+touch .nojekyll
+if [[ "${VERSION}" != "dev" ]]; then
+    ln -shf ${VERSION} latest
+fi
+
+git add -A .
+git commit -m "Deploy ${VERSION} to GitHub Pages"
+
+# Push up to gh-pages
+echo Pushing...
+git push --quiet origin gh-pages

--- a/ci/deploy_docs.sh
+++ b/ci/deploy_docs.sh
@@ -28,8 +28,12 @@ if [[ "${VERSION}" != "dev" ]]; then
 fi
 
 git add -A .
-git commit -m "Deploy ${VERSION} to GitHub Pages"
+if [[ "${VERSION}" == "dev" && `git log -1 --format='%s'` == *"dev"* ]]; then
+    git commit --amend --reset-author --no-edit
+else
+    git commit -m "Deploy ${VERSION} to GitHub Pages"
+fi
 
 # Push up to gh-pages
 echo Pushing...
-git push --quiet origin gh-pages
+git push --force --quiet origin gh-pages

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -61,14 +61,6 @@ html:	autogen
 	@echo
 	@echo "Build finished. The HTML pages are in $(HTMLBUILDDIR)."
 
-deployhtml:
-	@echo Deploying to gh-pages
-	@touch $(HTMLBUILDDIR)/.nojekyll
-	@git init -q $(HTMLBUILDDIR)
-	@cd $(HTMLBUILDDIR) && git add -A . && GIT_COMMITTER_NAME="sphinx" GIT_COMMITTER_EMAIL="deploy@sphinx.none" git commit -q -m "Deploy to GHPages." --author "Sphinx <deploy@sphinx.none>"
-	@cd $(HTMLBUILDDIR) && git push --quiet --force $(GITREMOTE) master:gh-pages 2>&1 >deploy.log
-	@rm -rf $(HTMLBUILDDIR)/.git
-
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -164,7 +164,7 @@ def setup(app):
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
+html_theme_options = {'canonical_url': 'https://unidata.github.io/MetPy/latest/'}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []


### PR DESCRIPTION
Fixes #284

Ended up not using doctr, because that wouldn't let me update a simlink to the latest easily. I've already updated the gh-pages branch with multiple versions. This doesn't allow for selecting between versions on the web page, but it does ensure that the default docs people see are the latest *released* docs. We also have the current dev snapshot of the docs at https://unidata.github.io/MetPy/dev/