### PR TITLE
Dewpoint from RH input validation.

### DIFF
--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -137,6 +137,18 @@ def test_scalar_dewpoint_rh():
     assert_almost_equal(td, 26. * units.degF, 0)
 
 
+def test_percent_dewpoint_rh():
+    """Test dewpoint_rh with rh in percent."""
+    td = dewpoint_rh(10.6 * units.degC, 37 * units.percent)
+    assert_almost_equal(td, 26. * units.degF, 0)
+
+
+def test_warning_dewpoint_rh():
+    """Test that warning is raised for >120% RH."""
+    with pytest.warns(UserWarning):
+        dewpoint_rh(10.6 * units.degC, 50)
+
+
 def test_dewpoint():
     """Test dewpoint calculation."""
     assert_almost_equal(dewpoint(6.112 * units.mbar), 0. * units.degC, 2)

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -5,12 +5,14 @@
 
 from __future__ import division
 
+import warnings
+
 import numpy as np
 import scipy.integrate as si
 import scipy.optimize as so
 
-from .tools import _greater_or_close, _less_or_close, broadcast_indices, find_intersections, \
-    get_layer, interp
+from .tools import (_greater_or_close, _less_or_close, broadcast_indices, find_intersections,
+                    get_layer, interp)
 from ..constants import Cp_d, epsilon, kappa, Lv, P0, Rd
 from ..package_tools import Exporter
 from ..units import atleast_1d, check_units, concatenate, units
@@ -423,7 +425,7 @@ def dewpoint_rh(temperature, rh):
     temperature : `pint.Quantity`
         Air temperature
     rh : `pint.Quantity`
-        Relative humidity expressed as a ratio in the range [0, 1]
+        Relative humidity expressed as a ratio in the range (0, 1]
 
     Returns
     -------
@@ -435,6 +437,8 @@ def dewpoint_rh(temperature, rh):
     dewpoint, saturation_vapor_pressure
 
     """
+    if np.any(rh > 1.2):
+        warnings.warn('Relative humidity >120%, ensure proper units.')
     return dewpoint(rh * saturation_vapor_pressure(temperature))
 
 


### PR DESCRIPTION
Add warning if relative humidity in dewpoint calculation is >120%. Does not address the divide by zero case if 0% RH is used. Is that an obvious enough message as is? Closes #424 