### PR TITLE
Add gradient and derivatives for irregular grids

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,7 @@
 """Configure pytest for metpy."""
 
 import matplotlib
+import matplotlib.pyplot
 import numpy
 import pint
 import pytest

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -20,6 +20,10 @@ References
            doi:`10.1175/1520-0493(1980)108%3C1046:TCOEPT%3E2.0.CO;2
            <https://doi.org/10.1175/1520-0493(1980)108%3C1046:TCOEPT%3E2.0.CO;2>`_.
 
+.. [Bowen2005] Bowen, M. K. and R. Smith, 2005: Derivative formulae and errors for
+           non-uniformly spaced points. *Proc. R. Soc. A*, **461**, 1975-1997,
+           doi:`10.1098/rspa.2004.1430 <https://doi.org/10.1098/rspa.2004.1430>`_.
+
 .. [Bunkers2000] Bunkers, M. J., B. A. Klimowski, J. W. Zeitler, R. L. Thompson,
            and M. L. Weisman, 2000: Predicting supercell motion using a new hodograph
            technique. *Wea. Forecasting.*, **15**, 61–79,

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -31,7 +31,7 @@ References
            doi:`10.1175/1520-0493(1959)087%3C0367:AOOAS%3E2.0.CO;2
            <https://doi.org/10.1175/1520-0493(1959)087%3C0367:AOOAS%3E2.0.CO;2>`_.
 
-.. [Davies-Jones2009] Davies-Jones, R., 2009: On Formulas for Equivalent Potential Temperature.
+.. [DaviesJones2009] Davies-Jones, R., 2009: On Formulas for Equivalent Potential Temperature.
            *Mon. Wea. Rev.*, **137**, 3137-3148,
            doi: `10.1175/2009mwr2774.1 <https://doi.org/10.1175/2009MWR2774.1>`_.
 

--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -185,12 +185,12 @@ def divergence(u, v, dx, dy):
 @exporter.export
 @deprecated('0.7', addendum=' This function has been replaced by divergence.',
             pending=False)
-def convergence(u, v, dx, dy, dim_order='xy'):
+def h_convergence(u, v, dx, dy, dim_order='xy'):
     """Wrap divergence for deprecated convergence function."""
     return divergence(u, v, dx, dy, dim_order=dim_order)
 
 
-convergence.__doc__ = divergence.__doc__
+h_convergence.__doc__ = divergence.__doc__
 
 
 @exporter.export

--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -194,8 +194,10 @@ h_convergence.__doc__ = divergence.__doc__
 
 
 @exporter.export
+@deprecated('0.7', addendum=' Use divergence and/or vorticity instead.',
+            pending=False)
 @ensure_yx_order
-def divergence_vorticity(u, v, dx, dy):
+def convergence_vorticity(u, v, dx, dy, dim_order='xy'):
     r"""Calculate the horizontal divergence and vertical vorticity of the horizontal wind.
 
     The grid must have a constant spacing in each direction.
@@ -228,17 +230,6 @@ def divergence_vorticity(u, v, dx, dy):
     """
     dudx, dudy, dvdx, dvdy = _get_gradients(u, v, dx, dy)
     return dudx + dvdy, dvdx - dudy
-
-
-@exporter.export
-@deprecated('0.7', addendum=' This function has been replaced by divergence_vorticity.',
-            pending=False)
-def convergence_vorticity(u, v, dx, dy, dim_order='xy'):
-    """Wrap divergence_vorticity for deprecated convergence vorticity function."""
-    return divergence_vorticity(u, v, dx, dy, dim_order=dim_order)
-
-
-convergence_vorticity.__doc__ = divergence_vorticity.__doc__
 
 
 @exporter.export

--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -454,14 +454,13 @@ def frontogenesis(thta, u, v, dx, dy, dim_order='yx'):
     Returns
     -------
     (M, N) ndarray
-        2D Frotogenesis in [temperature units]/m/s
-
+        2D Frontogenesis in [temperature units]/m/s
 
     Notes
     -----
     Assumes dim_order='yx', unless otherwise specified.
 
-    Conversion factor to go from [temperature units]/m/s to [tempature units/100km/3h]
+    Conversion factor to go from [temperature units]/m/s to [temperature units/100km/3h]
     :math:`1.08e4*1.e5`
 
     """

--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -132,7 +132,7 @@ def vorticity(u, v, dx, dy):
 
     See Also
     --------
-    divergence, divergence_vorticity
+    divergence
 
     """
     _, dudy, dvdx, _ = _get_gradients(u, v, dx, dy)
@@ -147,7 +147,9 @@ def v_vorticity(u, v, dx, dy, dim_order='xy'):
     return vorticity(u, v, dx, dy, dim_order=dim_order)
 
 
-v_vorticity.__doc__ = vorticity.__doc__
+v_vorticity.__doc__ = (vorticity.__doc__ +
+                       '\n    .. deprecated:: 0.7.0\n        Function has been renamed to '
+                       '`vorticity` and will be removed from MetPy in 0.9.0.')
 
 
 @exporter.export
@@ -175,7 +177,7 @@ def divergence(u, v, dx, dy):
 
     See Also
     --------
-    vorticity, divergence_vorticity
+    vorticity
 
     """
     dudx, _, _, dvdy = _get_gradients(u, v, dx, dy)
@@ -190,7 +192,9 @@ def h_convergence(u, v, dx, dy, dim_order='xy'):
     return divergence(u, v, dx, dy, dim_order=dim_order)
 
 
-h_convergence.__doc__ = divergence.__doc__
+h_convergence.__doc__ = (divergence.__doc__ +
+                         '\n    .. deprecated:: 0.7.0\n        Function has been renamed to '
+                         '`divergence` and will be removed from MetPy in 0.9.0.')
 
 
 @exporter.export
@@ -222,10 +226,10 @@ def convergence_vorticity(u, v, dx, dy, dim_order='xy'):
     --------
     vorticity, divergence
 
-    Notes
-    -----
-    This is a convenience function that will do less work than calculating
-    the horizontal divergence and vertical vorticity separately.
+    .. deprecated:: 0.7.0
+        Function no longer has any performance benefit over individual calls to
+        `divergence` and `vorticity` and will be removed from MetPy in 0.9.0.
+
 
     """
     dudx, dudy, dvdx, dvdy = _get_gradients(u, v, dx, dy)
@@ -257,7 +261,7 @@ def shearing_deformation(u, v, dx, dy):
 
     See Also
     --------
