### PR TITLE
Respelling of `v_vorticity` and `h_divergence`

### DIFF
--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -13,6 +13,7 @@ from pyproj import Geod
 from ..calc.tools import get_layer_heights
 from ..cbook import is_string_like, iterable
 from ..constants import Cp_d, g
+from ..deprecation import deprecated
 from ..package_tools import Exporter
 from ..units import atleast_2d, check_units, concatenate, units
 
@@ -139,6 +140,17 @@ def vorticity(u, v, dx, dy):
 
 
 @exporter.export
+@deprecated('0.7', addendum=' This function has been renamed vorticity.',
+            pending=False)
+def v_vorticity(u, v, dx, dy, dim_order='xy'):
+    """Wrap vorticity for deprecated v_vorticity function."""
+    return vorticity(u, v, dx, dy, dim_order=dim_order)
+
+
+v_vorticity.__doc__ = vorticity.__doc__
+
+
+@exporter.export
 @ensure_yx_order
 def divergence(u, v, dx, dy):
     r"""Calculate the horizontal divergence of the horizontal wind.
@@ -168,6 +180,17 @@ def divergence(u, v, dx, dy):
     """
     dudx, _, _, dvdy = _get_gradients(u, v, dx, dy)
     return dudx + dvdy
+
+
+@exporter.export
+@deprecated('0.7', addendum=' This function has been replaced by divergence.',
+            pending=False)
+def convergence(u, v, dx, dy, dim_order='xy'):
+    """Wrap divergence for deprecated convergence function."""
+    return divergence(u, v, dx, dy, dim_order=dim_order)
+
+
+convergence.__doc__ = divergence.__doc__
 
 
 @exporter.export
@@ -205,6 +228,17 @@ def divergence_vorticity(u, v, dx, dy):
     """
     dudx, dudy, dvdx, dvdy = _get_gradients(u, v, dx, dy)
     return dudx + dvdy, dvdx - dudy
+
+
+@exporter.export
+@deprecated('0.7', addendum=' This function has been replaced by divergence_vorticity.',
+            pending=False)
+def convergence_vorticity(u, v, dx, dy, dim_order='xy'):
+    """Wrap divergence_vorticity for deprecated convergence vorticity function."""
+    return divergence_vorticity(u, v, dx, dy, dim_order=dim_order)
+
+
+convergence_vorticity.__doc__ = divergence_vorticity.__doc__
 
 
 @exporter.export

--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -108,7 +108,7 @@ def ensure_yx_order(func):
 
 @exporter.export
 @ensure_yx_order
-def v_vorticity(u, v, dx, dy):
+def vorticity(u, v, dx, dy):
     r"""Calculate the vertical vorticity of the horizontal wind.
 
     The grid must have a constant spacing in each direction.
@@ -131,7 +131,7 @@ def v_vorticity(u, v, dx, dy):
 
     See Also
     --------
-    h_divergence, divergence_vorticity
+    divergence, divergence_vorticity
 
     """
     _, dudy, dvdx, _ = _get_gradients(u, v, dx, dy)
@@ -140,7 +140,7 @@ def v_vorticity(u, v, dx, dy):
 
 @exporter.export
 @ensure_yx_order
-def h_divergence(u, v, dx, dy):
+def divergence(u, v, dx, dy):
     r"""Calculate the horizontal divergence of the horizontal wind.
 
     The grid must have a constant spacing in each direction.
@@ -163,7 +163,7 @@ def h_divergence(u, v, dx, dy):
 
     See Also
     --------
