### PR TITLE
Cleanup precipitable water

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -94,9 +94,6 @@ References
            composite and significant tornado parameters. Preprints, 22nd Conf. on Severe Local
            Storms, Hyannis, MA, Amer. Meteor. Soc.
 
-.. [Tsonis2008] Tsonis, A. A., 2008: An introduction to atmospheric thermodynamics.
-           Cambridge Univ. Press, Cambridge.
-
 .. [Ziv1994] Ziv, B., and Alpert, P., 1994: Isobaric to Isentropic Interpolation Errors
            and Implication to Potential Vorticity Analysis. *J. Appl. Meteor.*, **33**,
            694-703, doi:`10.1175/1520-0450(1994)033%3C0694:ITIIEA%3E2.0.CO;2

--- a/metpy/calc/indices.py
+++ b/metpy/calc/indices.py
@@ -22,7 +22,7 @@ def precipitable_water(dewpt, pressure, bottom=None, top=None):
 
     .. math::  -\frac{1}{\rho_l g} \int\limits_{p_\text{bottom}}^{p_\text{top}} r dp
 
-    from [Tsonis2008]_, p. 170.
+    from [Salby1996]_, p. 28.
 
     Parameters
     ----------

--- a/metpy/calc/tests/test_indices.py
+++ b/metpy/calc/tests/test_indices.py
@@ -27,6 +27,18 @@ def test_precipitable_water():
     assert_array_equal(pw, truth)
 
 
+def test_precipitable_water_no_bounds():
+    """Test precipitable water with observed sounding and no bounds given."""
+    with UseSampleData():
+        data = get_upper_air_data(datetime(2016, 5, 22, 0), 'DDC', source='wyoming')
+    dewpoint = data.variables['dewpoint'][:]
+    pressure = data.variables['pressure'][:]
+    inds = pressure >= 400 * units.hPa
+    pw = precipitable_water(dewpoint[inds], pressure[inds])
+    truth = (0.8899441949243486 * units('inches')).to('millimeters')
+    assert_array_equal(pw, truth)
+
+
 def test_mean_pressure_weighted():
     """Test pressure-weighted mean wind function with vertical interpolation."""
     with UseSampleData():

--- a/metpy/calc/tests/test_indices.py
+++ b/metpy/calc/tests/test_indices.py
@@ -21,7 +21,8 @@ def test_precipitable_water():
     """Test precipitable water with observed sounding."""
     with UseSampleData():
         data = get_upper_air_data(datetime(2016, 5, 22, 0), 'DDC', source='wyoming')
-    pw = precipitable_water(data.variables['dewpoint'][:], data.variables['pressure'][:])
+    pw = precipitable_water(data.variables['dewpoint'][:], data.variables['pressure'][:],
+                            top=400 * units.hPa)
     truth = (0.8899441949243486 * units('inches')).to('millimeters')
     assert_array_equal(pw, truth)
 

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -323,6 +323,10 @@ def _get_bound_pressure_height(pressure, bound, heights=None, interpolate=True):
         The bound pressure and height.
 
     """
+    sort_inds = np.argsort(pressure)[::-1]
+    pressure = pressure[sort_inds]
+    if heights is not None:
+        heights = heights[sort_inds]
     # Bound is given in pressure
     if bound.dimensionality == {'[length]': -1.0, '[mass]': 1.0, '[time]': -2.0}:
         # If the bound is in the pressure data, we know the pressure bound exactly
@@ -538,7 +542,7 @@ def get_layer(pressure, *args, **kwargs):
 
     # If the bottom is not specified, make it the surface pressure
     if bottom is None:
-        bottom = pressure[0]
+        bottom = np.nanmax(pressure) * pressure.units
 
     bottom_pressure, bottom_height = _get_bound_pressure_height(pressure, bottom,
                                                                 heights=heights,


### PR DESCRIPTION
Precipitable water had a few worts. We were enforcing a 400 hPa top by default (because of SHARP), had no bottom argument, and there was an error in the formula displayed by the doc string.

cc @brianmapes @mwilson14 