-    stretching_deformation, shearing_stretching_deformation
+    stretching_deformation, total_deformation
 
     """
     _, dudy, dvdx, _ = _get_gradients(u, v, dx, dy)
@@ -289,14 +293,17 @@ def stretching_deformation(u, v, dx, dy):
 
     See Also
     --------
-    shearing_deformation, shearing_stretching_deformation
+    shearing_deformation, total_deformation
 
     """
-    dudx, _, _, dvdy = _get_gradients(u, v, dx, dy)
+    dudx = first_derivative(u, delta=dx, axis=1)
+    dvdy = first_derivative(v, delta=dy, axis=0)
     return dudx - dvdy
 
 
 @exporter.export
+@deprecated('0.7', addendum=' Use stretching_deformation and/or shearing_deformation instead.',
+            pending=False)
 @ensure_yx_order
 def shearing_stretching_deformation(u, v, dx, dy):
     r"""Calculate the horizontal shearing and stretching deformation of the horizontal wind.
@@ -323,10 +330,11 @@ def shearing_stretching_deformation(u, v, dx, dy):
     --------
     shearing_deformation, stretching_deformation
 
-    Notes
-    -----
-    This is a convenience function that will do less work than calculating
-    the shearing and streching deformation terms separately.
+
+    .. deprecated:: 0.7.0
+        Function no longer has any performance benefit over individual calls to
+        `shearing_deformation` and `stretching_deformation` and will be removed from
+        MetPy in 0.9.0.
 
     """
     dudx, dudy, dvdx, dvdy = _get_gradients(u, v, dx, dy)
@@ -358,13 +366,7 @@ def total_deformation(u, v, dx, dy):
 
     See Also
     --------