-    v_vorticity, divergence_vorticity
+    vorticity, divergence_vorticity
 
     """
     dudx, _, _, dvdy = _get_gradients(u, v, dx, dy)
@@ -195,7 +195,7 @@ def divergence_vorticity(u, v, dx, dy):
 
     See Also
     --------
-    v_vorticity, h_divergence
+    vorticity, divergence
 
     Notes
     -----
@@ -450,7 +450,7 @@ def frontogenesis(thta, u, v, dx, dy, dim_order='yx'):
     tdef = total_deformation(u, v, dx, dy, dim_order=dim_order)
 
     # Get the divergence of the wind field
-    div = h_divergence(u, v, dx, dy, dim_order=dim_order)
+    div = divergence(u, v, dx, dy, dim_order=dim_order)
 
     # Compute the angle (beta) between the wind field and the gradient of potential temperature
     psi = 0.5 * np.arctan2(shrd, strd)

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -6,11 +6,12 @@
 import numpy as np
 import pytest
 
-from metpy.calc import (advection, divergence_vorticity, frontogenesis,
-                        geostrophic_wind, get_wind_components, h_divergence,
-                        lat_lon_grid_spacing, montgomery_streamfunction, shearing_deformation,
+from metpy.calc import (advection, divergence, divergence_vorticity, frontogenesis,
+                        geostrophic_wind, get_wind_components,  lat_lon_grid_spacing,
+                        montgomery_streamfunction, shearing_deformation,
                         shearing_stretching_deformation, storm_relative_helicity,
-                        stretching_deformation, total_deformation, v_vorticity)
+                        stretching_deformation, total_deformation, vorticity)
+
 from metpy.constants import g, omega, Re
 from metpy.testing import assert_almost_equal, assert_array_equal
 from metpy.units import concatenate, units
@@ -75,7 +76,7 @@ def test_zero_vorticity():
     """Test vorticity calculation when zeros should be returned."""
     a = np.arange(3)
     u = np.c_[a, a, a] * units('m/s')
-    v = v_vorticity(u, u.T, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    v = vorticity(u, u.T, 1 * units.meter, 1 * units.meter, dim_order='xy')
     true_v = np.zeros_like(u) / units.sec
     assert_array_equal(v, true_v)
 
@@ -84,7 +85,7 @@ def test_vorticity():
     """Test vorticity for simple case."""
     a = np.arange(3)
     u = np.c_[a, a, a] * units('m/s')
-    v = v_vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    v = vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
     true_v = np.ones_like(u) / units.sec
     assert_array_equal(v, true_v)
 
@@ -93,12 +94,12 @@ def test_vorticity_asym():
     """Test vorticity calculation with a complicated field."""
     u = np.array([[2, 4, 8], [0, 2, 2], [4, 6, 8]]) * units('m/s')
     v = np.array([[6, 4, 8], [2, 6, 0], [2, 2, 6]]) * units('m/s')
-    vort = v_vorticity(u, v, 1 * units.meters, 2 * units.meters, dim_order='yx')
+    vort = vorticity(u, v, 1 * units.meters, 2 * units.meters, dim_order='yx')
     true_vort = np.array([[-1., 2., 7.], [3.5, -1.5, -6.], [-2., 0., 1.]]) / units.sec
     assert_array_equal(vort, true_vort)
 
     # Now try for xy ordered
-    vort = v_vorticity(u.T, v.T, 1 * units.meters, 2 * units.meters, dim_order='xy')
+    vort = vorticity(u.T, v.T, 1 * units.meters, 2 * units.meters, dim_order='xy')
     assert_array_equal(vort, true_vort.T)
 
 
@@ -106,7 +107,7 @@ def test_zero_divergence():
     """Test divergence calculation when zeros should be returned."""
     a = np.arange(3)
     u = np.c_[a, a, a] * units('m/s')
-    c = h_divergence(u, u.T, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    c = divergence(u, u.T, 1 * units.meter, 1 * units.meter, dim_order='xy')
     true_c = 2. * np.ones_like(u) / units.sec
     assert_array_equal(c, true_c)
 
@@ -115,7 +116,7 @@ def test_divergence():
     """Test divergence for simple case."""
     a = np.arange(3)
     u = np.c_[a, a, a] * units('m/s')
-    c = h_divergence(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    c = divergence(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
     true_c = np.ones_like(u) / units.sec
     assert_array_equal(c, true_c)
 
@@ -124,12 +125,12 @@ def test_divergence_asym():
     """Test divergence calculation with a complicated field."""
     u = np.array([[2, 4, 8], [0, 2, 2], [4, 6, 8]]) * units('m/s')
     v = np.array([[6, 4, 8], [2, 6, 0], [2, 2, 6]]) * units('m/s')
-    c = h_divergence(u, v, 1 * units.meters, 2 * units.meters, dim_order='yx')
+    c = divergence(u, v, 1 * units.meters, 2 * units.meters, dim_order='yx')
     true_c = np.array([[0., 4., 0.], [1., 0.5, -0.5], [2., 0., 5.]]) / units.sec
     assert_array_equal(c, true_c)
 
     # Now try for xy ordered
-    c = h_divergence(u.T, v.T, 1 * units.meters, 2 * units.meters, dim_order='xy')
+    c = divergence(u.T, v.T, 1 * units.meters, 2 * units.meters, dim_order='xy')
     assert_array_equal(c, true_c.T)
 
 

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -6,12 +6,12 @@
 import numpy as np
 import pytest
 
-from metpy.calc import (advection, divergence, divergence_vorticity, frontogenesis,
-                        geostrophic_wind, get_wind_components,  lat_lon_grid_spacing,
-                        montgomery_streamfunction, shearing_deformation,
-                        shearing_stretching_deformation, storm_relative_helicity,
-                        stretching_deformation, total_deformation, vorticity)
-
+from metpy.calc import (advection, convergence, convergence_vorticity, divergence,
+                        divergence_vorticity, frontogenesis, geostrophic_wind,
+                        get_wind_components, lat_lon_grid_spacing, montgomery_streamfunction,
+                        shearing_deformation, shearing_stretching_deformation,
+                        storm_relative_helicity, stretching_deformation, total_deformation,
+                        v_vorticity, vorticity)
 from metpy.constants import g, omega, Re
 from metpy.testing import assert_almost_equal, assert_array_equal
 from metpy.units import concatenate, units
@@ -515,3 +515,32 @@ def test_lat_lon_grid_spacing_mismatched_shape():
                     [-100., -97.5, -95., -92.5]])
     with pytest.raises(ValueError):
         dx, dy = lat_lon_grid_spacing(lon, lat)
+
+
+def test_v_vorticity():
+    """Test that v_vorticity wrapper works (deprecated in 0.7)."""
+    a = np.arange(3)
+    u = np.c_[a, a, a] * units('m/s')
+    v = v_vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    true_v = np.ones_like(u) / units.sec
+    assert_array_equal(v, true_v)
+
+
+def test_convergence():
+    """Test that convergence wrapper works (deprecated in 0.7)."""
+    a = np.arange(3)
+    u = np.c_[a, a, a] * units('m/s')
+    c = convergence(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    true_c = np.ones_like(u) / units.sec
+    assert_array_equal(c, true_c)
+
+
+def test_convergence_vorticity():
+    """Test that convergence_vorticity wrapper works (deprecated in 0.7)."""
+    a = np.arange(3)
+    u = np.c_[a, a, a] * units('m/s')
+    c, v = convergence_vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    true_c = np.ones_like(u) / units.sec
+    true_v = np.ones_like(u) / units.sec
+    assert_array_equal(c, true_c)
+    assert_array_equal(v, true_v)


### PR DESCRIPTION
A few respellings that are clearer instead of shorter. These could be up for debate, but it's more in line with the ethos we're working around here.

* `v_vorticity` -> `vertical_vorticity`
* `h_divergence` -> `divergence` (with options for 3D post X-array integration)

I still need to add some skeletons for the old names telling users that those have been renamed.