### PR TITLE
Fixing minor LFC bug

### DIFF
--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -224,6 +224,18 @@ def test_lfc_equals_lcl():
     assert_almost_equal(l[1], 15.8714 * units.celsius, 2)
 
 
+def test_lfc_sfc_precision():
+    """Test LFC when there are precision issues with the parcel path."""
+    levels = np.array([839., 819.4, 816., 807., 790.7, 763., 736.2,
+                       722., 710.1, 700.]) * units.mbar
+    temperatures = np.array([20.6, 22.3, 22.6, 22.2, 20.9, 18.7, 16.4,
+                             15.2, 13.9, 12.8]) * units.celsius
+    dewpoints = np.array([10.6, 8., 7.6, 6.2, 5.7, 4.7, 3.7, 3.2, 3., 2.8]) * units.celsius
+    l = lfc(levels, temperatures, dewpoints)
+    assert assert_nan(l[0], levels.units)
+    assert assert_nan(l[1], temperatures.units)
+
+
 def test_saturation_mixing_ratio():
     """Test saturation mixing ratio calculation."""
     p = 999. * units.mbar

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -233,13 +233,12 @@ def lfc(pressure, temperature, dewpt):
                               direction='increasing')
     # Two possible cases here: LFC = LCL, or LFC doesn't exist
     if len(x) == 0:
-        if np.any(_less_or_close(ideal_profile[1:], temperature[1:])==False):
-            # LFC = LCL
+        if np.all(_less_or_close(ideal_profile, temperature)):
+            # LFC doesn't exist
+            return np.nan * pressure.units, np.nan * temperature.units
+        else:  # LFC = LCL
             x, y = lcl(pressure[0], temperature[0], dewpt[0])
             return x, y
-        # LFC doesn't exist
-        else:
-            return np.nan * pressure.units, np.nan * temperature.units
     else:
         return x[0], y[0]
 

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -233,7 +233,7 @@ def lfc(pressure, temperature, dewpt):
                               direction='increasing')
     # Two possible cases here: LFC = LCL, or LFC doesn't exist
     if len(x) == 0:
-        if np.any(ideal_profile > temperature):
+        if np.any(_less_or_close(ideal_profile[1:], temperature[1:])==False):
             # LFC = LCL
             x, y = lcl(pressure[0], temperature[0], dewpt[0])
             return x, y


### PR DESCRIPTION
Adding a fix so that, in the case where the parcel path never intersects the profile, the surface data point is ignored in determining whether the parcel path is ever warmer than the environment (and thus, whether the LFC exists). Currently, in some cases the parcel is identified as warmer at the surface than the environment, resulting in a spurious LFC being identified at the same pressure as the LCL.