-    shearing_deformation, stretching_deformation, shearing_stretching_deformation
-
-    Notes
-    -----
-    This is a convenience function that will do less work than calculating
-    the shearing and streching deformation terms separately and calculating the
-    total deformation "by hand".
+    shearing_deformation, stretching_deformation
 
     """
     dudx, dudy, dvdx, dvdy = _get_gradients(u, v, dx, dy)
@@ -436,10 +438,6 @@ def frontogenesis(thta, u, v, dx, dy, dim_order='yx'):
     * :math:`\beta` is the angle between the axis of dilitation and the isentropes
     * :math:`\delta` is the divergence
 
-    Notes
-    -----
-    Assumes dim_order='yx', unless otherwise specified.
-
     Parameters
     ----------
     thta : (M, N) ndarray
@@ -459,6 +457,10 @@ def frontogenesis(thta, u, v, dx, dy, dim_order='yx'):
         2D Frotogenesis in [temperature units]/m/s
 
 
+    Notes
+    -----
+    Assumes dim_order='yx', unless otherwise specified.
+
     Conversion factor to go from [temperature units]/m/s to [tempature units/100km/3h]
     :math:`1.08e4*1.e5`
 
@@ -471,7 +473,8 @@ def frontogenesis(thta, u, v, dx, dy, dim_order='yx'):
     mag_thta = np.sqrt(ddx_thta**2 + ddy_thta**2)
 
     # Get the shearing, stretching, and total deformation of the wind field
-    shrd, strd = shearing_stretching_deformation(u, v, dx, dy, dim_order=dim_order)
+    shrd = shearing_deformation(u, v, dx, dy, dim_order=dim_order)
+    strd = stretching_deformation(u, v, dx, dy, dim_order=dim_order)
     tdef = total_deformation(u, v, dx, dy, dim_order=dim_order)
 
     # Get the divergence of the wind field

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -6,7 +6,7 @@
 import numpy as np
 import pytest
 
-from metpy.calc import (advection, convergence, convergence_vorticity, divergence,
+from metpy.calc import (advection, h_convergence, convergence_vorticity, divergence,
                         divergence_vorticity, frontogenesis, geostrophic_wind,
                         get_wind_components, lat_lon_grid_spacing, montgomery_streamfunction,
                         shearing_deformation, shearing_stretching_deformation,
@@ -530,7 +530,7 @@ def test_convergence():
     """Test that convergence wrapper works (deprecated in 0.7)."""
     a = np.arange(3)
     u = np.c_[a, a, a] * units('m/s')
-    c = convergence(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    c = h_convergence(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
     true_c = np.ones_like(u) / units.sec
     assert_array_equal(c, true_c)
 

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -6,9 +6,9 @@
 import numpy as np
 import pytest
 
-from metpy.calc import (advection, h_convergence, convergence_vorticity, divergence,
-                        frontogenesis, geostrophic_wind,
-                        get_wind_components, lat_lon_grid_spacing, montgomery_streamfunction,
+from metpy.calc import (advection, convergence_vorticity, divergence,
+                        frontogenesis, geostrophic_wind, get_wind_components, h_convergence,
+                        lat_lon_grid_spacing, montgomery_streamfunction,
                         shearing_deformation, shearing_stretching_deformation,
                         storm_relative_helicity, stretching_deformation, total_deformation,
                         v_vorticity, vorticity)
@@ -66,8 +66,8 @@ def test_vorticity_divergence_asym():
     with pytest.warns(MetpyDeprecationWarning):
         c, vort = convergence_vorticity(u, v, 1 * units.meters, 2 * units.meters,
                                         dim_order='yx')
-    true_c = np.array([[0., 4., 0.], [1., 0.5, -0.5], [2., 0., 5.]]) / units.sec
-    true_vort = np.array([[-1., 2., 7.], [3.5, -1.5, -6.], [-2., 0., 1.]]) / units.sec
+    true_c = np.array([[-2, 5.5, -2.5], [2., 0.5, -1.5], [3., -1.5, 8.5]]) / units.sec
+    true_vort = np.array([[-2.5, 3.5, 13.], [8.5, -1.5, -11.], [-5.5, -1.5, 0.]]) / units.sec
     assert_array_equal(c, true_c)
     assert_array_equal(vort, true_vort)
 
@@ -102,7 +102,7 @@ def test_vorticity_asym():
     u = np.array([[2, 4, 8], [0, 2, 2], [4, 6, 8]]) * units('m/s')
     v = np.array([[6, 4, 8], [2, 6, 0], [2, 2, 6]]) * units('m/s')
     vort = vorticity(u, v, 1 * units.meters, 2 * units.meters, dim_order='yx')
-    true_vort = np.array([[-1., 2., 7.], [3.5, -1.5, -6.], [-2., 0., 1.]]) / units.sec
+    true_vort = np.array([[-2.5, 3.5, 13.], [8.5, -1.5, -11.], [-5.5, -1.5, 0.]]) / units.sec
     assert_array_equal(vort, true_vort)
 
     # Now try for xy ordered
@@ -133,7 +133,7 @@ def test_divergence_asym():
     u = np.array([[2, 4, 8], [0, 2, 2], [4, 6, 8]]) * units('m/s')
     v = np.array([[6, 4, 8], [2, 6, 0], [2, 2, 6]]) * units('m/s')
     c = divergence(u, v, 1 * units.meters, 2 * units.meters, dim_order='yx')
-    true_c = np.array([[0., 4., 0.], [1., 0.5, -0.5], [2., 0., 5.]]) / units.sec
+    true_c = np.array([[-2, 5.5, -2.5], [2., 0.5, -1.5], [3., -1.5, 8.5]]) / units.sec
     assert_array_equal(c, true_c)
 
     # Now try for xy ordered
@@ -185,8 +185,8 @@ def test_shst_deformation_asym():
     with pytest.warns(MetpyDeprecationWarning):
         sh, st = shearing_stretching_deformation(u, v, 1 * units.meters, 2 * units.meters,
                                                  dim_order='yx')
-    true_sh = np.array([[-3., 0., 1.], [4.5, -0.5, -6.], [2., 4., 7.]]) / units.sec
-    true_st = np.array([[4., 2., 8.], [3., 1.5, 0.5], [2., 4., -1.]]) / units.sec
+    true_sh = np.array([[-7.5, -1.5, 1.], [9.5, -0.5, -11.], [1.5, 5.5, 12.]]) / units.sec
+    true_st = np.array([[4., 0.5, 12.5], [4., 1.5, -0.5], [1., 5.5, -4.5]]) / units.sec
     assert_array_equal(sh, true_sh)
     assert_array_equal(st, true_st)
 
@@ -203,7 +203,7 @@ def test_shearing_deformation_asym():
     u = np.array([[2, 4, 8], [0, 2, 2], [4, 6, 8]]) * units('m/s')
     v = np.array([[6, 4, 8], [2, 6, 0], [2, 2, 6]]) * units('m/s')
     sh = shearing_deformation(u, v, 1 * units.meters, 2 * units.meters, dim_order='yx')
-    true_sh = np.array([[-3., 0., 1.], [4.5, -0.5, -6.], [2., 4., 7.]]) / units.sec
+    true_sh = np.array([[-7.5, -1.5, 1.], [9.5, -0.5, -11.], [1.5, 5.5, 12.]]) / units.sec
     assert_array_equal(sh, true_sh)
 
     # Now try for yx ordered
@@ -217,7 +217,7 @@ def test_stretching_deformation_asym():
     u = np.array([[2, 4, 8], [0, 2, 2], [4, 6, 8]]) * units('m/s')
     v = np.array([[6, 4, 8], [2, 6, 0], [2, 2, 6]]) * units('m/s')
     st = stretching_deformation(u, v, 1 * units.meters, 2 * units.meters, dim_order='yx')
-    true_st = np.array([[4., 2., 8.], [3., 1.5, 0.5], [2., 4., -1.]]) / units.sec
+    true_st = np.array([[4., 0.5, 12.5], [4., 1.5, -0.5], [1., 5.5, -4.5]]) / units.sec
     assert_array_equal(st, true_st)
 
     # Now try for yx ordered
@@ -232,8 +232,8 @@ def test_total_deformation_asym():
     v = np.array([[6, 4, 8], [2, 6, 0], [2, 2, 6]]) * units('m/s')
     tdef = total_deformation(u, v, 1 * units.meters, 2 * units.meters,
                              dim_order='yx')
-    true_tdef = np.array([[5., 2., 8.06225775], [5.40832691, 1.58113883, 6.02079729],
-                          [2.82842712, 5.65685425, 7.07106781]]) / units.sec
+    true_tdef = np.array([[8.5, 1.58113883, 12.5399362], [10.30776406, 1.58113883, 11.0113578],
+                          [1.80277562, 7.7781746, 12.8160056]]) / units.sec
     assert_almost_equal(tdef, true_tdef)
 
     # Now try for xy ordered
@@ -249,9 +249,9 @@ def test_frontogenesis_asym():
     theta = np.array([[303, 295, 305], [308, 310, 312], [299, 293, 289]]) * units('K')
     fronto = frontogenesis(theta, u, v, 1 * units.meters, 2 * units.meters,
                            dim_order='yx')
-    true_fronto = np.array([[-20.93890452, -7.83070042, -36.43293256],
-                            [0.89442719, -2.12218672, -8.94427191],
-                            [-16.8, -7.65600391, -61.65921479]]
+    true_fronto = np.array([[-52.4746386, -37.3658646, -50.3996939],
+                            [3.5777088, -2.1221867, -16.9941166],
+                            [-23.1417334, 26.0499143, -158.4839684]]
                            ) * units.K / units.meter / units.sec
     assert_almost_equal(fronto, true_fronto)
 
@@ -303,7 +303,7 @@ def test_advection_2d():
     v = 2 * np.ones((3, 3)) * units('m/s')
     s = np.array([[1, 2, 1], [2, 4, 2], [1, 2, 1]]) * units.kelvin
     a = advection(s, [u, v], (1 * units.meter, 1 * units.meter), dim_order='xy')
-    truth = np.array([[-3, -2, 1], [-4, 0, 4], [-1, 2, 3]]) * units('K/sec')
+    truth = np.array([[-6, -4, 2], [-8, 0, 8], [-2, 4, 6]]) * units('K/sec')
     assert_array_equal(a, truth)
 
 
@@ -313,7 +313,7 @@ def test_advection_2d_asym():
     v = 2 * u
     s = np.array([[1, 2, 4], [4, 8, 4], [8, 6, 4]]) * units.kelvin
     a = advection(s, [u, v], (2 * units.meter, 1 * units.meter), dim_order='yx')
-    truth = np.array([[0, -12.75, -2], [-27., -16., 10.], [-42, 35, 8]]) * units('K/sec')
+    truth = np.array([[0, -20.75, -2.5], [-33., -16., 20.], [-48, 91., 8]]) * units('K/sec')
     assert_array_equal(a, truth)
 
     # Now try xy ordered
@@ -327,7 +327,7 @@ def test_geostrophic_wind():
     # Using g as the value for f allows it to cancel out
     ug, vg = geostrophic_wind(z, g.magnitude / units.sec,
                               100. * units.meter, 100. * units.meter, dim_order='xy')
-    true_u = np.array([[-1, 0, 1]] * 3) * units('m/s')
+    true_u = np.array([[-2, 0, 2]] * 3) * units('m/s')
     true_v = -true_u.T
     assert_array_equal(ug, true_u)
     assert_array_equal(vg, true_v)
@@ -339,8 +339,8 @@ def test_geostrophic_wind_asym():
     # Using g as the value for f allows it to cancel out
     ug, vg = geostrophic_wind(z, g.magnitude / units.sec,
                               200. * units.meter, 100. * units.meter, dim_order='yx')
-    true_u = -np.array([[6, 12, 0], [7, 4, 0], [8, -4, 0]]) * units('m/s')
-    true_v = np.array([[1, 1.5, 2], [4, 0, -4], [-2, -2, -2]]) * units('m/s')
+    true_u = -np.array([[5, 20, 0], [7, 4, 0], [9, -12, 0]]) * units('m/s')
+    true_v = np.array([[0.5, 1.5, 2.5], [8, 0, -8], [-2, -2, -2]]) * units('m/s')
     assert_array_equal(ug, true_u)
     assert_array_equal(vg, true_v)
 
@@ -356,7 +356,7 @@ def test_geostrophic_geopotential():
     z = np.array([[48, 49, 48], [49, 50, 49], [48, 49, 48]]) * 100. * units('m^2/s^2')
     ug, vg = geostrophic_wind(z, 1 / units.sec, 100. * units.meter, 100. * units.meter,
                               dim_order='xy')
-    true_u = np.array([[-1, 0, 1]] * 3) * units('m/s')
+    true_u = np.array([[-2, 0, 2]] * 3) * units('m/s')
     true_v = -true_u.T
     assert_array_equal(ug, true_u)
     assert_array_equal(vg, true_v)
@@ -369,7 +369,7 @@ def test_geostrophic_3d():
     z3d = np.dstack((z, z)) * units.meter
     ug, vg = geostrophic_wind(z3d, g.magnitude / units.sec,
                               100. * units.meter, 100. * units.meter, dim_order='xy')
-    true_u = np.array([[-1, 0, 1]] * 3) * units('m/s')
+    true_u = np.array([[-2, 0, 2]] * 3) * units('m/s')
     true_v = -true_u.T
 
     true_u = concatenate((true_u[..., None], true_u[..., None]), axis=2)

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -13,6 +13,7 @@ from metpy.calc import (advection, h_convergence, convergence_vorticity, diverge
                         storm_relative_helicity, stretching_deformation, total_deformation,
                         v_vorticity, vorticity)
 from metpy.constants import g, omega, Re
+from metpy.deprecation import MetpyDeprecationWarning
 from metpy.testing import assert_almost_equal, assert_array_equal
 from metpy.units import concatenate, units
 
@@ -27,7 +28,8 @@ def test_default_order_warns():
 def test_zero_gradient():
     """Test divergence_vorticity when there is no gradient in the field."""
     u = np.ones((3, 3)) * units('m/s')
-    c, v = convergence_vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    with pytest.warns(MetpyDeprecationWarning):
+        c, v = convergence_vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
     truth = np.zeros_like(u) / units.sec
     assert_array_equal(c, truth)
     assert_array_equal(v, truth)
@@ -37,7 +39,8 @@ def test_cv_zero_vorticity():
     """Test divergence_vorticity when there is only divergence."""
     a = np.arange(3)
     u = np.c_[a, a, a] * units('m/s')
-    c, v = convergence_vorticity(u, u.T, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    with pytest.warns(MetpyDeprecationWarning):
+        c, v = convergence_vorticity(u, u.T, 1 * units.meter, 1 * units.meter, dim_order='xy')
     true_c = 2. * np.ones_like(u) / units.sec
     true_v = np.zeros_like(u) / units.sec
     assert_array_equal(c, true_c)
@@ -48,7 +51,8 @@ def test_divergence_vorticity():
     """Test of vorticity and divergence calculation for basic case."""
     a = np.arange(3)
     u = np.c_[a, a, a] * units('m/s')
-    c, v = convergence_vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    with pytest.warns(MetpyDeprecationWarning):
+        c, v = convergence_vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
     true_c = np.ones_like(u) / units.sec
     true_v = np.ones_like(u) / units.sec
     assert_array_equal(c, true_c)
@@ -59,15 +63,18 @@ def test_vorticity_divergence_asym():
     """Test vorticity and divergence calculation with a complicated field."""
     u = np.array([[2, 4, 8], [0, 2, 2], [4, 6, 8]]) * units('m/s')
     v = np.array([[6, 4, 8], [2, 6, 0], [2, 2, 6]]) * units('m/s')
-    c, vort = convergence_vorticity(u, v, 1 * units.meters, 2 * units.meters, dim_order='yx')
+    with pytest.warns(MetpyDeprecationWarning):
+        c, vort = convergence_vorticity(u, v, 1 * units.meters, 2 * units.meters,
+                                        dim_order='yx')
     true_c = np.array([[0., 4., 0.], [1., 0.5, -0.5], [2., 0., 5.]]) / units.sec
     true_vort = np.array([[-1., 2., 7.], [3.5, -1.5, -6.], [-2., 0., 1.]]) / units.sec
     assert_array_equal(c, true_c)
     assert_array_equal(vort, true_vort)
 
     # Now try for xy ordered
-    c, vort = convergence_vorticity(u.T, v.T, 1 * units.meters, 2 * units.meters,
-                                   dim_order='xy')
+    with pytest.warns(MetpyDeprecationWarning):
+        c, vort = convergence_vorticity(u.T, v.T, 1 * units.meters, 2 * units.meters,
+                                        dim_order='xy')
     assert_array_equal(c, true_c.T)
     assert_array_equal(vort, true_vort.T)
 
@@ -137,8 +144,9 @@ def test_divergence_asym():
 def test_shst_zero_gradient():
     """Test shear_stretching_deformation when there is zero gradient."""
     u = np.ones((3, 3)) * units('m/s')
-    sh, st = shearing_stretching_deformation(u, u, 1 * units.meter, 1 * units.meter,
-                                             dim_order='xy')
+    with pytest.warns(MetpyDeprecationWarning):
+        sh, st = shearing_stretching_deformation(u, u, 1 * units.meter, 1 * units.meter,
+                                                 dim_order='xy')
     truth = np.zeros_like(u) / units.sec
     assert_array_equal(sh, truth)
     assert_array_equal(st, truth)
@@ -148,8 +156,9 @@ def test_shst_zero_stretching():
     """Test shear_stretching_deformation when there is only shearing."""
     a = np.arange(3)
     u = np.c_[a, a, a] * units('m/s')
-    sh, st = shearing_stretching_deformation(u, u.T, 1 * units.meter, 1 * units.meter,
-                                             dim_order='yx')
+    with pytest.warns(MetpyDeprecationWarning):
+        sh, st = shearing_stretching_deformation(u, u.T, 1 * units.meter, 1 * units.meter,
+                                                 dim_order='yx')
     true_sh = 2. * np.ones_like(u) / units.sec
     true_st = np.zeros_like(u) / units.sec
     assert_array_equal(sh, true_sh)
@@ -160,8 +169,9 @@ def test_shst_deformation():
     """Test of shearing and stretching deformation calculation for basic case."""
     a = np.arange(3)
     u = np.c_[a, a, a] * units('m/s')
-    sh, st = shearing_stretching_deformation(u, u, 1 * units.meter, 1 * units.meter,
-                                             dim_order='xy')
+    with pytest.warns(MetpyDeprecationWarning):
+        sh, st = shearing_stretching_deformation(u, u, 1 * units.meter, 1 * units.meter,
+                                                 dim_order='xy')
     true_sh = np.ones_like(u) / units.sec
     true_st = np.ones_like(u) / units.sec
     assert_array_equal(sh, true_st)
@@ -172,16 +182,18 @@ def test_shst_deformation_asym():
     """Test shearing and stretching deformation calculation with a complicated field."""
     u = np.array([[2, 4, 8], [0, 2, 2], [4, 6, 8]]) * units('m/s')
     v = np.array([[6, 4, 8], [2, 6, 0], [2, 2, 6]]) * units('m/s')
-    sh, st = shearing_stretching_deformation(u, v, 1 * units.meters, 2 * units.meters,
-                                             dim_order='yx')
+    with pytest.warns(MetpyDeprecationWarning):
+        sh, st = shearing_stretching_deformation(u, v, 1 * units.meters, 2 * units.meters,
+                                                 dim_order='yx')
     true_sh = np.array([[-3., 0., 1.], [4.5, -0.5, -6.], [2., 4., 7.]]) / units.sec
     true_st = np.array([[4., 2., 8.], [3., 1.5, 0.5], [2., 4., -1.]]) / units.sec
     assert_array_equal(sh, true_sh)
     assert_array_equal(st, true_st)
 
     # Now try for yx ordered
-    sh, st = shearing_stretching_deformation(u.T, v.T, 1 * units.meters, 2 * units.meters,
-                                             dim_order='xy')
+    with pytest.warns(MetpyDeprecationWarning):
+        sh, st = shearing_stretching_deformation(u.T, v.T, 1 * units.meters, 2 * units.meters,
+                                                 dim_order='xy')
     assert_array_equal(sh, true_sh.T)
     assert_array_equal(st, true_st.T)
 
@@ -521,7 +533,8 @@ def test_v_vorticity():
     """Test that v_vorticity wrapper works (deprecated in 0.7)."""
     a = np.arange(3)
     u = np.c_[a, a, a] * units('m/s')
-    v = v_vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    with pytest.warns(MetpyDeprecationWarning):
+        v = v_vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
     true_v = np.ones_like(u) / units.sec
     assert_array_equal(v, true_v)
 
@@ -530,7 +543,8 @@ def test_convergence():
     """Test that convergence wrapper works (deprecated in 0.7)."""
     a = np.arange(3)
     u = np.c_[a, a, a] * units('m/s')
-    c = h_convergence(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    with pytest.warns(MetpyDeprecationWarning):
+        c = h_convergence(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
     true_c = np.ones_like(u) / units.sec
     assert_array_equal(c, true_c)
 
@@ -539,7 +553,8 @@ def test_convergence_vorticity():
     """Test that convergence_vorticity wrapper works (deprecated in 0.7)."""
     a = np.arange(3)
     u = np.c_[a, a, a] * units('m/s')
-    c, v = convergence_vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    with pytest.warns(MetpyDeprecationWarning):
+        c, v = convergence_vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
     true_c = np.ones_like(u) / units.sec
     true_v = np.ones_like(u) / units.sec
     assert_array_equal(c, true_c)

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from metpy.calc import (advection, h_convergence, convergence_vorticity, divergence,
-                        divergence_vorticity, frontogenesis, geostrophic_wind,
+                        frontogenesis, geostrophic_wind,
                         get_wind_components, lat_lon_grid_spacing, montgomery_streamfunction,
                         shearing_deformation, shearing_stretching_deformation,
                         storm_relative_helicity, stretching_deformation, total_deformation,
@@ -21,13 +21,13 @@ def test_default_order_warns():
     """Test that using the default array ordering issues a warning."""
     u = np.ones((3, 3)) * units('m/s')
     with pytest.warns(FutureWarning):
-        divergence_vorticity(u, u, 1 * units.meter, 1 * units.meter)
+        vorticity(u, u, 1 * units.meter, 1 * units.meter)
 
 
 def test_zero_gradient():
     """Test divergence_vorticity when there is no gradient in the field."""
     u = np.ones((3, 3)) * units('m/s')
-    c, v = divergence_vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    c, v = convergence_vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
     truth = np.zeros_like(u) / units.sec
     assert_array_equal(c, truth)
     assert_array_equal(v, truth)
@@ -37,7 +37,7 @@ def test_cv_zero_vorticity():
     """Test divergence_vorticity when there is only divergence."""
     a = np.arange(3)
     u = np.c_[a, a, a] * units('m/s')
-    c, v = divergence_vorticity(u, u.T, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    c, v = convergence_vorticity(u, u.T, 1 * units.meter, 1 * units.meter, dim_order='xy')
     true_c = 2. * np.ones_like(u) / units.sec
     true_v = np.zeros_like(u) / units.sec
     assert_array_equal(c, true_c)
@@ -48,7 +48,7 @@ def test_divergence_vorticity():
     """Test of vorticity and divergence calculation for basic case."""
     a = np.arange(3)
     u = np.c_[a, a, a] * units('m/s')
-    c, v = divergence_vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
+    c, v = convergence_vorticity(u, u, 1 * units.meter, 1 * units.meter, dim_order='xy')
     true_c = np.ones_like(u) / units.sec
     true_v = np.ones_like(u) / units.sec
     assert_array_equal(c, true_c)
@@ -59,14 +59,14 @@ def test_vorticity_divergence_asym():
     """Test vorticity and divergence calculation with a complicated field."""
     u = np.array([[2, 4, 8], [0, 2, 2], [4, 6, 8]]) * units('m/s')
     v = np.array([[6, 4, 8], [2, 6, 0], [2, 2, 6]]) * units('m/s')
-    c, vort = divergence_vorticity(u, v, 1 * units.meters, 2 * units.meters, dim_order='yx')
+    c, vort = convergence_vorticity(u, v, 1 * units.meters, 2 * units.meters, dim_order='yx')
     true_c = np.array([[0., 4., 0.], [1., 0.5, -0.5], [2., 0., 5.]]) / units.sec
     true_vort = np.array([[-1., 2., 7.], [3.5, -1.5, -6.], [-2., 0., 1.]]) / units.sec
     assert_array_equal(c, true_c)
     assert_array_equal(vort, true_vort)
 
     # Now try for xy ordered
-    c, vort = divergence_vorticity(u.T, v.T, 1 * units.meters, 2 * units.meters,
+    c, vort = convergence_vorticity(u.T, v.T, 1 * units.meters, 2 * units.meters,
                                    dim_order='xy')
     assert_array_equal(c, true_c.T)
     assert_array_equal(vort, true_vort.T)

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -596,7 +596,7 @@ def equivalent_potential_temperature(pressure, temperature, dewpoint):
     Notes
     -----
     [Bolton1980]_ formula for Theta-e is used, since according to
-    [Davies-Jones2009]_ it is the most accurate non-iterative formulation
+    [DaviesJones2009]_ it is the most accurate non-iterative formulation
     available.
 
     """

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -8,7 +8,12 @@ import functools
 import warnings
 
 import numpy as np
