### PR TITLE
MNT: Bump numpy requirement to 1.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
   include:
     - python: 2.7
       env:
-        - VERSIONS="numpy==1.9.1 matplotlib==1.4.0 scipy==0.14.0 pint==0.8"
+        - VERSIONS="numpy==1.10.0 matplotlib==1.4.0 scipy==0.14.0 pint==0.8"
         - TASK="coverage"
         - TEST_OUTPUT_CONTROL=""
     - python: 3.4

--- a/docs/installguide.rst
+++ b/docs/installguide.rst
@@ -5,7 +5,7 @@ Installation Guide
 ------------
 Requirements
 ------------
-MetPy supports Python 2.7 as well as Python >= 3.4. Python 3.5 is the recommended version.
+MetPy supports Python 2.7 as well as Python >= 3.4. Python 3.6 is the recommended version.
 
 MetPy requires the following packages:
   - NumPy >= 1.10.0

--- a/docs/installguide.rst
+++ b/docs/installguide.rst
@@ -8,7 +8,7 @@ Requirements
 MetPy supports Python 2.7 as well as Python >= 3.4. Python 3.5 is the recommended version.
 
 MetPy requires the following packages:
-  - NumPy >= 1.9.1
+  - NumPy >= 1.10.0
   - SciPy >= 0.14.0
   - Matplotlib >= 1.4.0
   - pint >= 0.8

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import versioneer
 ver = versioneer.get_version()
 
 # Need to conditionally add enum support for older Python
-dependencies = ['matplotlib>=1.4', 'numpy>=1.9.1', 'scipy>=0.14', 'pint>=0.8']
+dependencies = ['matplotlib>=1.4', 'numpy>=1.10.0', 'scipy>=0.14', 'pint>=0.8']
 if sys.version_info < (3, 4):
     dependencies.append('enum34')
 


### PR DESCRIPTION
This gives us a few more features without needing to backport. It's been
out almost two years at this point...