### PR TITLE
Replace "View source" with "Improve this page"

### DIFF
--- a/docs/_static/theme_override.css
+++ b/docs/_static/theme_override.css
@@ -9,3 +9,17 @@ div[class^="highlight"] a:hover {
 .wy-nav-content {
     max-width: 100%
 }
+
+/* For the link to edit the page on Github */
+.source-link {
+    float: right;
+}
+
+/* Don't let the edit link disappear on mobile. */
+@media screen and (max-width: 480px) {
+    .wy-breadcrumbs li.source-link {
+        float:none;
+        display: block;
+        margin-top: 20px;
+    }
+}

--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -1,0 +1,20 @@
+{# Extend the RTD template to include links to Github instead of "View page
+   source" #}
+{% extends "!breadcrumbs.html" %}
+
+
+{% block breadcrumbs_aside %}
+    <li class="source-link">
+        {% if hasdoc(pagename) %}
+            {% if pagename.startswith("api/") or pagename.startswith("tutorials/") or pagename.startswith("examples/")%}
+                {% set title = "Suggested improvement for " + pagename %}
+                {% set body = "Please describe what could be improved about this page or the typo/mistake that you found:" %}
+                <a href="https://github.com/{{ github_repo }}/issues/new?title={{ title|urlencode }}&body={{ body|urlencode }}"
+                   class="fa fa-github"> Improve this page</a>
+            {% else %}
+                <a href="https://github.com/{{ github_repo }}/edit/{{ github_version }}/{{ doc_path }}/{{ pagename }}{{ suffix }}"
+                   class="fa fa-github"> Improve this page</a>
+            {% endif %}
+        {% endif %}
+    </li>
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,6 +174,14 @@ html_theme_options = {'canonical_url': 'https://unidata.github.io/MetPy/latest/'
 if 'sphinx_rtd_theme' in vars() and sphinx_rtd_theme.__version__ == '0.2.5b1.post1':
     html_theme_options['versions'] = {'latest': '../latest', 'dev': '../dev'}
 
+# Extra variables that will be available to the templates. Used to create the
+# links to the Github repository sources and issues
+html_context = {
+    'doc_path': 'docs',
+    'github_repo': 'Unidata/MetPy',
+    'github_version': 'master',  # Make changes to the master branch
+}
+
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
 


### PR DESCRIPTION
Modify the ReadTheDocs 'breadcrumbs.html' template to include this link. The link in the docs will point to the Github source in "edit" mode (on the master branch). If the page is autogenerated, it will point to a new issue instead with the page name included in the title and some instructions in the body.

Fixes #673 