-from numpy.core.numeric import normalize_axis_index
+try:
+    from numpy.core.numeric import normalize_axis_index
+except ImportError:  # Only available in numpy >=1.13.0
+    def normalize_axis_index(a, n):
+        """No op version of :func:`numpy.core.numeric.normalize_axis_index`."""
+        return a
 import numpy.ma as ma
 from scipy.spatial import cKDTree
 

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -14,7 +14,7 @@ from scipy.spatial import cKDTree
 
 from . import height_to_pressure_std, pressure_to_height_std
 from ..package_tools import Exporter
-from ..units import atleast_1d, check_units, concatenate, units
+from ..units import atleast_1d, check_units, concatenate, diff, units
 
 exporter = Exporter(globals())
 
@@ -1115,19 +1115,8 @@ def _process_deriv_args(f, kwargs):
             delta = _broadcast_to_axis(delta, axis, n)
     elif 'x' in kwargs:
         x = _broadcast_to_axis(kwargs['x'], axis, n)
-        delta = _diff(x, axis=axis)
+        delta = diff(x, axis=axis)
     else:
         raise ValueError('Must specify either "x" or "delta" for value positions.')
 
     return n, axis, delta
-
-
-def _diff(x, **kwargs):
-    """Wrap :func:`numpy.diff` to handle units."""
-    ret = np.diff(x, **kwargs)
-    if hasattr(x, 'units'):
-        # Can't just use units because of how things like temperature work
-        it = x.flat
-        true_units = (next(it) - next(it)).units
-        ret = ret * true_units
-    return ret

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -2,17 +2,19 @@
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Contains a collection of generally useful calculation tools."""
+from __future__ import division
 
 import functools
 import warnings
 
 import numpy as np
+from numpy.core.numeric import normalize_axis_index
 import numpy.ma as ma
 from scipy.spatial import cKDTree
 
 from . import height_to_pressure_std, pressure_to_height_std
 from ..package_tools import Exporter
-from ..units import check_units, units
+from ..units import atleast_1d, check_units, concatenate, units
 
 exporter = Exporter(globals())
 
@@ -831,3 +833,301 @@ def _less_or_close(a, value, **kwargs):
 
     """
     return np.less(a, value) | np.isclose(a, value, **kwargs)
