### PR TITLE
Storm Relative Helicity Improvements

### DIFF
--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -9,7 +9,7 @@ import warnings
 
 import numpy as np
 
-from ..calc.tools import get_layer
+from ..calc.tools import get_layer_heights
 from ..cbook import is_string_like, iterable
 from ..constants import Cp_d, g
 from ..package_tools import Exporter
@@ -539,9 +539,9 @@ def montgomery_streamfunction(height, temperature):
 
 
 @exporter.export
-@check_units('[speed]', '[speed]', '[pressure]', '[length]',
-             '[length]', '[length]', '[speed]', '[speed]')
-def storm_relative_helicity(u, v, p, heights, top, bottom=0 * units('meter'),
+@check_units('[speed]', '[speed]', '[length]', '[length]', '[length]',
+             '[speed]', '[speed]')
+def storm_relative_helicity(u, v, heights, depth, bottom=0 * units.m,
                             storm_u=0 * units('m/s'), storm_v=0 * units('m/s')):
     # Partially adapted from similar SharpPy code
     r"""Calculate storm relative helicity.
@@ -561,18 +561,16 @@ def storm_relative_helicity(u, v, p, heights, top, bottom=0 * units('meter'),
         u component winds
     v : array-like
         v component winds
-    p : array-like
-        atmospheric pressure
     heights : array-like
-        atmospheric heights
-    top : number
-        layer top
+        atmospheric heights, will be converted to AGL
+    depth : number
+        depth of the layer
     bottom : number
-        layer bottom (default is surface)
+        height of layer bottom AGL (default is surface)
     storm_u : number
-        u component of storm motion
+        u component of storm motion (default is 0 m/s)
     storm_v : number
-        v component of storm motion
+        v component of storm motion (default is 0 m/s)
 
     Returns
     -------
@@ -580,11 +578,10 @@ def storm_relative_helicity(u, v, p, heights, top, bottom=0 * units('meter'),
         positive, negative, total storm-relative helicity
 
     """
-    _, layer_u, layer_v = get_layer(p, u, v, heights=heights,
-                                    bottom=bottom, depth=top - bottom)
+    _, u, v = get_layer_heights(heights, depth, u, v, with_agl=True, bottom=bottom)
 
-    storm_relative_u = layer_u - storm_u
-    storm_relative_v = layer_v - storm_v
+    storm_relative_u = u - storm_u
+    storm_relative_v = v - storm_v
 
     int_layers = (storm_relative_u[1:] * storm_relative_v[:-1] -
                   storm_relative_u[:-1] * storm_relative_v[1:])

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -398,11 +398,10 @@ def test_storm_relative_helicity_no_storm_motion():
     u = np.array([0, 20, 10, 0]) * units('m/s')
     v = np.array([20, 0, 0, 10]) * units('m/s')
     u = u.to('knots')
-    pressure = np.array([1000, 900, 800, 700]) * units.hPa
     heights = np.array([0, 250, 500, 750]) * units.m
 
-    positive_srh, negative_srh, total_srh = storm_relative_helicity(u, v, pressure, heights,
-                                                                    top=750 * units.meters)
+    positive_srh, negative_srh, total_srh = storm_relative_helicity(u, v, heights,
+                                                                    depth=750 * units.meters)
 
     assert_almost_equal(positive_srh, 400. * units('meter ** 2 / second ** 2 '), 6)
     assert_almost_equal(negative_srh, -100. * units('meter ** 2 / second ** 2 '), 6)
@@ -414,11 +413,28 @@ def test_storm_relative_helicity_storm_motion():
     u = np.array([5, 25, 15, 5]) * units('m/s')
     v = np.array([30, 10, 10, 20]) * units('m/s')
     u = u.to('knots')
-    pressure = np.array([1000, 900, 800, 700]) * units.hPa
     heights = np.array([0, 250, 500, 750]) * units.m
 
-    pos_srh, neg_srh, total_srh = storm_relative_helicity(u, v, pressure, heights,
-                                                          top=750 * units.meters,
+    pos_srh, neg_srh, total_srh = storm_relative_helicity(u, v, heights,
+                                                          depth=750 * units.meters,
+                                                          storm_u=5 * units('m/s'),
+                                                          storm_v=10 * units('m/s'))
+
+    assert_almost_equal(pos_srh, 400. * units('meter ** 2 / second ** 2 '), 6)
+    assert_almost_equal(neg_srh, -100. * units('meter ** 2 / second ** 2 '), 6)
+    assert_almost_equal(total_srh, 300. * units('meter ** 2 / second ** 2 '), 6)
+
+
+def test_storm_relative_helicity_with_interpolation():
+    """Test storm relative helicity with interpolation."""
+    u = np.array([-5, 15, 25, 15, -5]) * units('m/s')
+    v = np.array([40, 20, 10, 10, 30]) * units('m/s')
+    u = u.to('knots')
+    heights = np.array([0, 100, 200, 300, 400]) * units.m
+
+    pos_srh, neg_srh, total_srh = storm_relative_helicity(u, v, heights,
+                                                          bottom=50 * units.meters,
+                                                          depth=300 * units.meters,
                                                           storm_u=5 * units('m/s'),
                                                           storm_v=10 * units('m/s'))
 


### PR DESCRIPTION
Closes #576 - There was complication with `get_layer` and some non-ideal testing/methods. This PR cleans up the docs, adds the function `get_layer_height` for height only subsetting (`get_layer` requires and interpolates in pressure space only). 

Testing now uses a triangular hodograph with a simple solution.

We may need to do some refactoring of `get_layer`, but that likely doesn't belong here. Either way I'm sure we can still do some API tuning.