### PR TITLE
Ensure that appropriate constants and function results are dimensionless

### DIFF
--- a/metpy/calc/tests/test_indices.py
+++ b/metpy/calc/tests/test_indices.py
@@ -13,7 +13,7 @@ from metpy.calc import (bulk_shear, bunkers_storm_motion, mean_pressure_weighted
 from metpy.deprecation import MetpyDeprecationWarning
 from metpy.io import get_upper_air_data
 from metpy.io.upperair import UseSampleData
-from metpy.testing import assert_almost_equal, assert_array_almost_equal, assert_array_equal
+from metpy.testing import assert_almost_equal, assert_array_equal
 from metpy.units import concatenate, units
 
 warnings.simplefilter('ignore', MetpyDeprecationWarning)

--- a/metpy/calc/tests/test_indices.py
+++ b/metpy/calc/tests/test_indices.py
@@ -49,7 +49,7 @@ def test_precipitable_water_bound_error():
                          -86.5, -88.1]) * units.degC
     pw = precipitable_water(dewpoint, pressure)
     truth = 89.86955998646951 * units('millimeters')
-    assert_array_equal(pw, truth)
+    assert_almost_equal(pw, truth, 8)
 
 
 def test_mean_pressure_weighted():

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -268,7 +268,7 @@ def test_equivalent_potential_temperature():
 def test_virtual_temperature():
     """Test virtual temperature calculation."""
     t = 288. * units.kelvin
-    qv = .0016  # kg/kg
+    qv = .0016 * units.dimensionless  # kg/kg
     tv = virtual_temperature(t, qv)
     assert_almost_equal(tv, 288.2796 * units.kelvin, 3)
 
@@ -277,7 +277,7 @@ def test_virtual_potential_temperature():
     """Test virtual potential temperature calculation."""
     p = 999. * units.mbar
     t = 288. * units.kelvin
-    qv = .0016  # kg/kg
+    qv = .0016 * units.dimensionless  # kg/kg
     theta_v = virtual_potential_temperature(p, t, qv)
     assert_almost_equal(theta_v, 288.3620 * units.kelvin, 3)
 
@@ -286,7 +286,7 @@ def test_density():
     """Test density calculation."""
     p = 999. * units.mbar
     t = 288. * units.kelvin
-    qv = .0016  # kg/kg
+    qv = .0016 * units.dimensionless  # kg/kg
     rho = density(p, t, qv).to(units.kilogram / units.meter ** 3)
     assert_almost_equal(rho, 1.2072 * (units.kilogram / units.meter ** 3), 3)
 
@@ -417,21 +417,21 @@ def test_rh_mixing_ratio():
     """Tests relative humidity from mixing ratio."""
     p = 1013.25 * units.mbar
     temperature = 20. * units.degC
-    w = 0.012
+    w = 0.012 * units.dimensionless
     rh = relative_humidity_from_mixing_ratio(w, temperature, p)
     assert_almost_equal(rh, 81.7219 * units.percent, 3)
 
 
 def test_mixing_ratio_from_specific_humidity():
     """Tests mixing ratio from specific humidity."""
-    q = 0.012
+    q = 0.012 * units.dimensionless
     w = mixing_ratio_from_specific_humidity(q)
     assert_almost_equal(w, 0.01215, 3)
 
 
 def test_specific_humidity_from_mixing_ratio():
     """Tests specific humidity from mixing ratio."""
-    w = 0.01215
+    w = 0.01215 * units.dimensionless
     q = specific_humidity_from_mixing_ratio(w)
     assert_almost_equal(q, 0.01200, 5)
 
@@ -440,7 +440,7 @@ def test_rh_specific_humidity():
     """Tests relative humidity from specific humidity."""
     p = 1013.25 * units.mbar
     temperature = 20. * units.degC