+
+
+@exporter.export
+def first_derivative(f, **kwargs):
+    """Calculate the first derivative of a grid of values.
+
+    Works for both regularly-spaced data and grids with varying spacing.
+
+    Either `x` or `delta` must be specified. This uses 3 points to calculate the
+    derivative, using forward or backward at the edges of the grid as appropriate, and
+    centered elsewhere. The irregular spacing is handled explicitly, using the formulation
+    as specified by [Bowen2005]_.
+
+    Parameters
+    ----------
+    f : array-like
+        Array of values of which to calculate the derivative
+    axis : int, optional
+        The array axis along which to take the derivative. Defaults to 0.
+    x : array-like, optional
+        The coordinate values corresponding to the grid points in `f`.
+    delta : array-like, optional
+        Spacing between the grid points in `f`. Should be one item less than the size
+        of `f` along `axis`.
+
+    Returns
+    -------
+    array-like
+        The first derivative calculated along the selected axis.
+
+    See Also
+    --------
+    second_derivative
+
+    """
+    n, axis, delta = _process_deriv_args(f, kwargs)
+
+    # create slice objects --- initially all are [:, :, ..., :]
+    slice0 = [slice(None)] * n
+    slice1 = [slice(None)] * n
+    slice2 = [slice(None)] * n
+    delta_slice0 = [slice(None)] * n
+    delta_slice1 = [slice(None)] * n
+
+    # First handle centered case
+    slice0[axis] = slice(None, -2)
+    slice1[axis] = slice(1, -1)
+    slice2[axis] = slice(2, None)
+    delta_slice0[axis] = slice(None, -1)
+    delta_slice1[axis] = slice(1, None)
+
+    combined_delta = delta[delta_slice0] + delta[delta_slice1]
+    delta_diff = delta[delta_slice1] - delta[delta_slice0]
+    center = (- delta[delta_slice1] / (combined_delta * delta[delta_slice0]) * f[slice0] +
+              delta_diff / (delta[delta_slice0] * delta[delta_slice1]) * f[slice1] +
+              delta[delta_slice0] / (combined_delta * delta[delta_slice1]) * f[slice2])
+
+    # Fill in "left" edge with forward difference
+    slice0[axis] = slice(None, 1)
+    slice1[axis] = slice(1, 2)
+    slice2[axis] = slice(2, 3)
+    delta_slice0[axis] = slice(None, 1)
+    delta_slice1[axis] = slice(1, 2)
+
+    combined_delta = delta[delta_slice0] + delta[delta_slice1]
+    big_delta = combined_delta + delta[delta_slice0]
+    left = (- big_delta / (combined_delta * delta[delta_slice0]) * f[slice0] +
+            combined_delta / (delta[delta_slice0] * delta[delta_slice1]) * f[slice1] -
+            delta[delta_slice0] / (combined_delta * delta[delta_slice1]) * f[slice2])
+
+    # Now the "right" edge with backward difference
+    slice0[axis] = slice(-3, -2)
+    slice1[axis] = slice(-2, -1)
+    slice2[axis] = slice(-1, None)
+    delta_slice0[axis] = slice(-2, -1)
+    delta_slice1[axis] = slice(-1, None)
+
+    combined_delta = delta[delta_slice0] + delta[delta_slice1]
+    big_delta = combined_delta + delta[delta_slice1]
+    right = (delta[delta_slice1] / (combined_delta * delta[delta_slice0]) * f[slice0] -
+             combined_delta / (delta[delta_slice0] * delta[delta_slice1]) * f[slice1] +
+             big_delta / (combined_delta * delta[delta_slice1]) * f[slice2])
+
+    return concatenate((left, center, right), axis=axis)
+
+
+@exporter.export
+def second_derivative(f, **kwargs):
+    """Calculate the second derivative of a grid of values.
+
+    Works for both regularly-spaced data and grids with varying spacing.
+
+    Either `x` or `delta` must be specified.
+
+    Either `x` or `delta` must be specified. This uses 3 points to calculate the
+    derivative, using forward or backward at the edges of the grid as appropriate, and
+    centered elsewhere. The irregular spacing is handled explicitly, using the formulation
+    as specified by [Bowen2005]_.
+
+    Parameters
+    ----------
+    f : array-like
+        Array of values of which to calculate the derivative
+    axis : int, optional
+        The array axis along which to take the derivative. Defaults to 0.
+    x : array-like, optional
+        The coordinate values corresponding to the grid points in `f`.
+    delta : array-like, optional
+        Spacing between the grid points in `f`. There should be one item less than the size
+        of `f` along `axis`.
+
+    Returns
+    -------
+    array-like
+        The second derivative calculated along the selected axis.
+
+    See Also
+    --------
+    first_derivative
+
+    """
+    n, axis, delta = _process_deriv_args(f, kwargs)
+
+    # create slice objects --- initially all are [:, :, ..., :]
+    slice0 = [slice(None)] * n
+    slice1 = [slice(None)] * n
+    slice2 = [slice(None)] * n
+    delta_slice0 = [slice(None)] * n
+    delta_slice1 = [slice(None)] * n
+
+    # First handle centered case
+    slice0[axis] = slice(None, -2)
+    slice1[axis] = slice(1, -1)
+    slice2[axis] = slice(2, None)
+    delta_slice0[axis] = slice(None, -1)
+    delta_slice1[axis] = slice(1, None)
+
+    combined_delta = delta[delta_slice0] + delta[delta_slice1]
+    center = 2 * (f[slice0] / (combined_delta * delta[delta_slice0]) -
+                  f[slice1] / (delta[delta_slice0] * delta[delta_slice1]) +
+                  f[slice2] / (combined_delta * delta[delta_slice1]))
+
+    # Fill in "left" edge
+    slice0[axis] = slice(None, 1)
+    slice1[axis] = slice(1, 2)
+    slice2[axis] = slice(2, 3)
+    delta_slice0[axis] = slice(None, 1)
+    delta_slice1[axis] = slice(1, 2)
+
+    combined_delta = delta[delta_slice0] + delta[delta_slice1]
+    left = 2 * (f[slice0] / (combined_delta * delta[delta_slice0]) -
+                f[slice1] / (delta[delta_slice0] * delta[delta_slice1]) +
+                f[slice2] / (combined_delta * delta[delta_slice1]))
+
+    # Now the "right" edge
+    slice0[axis] = slice(-3, -2)
+    slice1[axis] = slice(-2, -1)
+    slice2[axis] = slice(-1, None)
+    delta_slice0[axis] = slice(-2, -1)
+    delta_slice1[axis] = slice(-1, None)
+
+    combined_delta = delta[delta_slice0] + delta[delta_slice1]
+    right = 2 * (f[slice0] / (combined_delta * delta[delta_slice0]) -
+                 f[slice1] / (delta[delta_slice0] * delta[delta_slice1]) +
+                 f[slice2] / (combined_delta * delta[delta_slice1]))
+
+    return concatenate((left, center, right), axis=axis)
+
+
+def gradient(f, **kwargs):
+    """Calculate the gradient of a grid of values.
+
+    Works for both regularly-spaced data, and grids with varying spacing.
+
+    Either `x` or `deltas` must be specified.
+
+    Parameters
+    ----------
+    f : array-like
+        Array of values of which to calculate the derivative
+    x : array-like, optional
+        The coordinate values corresponding to the grid points in `f`
+    deltas : array-like, optional
+        Spacing between the grid points in `f`. There should be one item less than the size
+        of `f` along `axis`.
+
+    Returns
+    -------
+    array-like
+        The first derivative calculated along each axis in the original array
+
+    See Also
+    --------
+    laplacian
+
+    """
+    pos_kwarg, positions = _process_gradient_args(kwargs)
+    return tuple(first_derivative(f, axis=ind, **{pos_kwarg: positions[ind]})
+                 for ind, pos in enumerate(positions))
+
+
+@exporter.export
+def laplacian(f, **kwargs):
+    """Calculate the laplacian of a grid of values.
+
+    Works for both regularly-spaced data, and grids with varying spacing.
+
+    Either `x` or `deltas` must be specified.
+
+    Parameters
+    ----------
+    f : array-like
+        Array of values of which to calculate the derivative
+    x : array-like, optional
+        The coordinate values corresponding to the grid points in `f`
+    deltas : array-like, optional
+        Spacing between the grid points in `f`. There should be one item less than the size
+        of `f` along `axis`.
+
+    Returns
+    -------
+    array-like
+        The laplacian
+
+    See Also
+    --------
+    gradient
+
+    """
+    pos_kwarg, positions = _process_gradient_args(kwargs)
+    return sum(second_derivative(f, axis=ind, **{pos_kwarg: positions[ind]})
+               for ind, pos in enumerate(positions))
+
+
+def _broadcast_to_axis(arr, axis, ndim):
+    """Handle reshaping coordinate array to have proper dimensionality.
+
+    This puts the values along the specified axis.
+    """
+    if arr.ndim == 1 and arr.ndim < ndim:
+        new_shape = [1] * ndim
+        new_shape[axis] = arr.size
+        arr = arr.reshape(*new_shape)
+    return arr
+
+
+def _process_gradient_args(kwargs):
+    """Handle common processing of arguments for gradient and gradient-like functions."""
+    if 'deltas' in kwargs:
+        if 'x' in kwargs:
+            raise ValueError('Cannot specify both "x" and "deltas".')
+        return 'delta', kwargs['deltas']
+    elif 'x' in kwargs:
+        return 'x', kwargs['x']
+    else:
+        raise ValueError('Must specify either "x" or "delta" for value positions.')
+
+
+def _process_deriv_args(f, kwargs):
+    """Handle common processing of arguments for derivative functions."""
+    n = f.ndim
+    axis = normalize_axis_index(kwargs.get('axis', 0), n)
+
+    if f.shape[axis] < 3:
+        raise ValueError('f must have at least 3 point along the desired axis.')
+
+    if 'delta' in kwargs:
+        if 'x' in kwargs:
+            raise ValueError('Cannot specify both "x" and "delta".')
+
+        delta = atleast_1d(kwargs['delta'])
+        if delta.size == 1:
+            diff_size = list(f.shape)
+            diff_size[axis] -= 1
+            delta_units = getattr(delta, 'units', None)
+            delta = np.broadcast_to(delta, diff_size, subok=True)
+            if delta_units is not None:
+                delta = delta * delta_units
+        else:
+            delta = _broadcast_to_axis(delta, axis, n)
+    elif 'x' in kwargs:
+        x = _broadcast_to_axis(kwargs['x'], axis, n)
+        delta = _diff(x, axis=axis)
+    else:
+        raise ValueError('Must specify either "x" or "delta" for value positions.')
+
+    return n, axis, delta
+
+
+def _diff(x, **kwargs):
+    """Wrap :func:`numpy.diff` to handle units."""
+    ret = np.diff(x, **kwargs)
+    if hasattr(x, 'units'):
+        # Can't just use units because of how things like temperature work
+        it = x.flat
+        true_units = (next(it) - next(it)).units
+        ret = ret * true_units
+    return ret

