### PR TITLE
Add Batch of Functions for Brunt-Väisälä Frequency and Period

### DIFF
--- a/docs/gempak.rst
+++ b/docs/gempak.rst
@@ -333,9 +333,9 @@ blue is uncertain of parity, and white is unevaluated.
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">BVSQ(THTA)</td>
-        <td class="tg-notimplemented">Brunt-Vaisala frequency squared in a layer</td>
-        <td class="tg-notimplemented"><a href="https://github.com/Unidata/MetPy/issues/629">Issue #629</a></td>
+        <td class="tg-implemented">BVSQ(THTA)</td>
+        <td class="tg-implemented">Brunt-Vaisala frequency squared in a layer</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.brunt_vaisala_frequency_squared.html#metpy.calc.brunt_vaisala_frequency_squared">metpy.calc.brunt_vaisala_frequency_squared</a> (use with <a href="api/generated/metpy.calc.mixed_layer.html#metpy.calc.mixed_layer">metpy.calc.mixed_layer</a> to obtain layer average)</td>
         <td></td>
         <td></td>
         <td></td>
@@ -3857,25 +3857,25 @@ blue is uncertain of parity, and white is unevaluated.
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">BVFQ</td>
-        <td class="tg-notimplemented">Brunt-Vaisala frequency in a layer</td>
-        <td class="tg-notimplemented"><a href="https://github.com/Unidata/MetPy/issues/629">Issue #629</a></td>
+        <td class="tg-implemented">BVFQ</td>
+        <td class="tg-implemented">Brunt-Vaisala frequency in a layer</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.brunt_vaisala_frequency.html#metpy.calc.brunt_vaisala_frequency">metpy.calc.brunt_vaisala_frequency</a> (use with <a href="api/generated/metpy.calc.mixed_layer.html#metpy.calc.mixed_layer">metpy.calc.mixed_layer</a> to obtain layer average)</td>
         <td></td>
         <td></td>
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">BVPD</td>
-        <td class="tg-notimplemented">Brunt-Vaisala period in a layer</td>
-        <td class="tg-notimplemented"><a href="https://github.com/Unidata/MetPy/issues/629">Issue #629</a></td>
+        <td class="tg-implemented">BVPD</td>
+        <td class="tg-implemented">Brunt-Vaisala period in a layer</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.brunt_vaisala_period.html#metpy.calc.brunt_vaisala_period">metpy.calc.brunt_vaisala_period</a> (use with <a href="api/generated/metpy.calc.mixed_layer.html#metpy.calc.mixed_layer">metpy.calc.mixed_layer</a> to obtain layer average)</td>
         <td></td>
         <td></td>
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">BVSQ</td>
-        <td class="tg-notimplemented">Brunt-Vaisala frequency squared in a layer</td>
-        <td class="tg-notimplemented"><a href="https://github.com/Unidata/MetPy/issues/629">Issue #629</a></td>
+        <td class="tg-implemented">BVSQ</td>
+        <td class="tg-implemented">Brunt-Vaisala frequency squared in a layer</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.brunt_vaisala_frequency_squared.html#metpy.calc.brunt_vaisala_frequency_squared">metpy.calc.brunt_vaisala_frequency_squared</a> (use with <a href="api/generated/metpy.calc.mixed_layer.html#metpy.calc.mixed_layer">metpy.calc.mixed_layer</a> to obtain layer average)</td>
         <td></td>
         <td></td>
         <td></td>


### PR DESCRIPTION
I'm sorry that my "later this week" turned into a couple weeks after finals and holidays!

But, in any case, here is a PR addressing issue #629, implementing the various Brunt-Väisälä frequency and period functions discussed in comments. This PR also makes a modification to the `kinematics._gradient` function, which previously had issues with the `axis` kwarg. Finally, it also updates the GEMPAK table to reflect these new functions.

Feedback is greatly appreciated! I especially wanted to ask about on the following:

- Should I be using "Vaisala" or "Väisälä"?
- Is the modification to `kinematics._gradient` acceptable, or is there a better approach to taking the derivative along a single axis that works with various array sizes?
- Is the test coverage sufficient, or are there additional cases I should be testing?