### PR TITLE
MNT: Change default dimension ordering for kinematics functions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -6,5 +6,5 @@ Tyler Wixtrom <tjwixtrom@gmail.com> <twixtrom@candy.unidata.ucar.edu>
 Tyler Wixtrom <tjwixtrom@gmail.com>
 Brian Mapes <mapes@miami.edu>
 Kristen Pozsonyi <knpozson@millersville.edu>
-
-
+Daryl Herzmann <akrherz@iastate.edu>
+Kishan Mehta <kishan@mobifly.co.uk>

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
     - WHEELDIR="wheelhouse/"
     # Shapely dependency needed to keep from using Shapely's manylinux wheels
     # which use a different geos that what we build cartopy with on Travis
-    - EXTRA_PACKAGES="shapely<1.5.17.post1"
+    - EXTRA_PACKAGES="shapely<1.5.17.post1 flake8-docstrings!=1.2.0"
     - EXTRA_INSTALLS="test,cdm"
     - MPLLOCALFREETYPE="1"
     - TEST_OUTPUT_CONTROL="-s"

--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -27,11 +27,11 @@ def _stack(arrs):
 def _is_x_first_dim(dim_order):
     """Determine whether x is the first dimension based on the value of dim_order."""
     if dim_order is None:
-        warnings.warn('dim_order is using the default setting (currently "xy"). This will '
-                      'change to "yx" in the next version. It is recommended that you '
+        warnings.warn('dim_order is using the default setting ("yx"). This changed in '
+                      'version 0.7. It is recommended that you '
                       'specify the appropriate ordering ("xy", "yx") for your data by '
-                      'passing the `dim_order` argument to the calculation.', FutureWarning)
-        dim_order = 'xy'
+                      'passing the `dim_order` argument to the calculation.', UserWarning)
+        dim_order = 'yx'
     return dim_order == 'xy'
 
 
@@ -78,7 +78,7 @@ def ensure_yx_order(func):
         or ``'yx'``. ``'xy'`` indicates that the dimension corresponding to x is the leading
         dimension, followed by y. ``'yx'`` indicates that x is the last dimension, preceded
         by y. ``None`` indicates that the default ordering should be assumed,
-        which will change in version 0.6 from 'xy' to 'yx'. Can only be passed as a keyword
+        which changed in version 0.7 from 'xy' to 'yx'. Can only be passed as a keyword
         argument, i.e. func(..., dim_order='xy')."""
 
     # Find the first blank line after the start of the parameters section

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -21,7 +21,7 @@ from metpy.units import concatenate, units
 def test_default_order_warns():
     """Test that using the default array ordering issues a warning."""
     u = np.ones((3, 3)) * units('m/s')
-    with pytest.warns(FutureWarning):
+    with pytest.warns(UserWarning):
         vorticity(u, u, 1 * units.meter, 1 * units.meter)
 
 


### PR DESCRIPTION
We already promised that we were going to do this, so we probably should.
  