--- a/metpy/tests/test_units.py
+++ b/metpy/tests/test_units.py
@@ -6,10 +6,11 @@ r"""Tests the operation of MetPy's unit support code."""
 import sys
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 
-from metpy.testing import set_agg_backend  # noqa: F401
-from metpy.units import check_units, units
+from metpy.testing import assert_array_equal, set_agg_backend  # noqa: F401
+from metpy.units import atleast_1d, atleast_2d, check_units, units
 
 
 @pytest.mark.mpl_image_compare(tolerance=0, remove_text=True)
@@ -30,6 +31,16 @@ def test_axvline():
     ax.set_xlim(-1, 1)
     ax.set_xlabel('')
     return fig
+
+
+def test_atleast1d_without_units():
+    """Test that atleast_1d wrapper can handle plain arrays."""
+    assert_array_equal(atleast_1d(1), np.array([1]))
+
+
+def test_atleast2d_without_units():
+    """Test that atleast_2d wrapper can handle plain arrays."""
+    assert_array_equal(atleast_2d(1), np.array([[1]]))
 
 #
 # Tests for unit-checking decorator

--- a/metpy/tests/test_units.py
+++ b/metpy/tests/test_units.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 from metpy.testing import assert_array_equal, set_agg_backend  # noqa: F401
-from metpy.units import atleast_1d, atleast_2d, check_units, units
+from metpy.units import atleast_1d, atleast_2d, check_units, diff, units
 
 
 @pytest.mark.mpl_image_compare(tolerance=0, remove_text=True)
