### PR TITLE
Force `mixing_ratio_from_relative_humidity` to return dimensionless

### DIFF
--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -828,3 +828,12 @@ def test_saturation_mixing_ratio_dimensions():
     p = 998. * units.mbar
     temp = 20 * units.celsius
     assert str(saturation_mixing_ratio(p, temp).units) == 'dimensionless'
+
+
+def test_mixing_ratio_from_rh_dimensions():
+    """Verify mixing ratio from RH returns a dimensionless number."""
+    p = 1000. * units.mbar
+    temperature = 0. * units.degC
+    rh = 100. * units.percent
+    assert (str(mixing_ratio_from_relative_humidity(rh, temperature, p).units) ==
+            'dimensionless')

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -842,7 +842,8 @@ def mixing_ratio_from_relative_humidity(relative_humidity, temperature, pressure
     relative_humidity_from_mixing_ratio, saturation_mixing_ratio
 
     """
-    return relative_humidity * saturation_mixing_ratio(pressure, temperature)
+    return (relative_humidity *
+            saturation_mixing_ratio(pressure, temperature)).to('dimensionless')
 
 
 @exporter.export


### PR DESCRIPTION
Fixes issue #703 where `mixing_ratio_from_relative_humidity` returns in percent when RH is supplied in percent. Also adds a test to verify the unit on the returned value is indeed dimensionless.