### PR TITLE
Fix build

### DIFF
--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -266,10 +266,10 @@ def reduce_point_density(points, radius, priority=None):
     Examples
     --------
     >>> metpy.calc.reduce_point_density(np.array([1, 2, 3]), 1.)
-    array([ True, False,  True], dtype=bool)
+    array([ True, False,  True])
     >>> metpy.calc.reduce_point_density(np.array([1, 2, 3]), 1.,
     ... priority=np.array([0.1, 0.9, 0.3]))
-    array([False,  True, False], dtype=bool)
+    array([False,  True, False])
 
     """
     # Handle 1D input
@@ -643,7 +643,7 @@ def interp(x, xp, *args, **kwargs):
      >>> y = np.array([1., 2., 3., 4.])
      >>> x_interp = np.array([2.5, 3.5])
      >>> metpy.calc.interp(x_interp, x, y)
-     array([ 2.5,  3.5])
+     array([2.5, 3.5])
 
     Notes
     -----
@@ -779,7 +779,7 @@ def log_interp(x, xp, *args, **kwargs):
      >>> y_log = np.log(x_log) * 2 + 3
      >>> x_interp = np.array([5e3, 5e4, 5e5])
      >>> metpy.calc.log_interp(x_interp, x_log, y_log)
-     array([ 20.03438638,  24.63955657,  29.24472675])
+     array([20.03438638, 24.63955657, 29.24472675])
 
     Notes
     -----


### PR DESCRIPTION
Right now, this updates doctests for NumPy 1.14 (Fixes #687). Since we really only need to run doctests on the latest numpy, just update the text output rather than try to use numpy's support for the "legacy" print mode.

Waiting to see if there's anything else that needs doing. AppVeyor failure should be fixed once conda-forge/flake8-docstrings-feedstock#4 is merged.