### PR TITLE
Add RTD Theme

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - jupyter
   - sphinx
   - sphinx-gallery
+  - sphinx_rtd_theme
   - pytest>=2.4
   - pytest-cov
   - pytest-flake8


### PR DESCRIPTION
Add sphinx_rtd_theme to development environment to make getting setup to develop and build docs locally easier.