@@ -41,6 +41,13 @@ def test_atleast1d_without_units():
 def test_atleast2d_without_units():
     """Test that atleast_2d wrapper can handle plain arrays."""
     assert_array_equal(atleast_2d(1), np.array([[1]]))
+
+
+def test_units_diff():
+    """Test our diff handles units properly."""
+    assert_array_equal(diff(np.arange(20, 22) * units.degC),
+                       np.array([1]) * units.delta_degC)
+
 
 #
 # Tests for unit-checking decorator

--- a/metpy/units.py
+++ b/metpy/units.py
@@ -69,6 +69,41 @@ def concatenate(arrs, axis=0):
     return units.Quantity(np.concatenate(data, axis=axis), dest)
 
 
+def diff(x, **kwargs):
+    """Calculate the n-th discrete difference along given axis.
+
+    Wraps :func:`numpy.diff` to handle units.
+
+    Parameters
+    ----------
+    x : array-like
+        Input data
+    n : int, optional
+        The number of times values are differenced.
+    axis : int, optional
+        The axis along which the difference is taken, default is the last axis.
+
+    Returns
+    -------
+    diff : ndarray
+        The n-th differences. The shape of the output is the same as `a`
+        except along `axis` where the dimension is smaller by `n`. The
+        type of the output is the same as that of the input.
+
+    See Also
+    --------
+    numpy.diff
+
+    """
+    ret = np.diff(x, **kwargs)
+    if hasattr(x, 'units'):
+        # Can't just use units because of how things like temperature work
+        it = x.flat
+        true_units = (next(it) - next(it)).units
+        ret = ret * true_units
+    return ret
+
+
 def atleast_1d(*arrs):
     r"""Convert inputs to arrays with at least one dimension.
 

--- a/metpy/units.py
+++ b/metpy/units.py
@@ -87,12 +87,15 @@ def atleast_1d(*arrs):
         A single quantity or a list of quantities, matching the number of inputs.
 
     """