-    q = 0.012
+    q = 0.012 * units.dimensionless
     rh = relative_humidity_from_specific_humidity(q, temperature, p)
     assert_almost_equal(rh, 82.7145 * units.percent, 3)
 

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -434,14 +434,14 @@ def test_rh_mixing_ratio():
 
 
 def test_mixing_ratio_from_specific_humidity():
-    """Tests mixing ratio from specific humidity."""
+    """Test mixing ratio from specific humidity."""
     q = 0.012 * units.dimensionless
     w = mixing_ratio_from_specific_humidity(q)
     assert_almost_equal(w, 0.01215, 3)
 
 
 def test_specific_humidity_from_mixing_ratio():
-    """Tests specific humidity from mixing ratio."""
+    """Test specific humidity from mixing ratio."""
     w = 0.01215 * units.dimensionless
     q = specific_humidity_from_mixing_ratio(w)
     assert_almost_equal(q, 0.01200, 5)

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -499,8 +499,8 @@ def mixing_ratio(part_press, tot_press, molecular_weight_ratio=epsilon):
     saturation_mixing_ratio, vapor_pressure
 
     """
-    return (molecular_weight_ratio
-            * part_press / (tot_press - part_press)).to('dimensionless')
+    return (molecular_weight_ratio *
+            part_press / (tot_press - part_press)).to('dimensionless')
 
 
 @exporter.export
@@ -844,7 +844,11 @@ def mixing_ratio_from_specific_humidity(specific_humidity):
     mixing_ratio, specific_humidity_from_mixing_ratio
 
     """
-    return specific_humidity.to('dimensionless') / (1 - specific_humidity.to('dimensionless'))
+    try:
+        specific_humidity = specific_humidity.to('dimensionless')
+    except AttributeError:
+        pass
+    return specific_humidity / (1 - specific_humidity)
 
 
 @exporter.export
@@ -876,7 +880,11 @@ def specific_humidity_from_mixing_ratio(mixing_ratio):
     mixing_ratio, mixing_ratio_from_specific_humidity
 
     """
-    return mixing_ratio.to('dimensionless') / (1 + mixing_ratio.to('dimensionless'))
+    try:
+        mixing_ratio = mixing_ratio.to('dimensionless')
+    except AttributeError:
+        pass
+    return mixing_ratio / (1 + mixing_ratio)
 
 
 @exporter.export
@@ -1508,5 +1516,5 @@ def moist_static_energy(heights, temperature, specific_humidity):
         The moist static energy
 
     """
-    return (dry_static_energy(heights, temperature)
-            + Lv * specific_humidity.to('dimensionless')).to('kJ/kg')
+    return (dry_static_energy(heights, temperature) +
+            Lv * specific_humidity.to('dimensionless')).to('kJ/kg')

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -499,7 +499,7 @@ def mixing_ratio(part_press, tot_press, molecular_weight_ratio=epsilon):
     saturation_mixing_ratio, vapor_pressure
 
     """
-    return molecular_weight_ratio * part_press / (tot_press - part_press)
+    return (molecular_weight_ratio * part_press / (tot_press - part_press)).to('dimensionless')
 
 
 @exporter.export
@@ -536,7 +536,7 @@ def equivalent_potential_temperature(pressure, temperature, dewpoint):
 
     First, the LCL temperature is calculated:
 
-    .. math:: T_{L}=\frac{1}{\frac{1}{T_{D}-56}+\frac{(T_{K}/T_{D})}{800}}+56
+    .. math:: T_{L}=\frac{1}{\frac{1}{T_{D}-56}+\frac{ln(T_{K}/T_{D})}{800}}+56
 
     Which is then used to calculate the potential temperature at the LCL:
 
@@ -545,8 +545,8 @@ def equivalent_potential_temperature(pressure, temperature, dewpoint):
 
     Both of these are used to calculate the final equivalent potential temperature:
 
-    .. math:: \theta_{E}=\theta_{DL}\exp[\left(\left\frac{3036.}{T_{L}}
-                                        -1.78\right)*r(1+.448r)\right]
+    .. math:: \theta_{E}=\theta_{DL}\exp\left[\left(\frac{3036.}{T_{L}}
+                                              -1.78\right)*r(1+.448r)\right]
 
     Parameters
     ----------
@@ -802,7 +802,7 @@ def relative_humidity_from_mixing_ratio(mixing_ratio, temperature, pressure):
     .. math:: RH = 100 \frac{w}{w_s}
 
     * :math:`RH` is relative humidity
-    * :math:`w` is mxing ratio
+    * :math:`w` is mixing ratio
     * :math:`w_s` is the saturation mixing ratio
 
     See Also
@@ -875,7 +875,7 @@ def specific_humidity_from_mixing_ratio(mixing_ratio):
     mixing_ratio, mixing_ratio_from_specific_humidity
 
     """
