### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ before_install:
   - if [[ $TASK == "docs" ]]; then
       if ! git describe --tags; then git fetch --depth=150; fi;
       export EXTRA_INSTALLS="cdm,doc,examples";
-      export EXTRA_PACKAGES="Cython pillow shapely<1.5.17.post1 sphinx_rtd_theme==0.2.5b1.post1 pytest recommonmark";
+      export EXTRA_PACKAGES="Cython pillow shapely<1.5.17.post1 sphinx_rtd_theme==0.2.5b1.post1 pytest recommonmark matplotlib<2.1";
       ls $HOME/local/lib/;
       if [[ ! -f $HOME/local/lib/libproj.so ]]; then
         wget http://download.osgeo.org/proj/proj-4.9.3.tar.gz;

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ before_install:
       pkg-config --modversion proj;
     else
       export TEST_OPTS="--flake8 --mpl";
+      export EXTRA_PACKAGES="$EXTRA_PACKAGES pydocstyle<2.1";
       if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then
         export EXTRA_PACKAGES="$EXTRA_PACKAGES flake8-bugbear";
       fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,7 @@ script:
         export DOC_TEST_RESULT=0;
       fi;
       doc8 --file-encoding utf8 README.rst docs/;
-      if [[ $DOC_BUILD_RESULT -ne 0 || $DOC_TEST_RESULT -ne 0 || $? -ne 0 ]]; then
+      if [[ $? -ne 0 || $DOC_BUILD_RESULT -ne 0 || $DOC_TEST_RESULT -ne 0 ]]; then
         false;
       fi;
     else

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,7 +99,7 @@ Related Projects
 
 * netCDF4-python_ is the officially blessed Python API for netCDF_
 * siphon_ is an API for accessing remote data on `THREDDS Data Server`__
-* unidata_python_gallery_ is a collection of meteorological Python scripts 
+* unidata_python_gallery_ is a collection of meteorological Python scripts
 
 .. _netCDF4-python: https://unidata.github.io/netcdf4-python/
 .. _netCDF: https://www.unidata.ucar.edu/software/netcdf/

--- a/examples/isentropic_example.py
+++ b/examples/isentropic_example.py
@@ -25,7 +25,8 @@ from metpy.units import units
 # **Getting the data**
 #
 # In this example, NARR reanalysis data for 18 UTC 04 April 1987 from the National Centers
-# for Environmental Information (https://nomads.ncdc.noaa.gov) will be used.
+# for Environmental Information (https://www.ncdc.noaa.gov/data-access/model-data)
+# will be used.
 
 data = Dataset(get_test_data('narr_example.nc', False))
 


### PR DESCRIPTION
- An incompatibility exists between flake8-docstrings and pydocstyle 2.1.1, breaking our build. (See [here](https://gitlab.com/pycqa/flake8-docstrings/issues/23))
- Run examples with matplotlib <2.1 since that's broken cartopy maps
- Fix doc8 return code detection -- we weren't error-ing out the build when doc8 noticed some lint
- Update a link to remove a redirect