### PR TITLE
Update GINI Example with new color table values

### DIFF
--- a/examples/formats/GINI_Water_Vapor.py
+++ b/examples/formats/GINI_Water_Vapor.py
@@ -48,7 +48,8 @@ proj = ccrs.LambertConformal(central_longitude=proj_var.longitude_of_central_mer
 # Plot the image
 fig = plt.figure(figsize=(10, 12))
 ax = fig.add_subplot(1, 1, 1, projection=proj)
-wv_norm, wv_cmap = ctables.registry.get_with_steps('WVCIMSS', 0, 1)
+wv_norm, wv_cmap = ctables.registry.get_with_range('WVCIMSS', 100, 260)
+wv_cmap.set_under('k')
 im = ax.imshow(dat[:], cmap=wv_cmap, norm=wv_norm, zorder=0,
                extent=ds.img_extent, origin='upper')
 ax.coastlines(resolution='50m', zorder=2, color='black')


### PR DESCRIPTION
The old example didn't plot properly, this updates the norm using `get_with_range` and sets the value below to black. Closes #560 