-    return mixing_ratio / (1 + mixing_ratio)
+    return mixing_ratio.to('dimensionless') / (1 + mixing_ratio.to('dimensionless'))
 
 
 @exporter.export
@@ -1507,4 +1507,4 @@ def moist_static_energy(heights, temperature, specific_humidity):
         The moist static energy
 
     """
-    return (dry_static_energy(heights, temperature) + Lv * specific_humidity).to('kJ/kg')
+    return (dry_static_energy(heights, temperature) + Lv * specific_humidity.to('dimensionless')).to('kJ/kg')

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -1682,3 +1682,4 @@ def thickness_hydrostatic_from_relative_humidity(pressure, temperature, relative
 
     return thickness_hydrostatic(pressure, temperature, mixing=mixing, bottom=bottom,
                                  depth=depth)
+

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -1682,4 +1682,3 @@ def thickness_hydrostatic_from_relative_humidity(pressure, temperature, relative
 
     return thickness_hydrostatic(pressure, temperature, mixing=mixing, bottom=bottom,
                                  depth=depth)
-

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -499,7 +499,8 @@ def mixing_ratio(part_press, tot_press, molecular_weight_ratio=epsilon):
     saturation_mixing_ratio, vapor_pressure
 
     """
-    return (molecular_weight_ratio * part_press / (tot_press - part_press)).to('dimensionless')
+    return (molecular_weight_ratio
+            * part_press / (tot_press - part_press)).to('dimensionless')
 
 
 @exporter.export
@@ -843,7 +844,7 @@ def mixing_ratio_from_specific_humidity(specific_humidity):
     mixing_ratio, specific_humidity_from_mixing_ratio
 
     """
-    return specific_humidity / (1 - specific_humidity)
+    return specific_humidity.to('dimensionless') / (1 - specific_humidity.to('dimensionless'))
 
 
 @exporter.export
@@ -1507,4 +1508,5 @@ def moist_static_energy(heights, temperature, specific_humidity):
         The moist static energy
 
     """
-    return (dry_static_energy(heights, temperature) + Lv * specific_humidity.to('dimensionless')).to('kJ/kg')
+    return (dry_static_energy(heights, temperature)
+            + Lv * specific_humidity.to('dimensionless')).to('kJ/kg')

--- a/metpy/constants.py
+++ b/metpy/constants.py
@@ -104,8 +104,8 @@ with exporter:
 
     # General meteorology constants
     P0 = pot_temp_ref_press = 1000. * units.mbar
-    kappa = poisson_exponent = Rd / Cp_d
+    kappa = poisson_exponent = (Rd / Cp_d).to('dimensionless')
     gamma_d = dry_adiabatic_lapse_rate = g / Cp_d
-    epsilon = molecular_weight_ratio = Mw / Md
+    epsilon = molecular_weight_ratio = (Mw / Md).to('dimensionless')
 
 del Exporter


### PR DESCRIPTION
and fix some typos in docstrings of `calc/thermo.py`.

Addresses #623.