### PR TITLE
Make mixing_ratio return 'dimensionless'

### DIFF
--- a/metpy/calc/tests/test_indices.py
+++ b/metpy/calc/tests/test_indices.py
@@ -13,7 +13,7 @@ from metpy.calc import (bulk_shear, bunkers_storm_motion, mean_pressure_weighted
 from metpy.deprecation import MetpyDeprecationWarning
 from metpy.io import get_upper_air_data
 from metpy.io.upperair import UseSampleData
-from metpy.testing import assert_almost_equal, assert_array_equal
+from metpy.testing import assert_almost_equal, assert_array_almost_equal, assert_array_equal
 from metpy.units import concatenate, units
 
 warnings.simplefilter('ignore', MetpyDeprecationWarning)
@@ -49,7 +49,7 @@ def test_precipitable_water_bound_error():
                          -86.5, -88.1]) * units.degC
     pw = precipitable_water(dewpoint, pressure)
     truth = 89.86955998646951 * units('millimeters')
-    assert_array_equal(pw, truth)
+    assert_array_almost_equal(pw, truth)
 
 
 def test_mean_pressure_weighted():

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -801,3 +801,17 @@ def test_thickness_hydrostatic_from_relative_humidity():
     thickness = thickness_hydrostatic_from_relative_humidity(pressure, temperature,
                                                              relative_humidity)
     assert_almost_equal(thickness, 9892.07 * units.m, 2)
+
+
+def test_mixing_ratio_dimensions():
+    """Verify mixing ratio returns a dimensionless number."""
+    p = 998. * units.mbar
+    e = 73.75 * units.hPa
+    assert str(mixing_ratio(e, p).units) == 'dimensionless'
+
+
+def test_saturation_mixing_ratio_dimensions():
+    """Verify saturation mixing ratio returns a dimensionless number."""
+    p = 998. * units.mbar
+    temp = 20 * units.celsius
+    assert str(saturation_mixing_ratio(p, temp).units) == 'dimensionless'

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -523,7 +523,7 @@ def saturation_mixing_ratio(tot_press, temperature):
         The saturation mixing ratio, dimensionless
 
     """
-    return mixing_ratio(saturation_vapor_pressure(temperature), tot_press).to('dimensionless')
+    return mixing_ratio(saturation_vapor_pressure(temperature), tot_press)
 
 
 @exporter.export

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -499,7 +499,7 @@ def mixing_ratio(part_press, tot_press, molecular_weight_ratio=epsilon):
     saturation_mixing_ratio, vapor_pressure
 
     """
-    return molecular_weight_ratio * part_press / (tot_press - part_press)
+    return (molecular_weight_ratio * part_press / (tot_press - part_press)).to('dimensionless')
 
 
 @exporter.export
@@ -523,7 +523,7 @@ def saturation_mixing_ratio(tot_press, temperature):
         The saturation mixing ratio, dimensionless
 
     """
-    return mixing_ratio(saturation_vapor_pressure(temperature), tot_press)
+    return mixing_ratio(saturation_vapor_pressure(temperature), tot_press).to('dimensionless')
 
 
 @exporter.export


### PR DESCRIPTION
In the edge case that `part_pres` and `tot_pres` are in units of mb and hPa respectively, force a return of 'dimensionless' rather than mb/hPa, which is technically a dimensionless quantity but not very intuitive to the user. Also changes a test on precipitable water from `assert_array_equal` to `assert_array_almost_equal` to account for a machine precision error.