-    mags = [a.magnitude for a in arrs]
-    orig_units = [a.units for a in arrs]
+    mags = [a.magnitude if hasattr(a, 'magnitude') else a for a in arrs]
+    orig_units = [a.units if hasattr(a, 'units') else None for a in arrs]
     ret = np.atleast_1d(*mags)
     if len(mags) == 1:
-        return units.Quantity(ret, orig_units[0])
-    return [units.Quantity(m, u) for m, u in zip(ret, orig_units)]
+        if orig_units[0] is not None:
+            return units.Quantity(ret, orig_units[0])
+        else:
+            return ret
+    return [units.Quantity(m, u) if u is not None else m for m, u in zip(ret, orig_units)]
 
 
 def atleast_2d(*arrs):
@@ -113,12 +116,15 @@ def atleast_2d(*arrs):
         A single quantity or a list of quantities, matching the number of inputs.
 
     """
-    mags = [a.magnitude for a in arrs]
-    orig_units = [a.units for a in arrs]
+    mags = [a.magnitude if hasattr(a, 'magnitude') else a for a in arrs]
+    orig_units = [a.units if hasattr(a, 'units') else None for a in arrs]
     ret = np.atleast_2d(*mags)
     if len(mags) == 1:
-        return units.Quantity(ret, orig_units[0])
-    return [units.Quantity(m, u) for m, u in zip(ret, orig_units)]
+        if orig_units[0] is not None:
+            return units.Quantity(ret, orig_units[0])
+        else:
+            return ret
+    return [units.Quantity(m, u) if u is not None else m for m, u in zip(ret, orig_units)]
 
 
 def masked_array(data, data_units=None, **kwargs):

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ flake8-ignore = *.py F405
 flake8-max-line-length = 95
 doctest_optionflags = NORMALIZE_WHITESPACE
 mpl-results-path = test_output
+log_print = False
 
 [doc8]
 ignore-path = docs/build,docs/api,docs/_templates


### PR DESCRIPTION
This should be good to go now. This adds 1st and 2nd derivatives, as well as gradient and laplacian that work with irregular grids. This also updates the kinematics functions to use them rather than wrappers for numpy's gradient function.

Closes #174 .