### PR TITLE
ENH: Add link to MetPy poster and repo for SciPy 2017

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,8 @@ __ https://github.com/Unidata/MetPy/issues
 Media
 -----
 
+* `SciPy 2017 poster`_ and `repository <https://github.com/jrleeman/CAPE-SciPy-2017>`_
+  about reproducing a classic CAPE paper with MetPy.
 * `SciPy 2017 talk`_ and `slides
   <http://nbviewer.jupyter.org/format/slides/github/dopplershift/
   Talks/blob/master/SciPy2017/MetPy%20Units.ipynb>`_
@@ -81,6 +83,7 @@ Media
 .. _`SciPy 2016`: https://youtu.be/moLKGjbXvgE
 .. _`Episode 100 of Podcast.__init__`: https://www.podcastinit.com/episode-100-metpy-with-ryan-may-sean-arms-and-john-leeman/
 .. _`SciPy 2017 talk`: https://youtu.be/qCo9bkT9sow
+.. _`SciPy 2017 poster`: https://github.com/jrleeman/CAPE-SciPy-2017/blob/master/Poster/SciPy_Poster_2017.pdf
 
 -------
 License


### PR DESCRIPTION
Add a link to the poster and repo.