### PR TITLE
SBCAPE

### DIFF
--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -17,7 +17,8 @@ from metpy.calc import (cape_cin, density, dewpoint, dewpoint_rh, dry_lapse, el,
                         relative_humidity_from_specific_humidity,
                         relative_humidity_wet_psychrometric,
                         saturation_mixing_ratio,
-                        saturation_vapor_pressure, vapor_pressure,
+                        saturation_vapor_pressure,
+                        surface_based_cape_cin, vapor_pressure,
                         virtual_potential_temperature, virtual_temperature)
 
 from metpy.calc.thermo import _find_append_zero_crossings
@@ -638,3 +639,13 @@ def test_isentropic_pressure_4d():
     assert_almost_equal(isentprs[0][:, 1, :], trueprs2, 3)
     assert_almost_equal(isentprs[0][:, 2, :], trueprs3, 3)
     assert_almost_equal(isentprs[1][:, 1, ], truerh, 3)
+
+
+def test_surface_based_cape_cin():
+    """Tests the surface-based CAPE and CIN calculation."""
+    p = np.array([959., 779.2, 751.3, 724.3, 700., 269.]) * units.mbar
+    temperature = np.array([22.2, 14.6, 12., 9.4, 7., -38.]) * units.celsius
+    dewpoint = np.array([19., -11.2, -10.8, -10.4, -10., -53.2]) * units.celsius
+    cape, cin = surface_based_cape_cin(p, temperature, dewpoint)
+    assert_almost_equal(cape, 58.0368212 * units('joule / kilogram'), 6)
+    assert_almost_equal(cin, -89.8073512 * units('joule / kilogram'), 6)

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -1042,7 +1042,7 @@ def most_unstable_parcel(pressure, temperature, dewpoint, heights=None,
     """
     Determine the most unstable parcel in a layer.
 
-    Determines the most unstable parcle of air by calculating the equivalent
+    Determines the most unstable parcel of air by calculating the equivalent
     potential temperature and finding its maximum in the specified layer.
 
     Parameters
@@ -1237,3 +1237,40 @@ def isentropic_interpolation(theta_levels, pressure, temperature, *args, **kwarg
 
     # output values as a list
     return ret
+
+
+@exporter.export
+@check_units('[pressure]', '[temperature]', '[temperature]')
+def surface_based_cape_cin(pressure, temperature, dewpoint):
+    r"""Calculate surface-based CAPE and CIN.
+
+    Calculate the convective available potential energy (CAPE) and convective inhibition (CIN)
+    of a given upper air profile for a surface-based parcel. CIN is integrated
+    between the surface and LFC, CAPE is integrated between the LFC and EL (or top of
+    sounding). Intersection points of the measured temperature profile and parcel profile are
+    linearly interpolated.
+
+    Parameters
+    ----------
+    pressure : `pint.Quantity`
+        Atmospheric pressure profile. The first entry should be the starting
+        (surface) observation.
+    temperature : `pint.Quantity`
+        Temperature profile
+    dewpoint : `pint.Quantity`
+        Dewpoint profile
+
+    Returns
+    -------
+    `pint.Quantity`
+        Surface based Convective Available Potential Energy (CAPE).
+    `pint.Quantity`
+        Surface based Convective INhibition (CIN).
+
+    See Also
+    --------
+    cape_cin, parcel_profile
+
+    """
+    profile = parcel_profile(pressure, temperature[0], dewpoint[0])
+    return cape_cin(pressure, temperature, dewpoint, profile)


### PR DESCRIPTION
This adds a helper function for the calculation of surface-based CAPE. Due to issue #488, the profile is converted to degC before calling cape_cin. Once this issue has been resolved, scape_sbcin can be changed to remove unit conversions. 