### PR TITLE
Assign depth kwarg default value if it is None in `get_layer`

### DIFF
--- a/metpy/calc/tests/test_indices.py
+++ b/metpy/calc/tests/test_indices.py
@@ -77,6 +77,17 @@ def test_bulk_shear():
     assert_almost_equal(v.to('knots'), truth[1], 8)
 
 
+def test_bulk_shear_no_depth():
+    """Test bulk shear with observed sounding and no depth given. Issue #568."""
+    with UseSampleData():
+        data = get_upper_air_data(datetime(2016, 5, 22, 0), 'DDC', source='wyoming')
+    u, v = bulk_shear(data.variables['pressure'][:], data.variables['u_wind'][:],
+                      data.variables['v_wind'][:], heights=data.variables['height'][:])
+    truth = [20.225018939, 22.602359692] * units('knots')
+    assert_almost_equal(u.to('knots'), truth[0], 8)
+    assert_almost_equal(v.to('knots'), truth[1], 8)
+
+
 def test_bulk_shear_elevated():
     """Test bulk shear with observed sounding and a base above the surface."""
     with UseSampleData():

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -436,6 +436,10 @@ def get_layer(pressure, *args, **kwargs):
     depth = kwargs.pop('depth', 100 * units.hPa)
     interpolate = kwargs.pop('interpolate', True)
 
+    # If we get the depth kwarg, but it's None, set it to the default as well
+    if depth is None:
+        depth = 100 * units.hPa
+
     # Make sure pressure and datavars are the same length
     for datavar in args:
         if len(pressure) != len(datavar):


### PR DESCRIPTION
What appeared to be an issue in `bulk_shear` was really it passing None as a kwarg to `get_layer` and short circuiting the logic that assigned a default value. Closes #568 