### PR TITLE
Flake8 3.5 Maint

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - pytest-flake8
   - pytest-mpl
   - pytest-runner
+  - flake8!=3.5
   - flake8-builtins
   - flake8-comprehensions
   - flake8-copyright


### PR DESCRIPTION
It appears that flake8 released 3.5 a few days ago and that's breaking things. Windows only currently as conda still has 3.4.X.