### PR TITLE
BUG: Fix get_layer with float32 data

### DIFF
--- a/metpy/calc/tests/test_tools.py
+++ b/metpy/calc/tests/test_tools.py
@@ -268,6 +268,23 @@ def test_get_bound_height_out_of_range():
         _get_bound_pressure_height(p, 100 * units.meter, heights=h)
 
 
+def test_get_layer_float32():
+    """Test that get_layer works properly with float32 data."""
+    p = np.asarray([940.85083008, 923.78851318, 911.42022705, 896.07220459,
+                    876.89404297, 781.63330078], np.float32) * units('hPa')
+    hgt = np.asarray([563.671875, 700.93817139, 806.88098145, 938.51745605,
+                      1105.25854492, 2075.04443359], dtype=np.float32) * units.meter
+
+    true_p_layer = np.asarray([940.85083008, 923.78851318, 911.42022705, 896.07220459,
+                               876.89404297, 831.86472819], np.float32) * units('hPa')
+    true_hgt_layer = np.asarray([563.671875, 700.93817139, 806.88098145, 938.51745605,
+                                 1105.25854492, 1549.8079], dtype=np.float32) * units.meter
+
+    p_layer, hgt_layer = get_layer(p, hgt, heights=hgt, depth=1000. * units.meter)
+    assert_array_almost_equal(p_layer, true_p_layer, 4)
+    assert_array_almost_equal(hgt_layer, true_hgt_layer, 4)
+
+
 def test_get_layer_ragged_data():
     """Tests that error is raised for unequal length pressure and data arrays."""
     p = np.arange(10) * units.hPa

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -349,8 +349,12 @@ def _get_bound_pressure_height(pressure, bound, heights=None, interpolate=True):
             else:  # Bound is not in the data
                 if interpolate:
                     bound_height = bound
-                    bound_pressure = np.interp(np.array(bound.m), heights,
-                                               pressure) * pressure.units
+
+                    # Need to cast back to the input type since interp (up to at least numpy
+                    # 1.13 always returns float64. This can cause upstream users problems,
+                    # resulting in something like np.append() to upcast.
+                    bound_pressure = np.interp(np.atleast_1d(bound), heights,
+                                               pressure).astype(bound.dtype) * pressure.units
                 else:
                     idx = (np.abs(heights - bound)).argmin()
                     bound_pressure = pressure[idx]


### PR DESCRIPTION
It turns out the numpy.interp() always returns float64, no matter the
input (except for complex). This causes problems when we try to append
the result of the interpolation to our float32 data, causing the array
to upcast. This in turn causes, depending on the truncation, checks to
consider the lowest layer to seem like it's outside the bounds of the
data.