### PR TITLE
fix to erroneous/misleading theta-e formula

### DIFF
--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -529,18 +529,19 @@ def saturation_mixing_ratio(tot_press, temperature):
 
 @exporter.export
 @check_units('[pressure]', '[temperature]')
-def equivalent_potential_temperature(pressure, temperature):
+def equivalent_potential_temperature(pressure_LCL, temperature_LCL):
     r"""Calculate equivalent potential temperature.
 
-    This calculation must be given an air parcel's pressure and temperature.
+    This calculation must be given an air parcel's pressure and temperature
+    ** at its LCL **, not its ambient pressure and temperature.
     The implementation uses the formula outlined in [Hobbs1977]_ pg.78-79.
 
     Parameters
     ----------
     pressure: `pint.Quantity`
-        Total atmospheric pressure
+        atmospheric pressure **at the parcel's LCL**
     temperature: `pint.Quantity`
-        The temperature
+        The temperature **at the parcel's LCL**
 
     Returns
     -------
@@ -552,9 +553,9 @@ def equivalent_potential_temperature(pressure, temperature):
     .. math:: \Theta_e = \Theta e^\frac{L_v r_s}{C_{pd} T}
 
     """
-    pottemp = potential_temperature(pressure, temperature)
-    smixr = saturation_mixing_ratio(pressure, temperature)
-    return pottemp * np.exp(Lv * smixr / (Cp_d * temperature))
+    pottemp = potential_temperature(pressure_LCL, temperature_LCL)
+    smixr = saturation_mixing_ratio(pressure_LCL, temperature_LCL)
+    return pottemp_LCL * np.exp(Lv * smixr / (Cp_d * temperature_LCL))
 
 
 @exporter.export


### PR DESCRIPTION
The formula as it stood is quite approximate, and missed a crucial aspect: theta-e depends on moisture content!
The formula as it stands involves T,p at the LCL, not just T,p. I clarified that. 

But it would be better to add a more accurate theta-e formula to thermo.py, like the Bolton (1980) formula for numerical accuracy, it can be found at 
https://en.wikipedia.org/wiki/Equivalent_potential_temperature