### PR TITLE
DOC: check presence of patched rtd_theme prior to setting versions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,8 +170,9 @@ def setup(app):
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {'canonical_url': 'https://unidata.github.io/MetPy/latest/',
-                      'versions': {'latest': '../latest', 'dev': '../dev'}}
+html_theme_options = {'canonical_url': 'https://unidata.github.io/MetPy/latest/'}
+if 'sphinx_rtd_theme' in vars() and sphinx_rtd_theme.__version__ == '0.2.5b1.post1':
+    html_theme_options['versions'] = {'latest': '../latest', 'dev': '../dev'}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []


### PR DESCRIPTION
Allows docs to build on vanilla sphinx_rtd_theme, see #644