### PR TITLE
Add unit verification to find_intersections

### DIFF
--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -70,6 +70,7 @@ def nearest_intersection_idx(a, b):
 
 
 @exporter.export
+@units.wraps(('=A', '=B'), ('=A', '=B', '=B'))
 def find_intersections(x, a, b, direction='all'):
     """Calculate the best estimate of intersection.
 


### PR DESCRIPTION
Makes sure that a mix of units cannot pass through `find_intersections` and result in confusing behavior. Closes #466 