### PR TITLE
Sorting in bulk_shear and mean_pressure_weighted

### DIFF
--- a/metpy/calc/indices.py
+++ b/metpy/calc/indices.py
@@ -88,17 +88,18 @@ def mean_pressure_weighted(pressure, *args, **kwargs):
     heights = kwargs.pop('heights', None)
     bottom = kwargs.pop('bottom', None)
     depth = kwargs.pop('depth', None)
-    #Sort in correct order by pressure
+    # Sort in decreasing pressure order
     sort_inds = np.argsort(pressure[::-1])
     pressure = pressure[sort_inds]
     heights = heights[sort_inds]
-    for datavar in args:
-        datavar = datavar[sort_inds]
     ret = []  # Returned variable means in layer
-    layer_arg = get_layer(pressure, *args, heights=heights,
-                          bottom=bottom, depth=depth)
-    layer_p = layer_arg[0]
-    layer_arg = layer_arg[1:]
+    layer_arg = []
+    for i, datavar in enumerate(args):
+        datavar = datavar[sort_inds]
+        layer_var = get_layer(pressure, datavar, heights=heights,
+                              bottom=bottom, depth=depth)
+        layer_p = layer_var[0]
+        layer_arg.append(layer_var[1])
     # Taking the integral of the weights (pressure) to feed into the weighting
     # function. Said integral works out to this function:
     pres_int = 0.5 * (layer_p[-1].magnitude**2 - layer_p[0].magnitude**2)
@@ -137,6 +138,11 @@ def bunkers_storm_motion(pressure, u, v, heights):
         U and v component of sfc-6km mean flow
 
     """
+    sort_inds = np.argsort(pressure[::-1])
+    pressure = pressure[sort_inds]
+    heights = heights[sort_inds]
+    u = u[sort_inds]
+    v = v[sort_inds]
     # mean wind from sfc-6km
     wind_mean = concatenate(mean_pressure_weighted(pressure, u, v, heights=heights,
                                                    depth=6000 * units('meter')))

--- a/metpy/calc/indices.py
+++ b/metpy/calc/indices.py
@@ -88,6 +88,12 @@ def mean_pressure_weighted(pressure, *args, **kwargs):
     heights = kwargs.pop('heights', None)
     bottom = kwargs.pop('bottom', None)
     depth = kwargs.pop('depth', None)
+    #Sort in correct order by pressure
+    sort_inds = np.argsort(pressure[::-1])
+    pressure = pressure[sort_inds]
+    heights = heights[sort_inds]
+    for datavar in args:
+        datavar = datavar[sort_inds]
     ret = []  # Returned variable means in layer
     layer_arg = get_layer(pressure, *args, heights=heights,
                           bottom=bottom, depth=depth)
@@ -195,6 +201,11 @@ def bulk_shear(pressure, u, v, heights=None, bottom=None, depth=None):
         v-component of layer bulk shear
 
     """
+    sort_inds = np.argsort(pressure[::-1])
+    pressure = pressure[sort_inds]
+    heights = heights[sort_inds]
+    u = u[sort_inds]
+    v = v[sort_inds]
     _, u_layer, v_layer = get_layer(pressure, u, v, heights=heights,
                                     bottom=bottom, depth=depth)
 

--- a/metpy/calc/tests/test_indices.py
+++ b/metpy/calc/tests/test_indices.py
@@ -39,6 +39,19 @@ def test_mean_pressure_weighted():
     assert_almost_equal(v, 7.966031839967931 * units('m/s'), 7)
 
 
+def test_mean_pressure_weighted_backwards():
+    """Test pressure-weighted mean wind function with data in increasing-pressure order."""
+    with UseSampleData():
+        data = get_upper_air_data(datetime(2016, 5, 22, 0), 'DDC', source='wyoming')
+    u, v = mean_pressure_weighted(data.variables['pressure'][:][::-1],
+                                  data.variables['u_wind'][:][::-1],
+                                  data.variables['v_wind'][:][::-1],
+                                  heights=data.variables['height'][:][::-1],
+                                  depth=6000 * units('meter'))
+    assert_almost_equal(u, 6.0208700094534775 * units('m/s'), 7)
+    assert_almost_equal(v, 7.966031839967931 * units('m/s'), 7)
+
+
 def test_mean_pressure_weighted_elevated():
     """Test pressure-weighted mean wind function with a base above the surface."""
     with UseSampleData():
@@ -72,6 +85,18 @@ def test_bulk_shear():
     u, v = bulk_shear(data.variables['pressure'][:], data.variables['u_wind'][:],
                       data.variables['v_wind'][:], heights=data.variables['height'][:],
                       depth=6000 * units('meter'))
+    truth = [29.899581266946115, -14.389225800205509] * units('knots')
+    assert_almost_equal(u.to('knots'), truth[0], 8)
+    assert_almost_equal(v.to('knots'), truth[1], 8)
+
+
+def test_bulk_shear_backward():
+    """Test bulk shear with observed sounding and data in increasing-pressure order."""
+    with UseSampleData():
+        data = get_upper_air_data(datetime(2016, 5, 22, 0), 'DDC', source='wyoming')
+    u, v = bulk_shear(data.variables['pressure'][:][::-1], data.variables['u_wind'][:][::-1],
+                      data.variables['v_wind'][:][::-1],
+                      heights=data.variables['height'][:][::-1], depth=6000 * units('meter'))
     truth = [29.899581266946115, -14.389225800205509] * units('knots')
     assert_almost_equal(u.to('knots'), truth[0], 8)
     assert_almost_equal(v.to('knots'), truth[1], 8)


### PR DESCRIPTION
This sorts the inputs to bulk_shear and mean_pressure_weighted in decreasing-pressure order, fixing a problem where they would break when fed data in increasing-pressure order. I've also added some simple tests for data in reversed order. The sorting for the *args in mean_pressure_weighted seems sort of inefficient right now, so any suggestions of better ways to sort them would definitely be welcome!