### PR TITLE
get_layer with data in increasing pressure order

### DIFF
--- a/metpy/calc/tests/test_tools.py
+++ b/metpy/calc/tests/test_tools.py
@@ -286,7 +286,8 @@ def test_get_bound_height_out_of_range():
         _get_bound_pressure_height(p, 100 * units.meter, heights=h)
 
 
-def test_get_layer_float32():
+@pytest.mark.parametrize('flip_order', [(True, False)])
+def test_get_layer_float32(flip_order):
     """Test that get_layer works properly with float32 data."""
     p = np.asarray([940.85083008, 923.78851318, 911.42022705, 896.07220459,
                     876.89404297, 781.63330078], np.float32) * units('hPa')
@@ -298,6 +299,9 @@ def test_get_layer_float32():
     true_hgt_layer = np.asarray([563.671875, 700.93817139, 806.88098145, 938.51745605,
                                  1105.25854492, 1549.8079], dtype=np.float32) * units.meter
 
+    if flip_order:
+        p = p[::-1]
+        hgt = hgt[::-1]
     p_layer, hgt_layer = get_layer(p, hgt, heights=hgt, depth=1000. * units.meter)
     assert_array_almost_equal(p_layer, true_p_layer, 4)
     assert_array_almost_equal(hgt_layer, true_hgt_layer, 4)

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -323,10 +323,12 @@ def _get_bound_pressure_height(pressure, bound, heights=None, interpolate=True):
         The bound pressure and height.
 
     """
+    # Make sure pressure is monotonically decreasing
     sort_inds = np.argsort(pressure)[::-1]
     pressure = pressure[sort_inds]
     if heights is not None:
         heights = heights[sort_inds]
+
     # Bound is given in pressure
     if bound.dimensionality == {'[length]': -1.0, '[mass]': 1.0, '[time]': -2.0}:
         # If the bound is in the pressure data, we know the pressure bound exactly


### PR DESCRIPTION
Closes #593 by ensuring that `get_layer` works with data that are in increasing pressure order.

Not necessarily that pretty - I have a feeling that a refactor for all of this bounds/layer code is in order, but not sure when given our upcoming data model work.