### PR TITLE
Wind direction warning

### DIFF
--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -12,6 +12,8 @@ These include:
 
 from __future__ import division
 
+import warnings
+
 import numpy as np
 
 from ..constants import g, omega, Rd
@@ -106,6 +108,12 @@ def get_wind_components(speed, wdir):
      <Quantity(7.071067811865477, 'meter / second')>)
 
     """
+    try:
+        wdir = wdir.to('radians').m
+    except AttributeError:
+        pass
+    if np.greater(np.nanmax(wdir), 4 * np.pi):
+        warnings.warn('Wind direction >4Pi. Ensure proper units are given.')
     u = -speed * np.sin(wdir)
     v = -speed * np.cos(wdir)
     return u, v

--- a/metpy/calc/tests/test_basic.py
+++ b/metpy/calc/tests/test_basic.py
@@ -4,6 +4,7 @@
 """Test the `basic` module."""
 
 import numpy as np
+import pytest
 
 from metpy.calc import (add_height_to_pressure, add_pressure_to_height, coriolis_parameter,
                         get_wind_components, get_wind_dir, get_wind_speed, heat_index,
@@ -278,3 +279,9 @@ def test_sigma_to_pressure():
     expected = np.arange(0., 1100., 100.) * units.hPa
     pressure = sigma_to_pressure(sigma, surface_pressure, model_top_pressure)
     assert_array_almost_equal(pressure, expected, 5)
+
+
+def test_warning_dir():
+    """Test that warning is raised wind direction > 2Pi."""
+    with pytest.warns(UserWarning):
+        get_wind_components(3. * units('m/s'), 270)


### PR DESCRIPTION
Warn if the given wind direction is greater than 2Pi, indicating that the user is probably passing values in degrees without units attached. This is particularly thorny as we have to work with lists, arrays, and individual values with and without units. I don't love this implementation, but it is the least checking and if/else blocks. There must be a better way.... right? Maybe this gets ripped out into a helper in tools? Closes #547 