### PR TITLE
adds frontogenesis calculation and test

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -11,6 +11,10 @@ References
            doi:`10.1175/1520-0450(1964)003%3C0396:ATFMDI%3E2.0.CO;2
            <https://doi.org/10.1175/1520-0450(1964)003%3C0396:ATFMDI%3E2.0.CO;2>`_.
 
+.. [Bluestein1993] Bluestein, H. B., 1993: *Observations and Theory of Weather Systems.
+           Vol. 2, Synoptic-Dynamic Meteorology in Midlatitudes*. Oxford University Press,
+           608 pp.
+
 .. [Bolton1980] Bolton, D., 1980: The computation of equivalent potential
            temperature. *Mon. Wea. Rev.*, **108**, 1046-1053,
            doi:`10.1175/1520-0493(1980)108%3C1046:TCOEPT%3E2.0.CO;2
@@ -86,4 +90,3 @@ References
 
 .. [WMO8-2014] WMO, 2014: *Guide to Meteorological Instruments and Methods of Observation*.
            `WMO No.8 <https://library.wmo.int/opac/doc_num.php?explnum_id=3121>`_.
-

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -6,7 +6,7 @@
 import numpy as np
 import pytest
 
-from metpy.calc import (advection, convergence_vorticity, geostrophic_wind,
+from metpy.calc import (advection, convergence_vorticity, frontogenesis, geostrophic_wind,
                         get_wind_components, h_convergence,
                         montgomery_streamfunction, shearing_deformation,
                         shearing_stretching_deformation, storm_relative_helicity,
@@ -224,9 +224,28 @@ def test_total_deformation_asym():
     assert_almost_equal(tdef, true_tdef)
 
     # Now try for xy ordered
-    true_tdef = total_deformation(u.T, v.T, 1 * units.meters, 2 * units.meters,
-                                  dim_order='xy')
+    tdef = total_deformation(u.T, v.T, 1 * units.meters, 2 * units.meters,
+                             dim_order='xy')
     assert_almost_equal(tdef, true_tdef.T)
+
+
+def test_frontogenesis_asym():
+    """Test vorticity and convergence calculation with a complicated field."""
+    u = np.array([[2, 4, 8], [0, 2, 2], [4, 6, 8]]) * units('m/s')
+    v = np.array([[6, 4, 8], [2, 6, 0], [2, 2, 6]]) * units('m/s')
+    theta = np.array([[303, 295, 305], [308, 310, 312], [299, 293, 289]]) * units('K')
+    fronto = frontogenesis(theta, u, v, 1 * units.meters, 2 * units.meters,
+                           dim_order='yx')
+    true_fronto = np.array([[-20.93890452, -7.83070042, -36.43293256],
+                            [0.89442719, -2.12218672, -8.94427191],
+                            [-16.8, -7.65600391, -61.65921479]]
+                           ) * units.K / units.meter / units.sec
+    assert_almost_equal(fronto, true_fronto)
+
+    # Now try for xy ordered
+    fronto = frontogenesis(theta.T, u.T, v.T, 1 * units.meters, 2 * units.meters,
+                           dim_order='xy')
+    assert_almost_equal(fronto, true_fronto.T)
 
 
 def test_advection_uniform():


### PR DESCRIPTION
This PR adds a 2D frontogenesis calculation to the MetPy suite with a test. Don't know if the equation in the docstring will render correctly. There was also a small error in the test for total deformation that I corrected. It was testing something in a backwards way, so now made it conform to the other deformation style tests.