### PR TITLE
Clean up sigma interpolation example

### DIFF
--- a/examples/sigma_to_pressure_interpolation.py
+++ b/examples/sigma_to_pressure_interpolation.py
@@ -48,15 +48,10 @@ plevs = [700.] * units.hPa
 # interpolated from the irregular pressure values for each sigma level to the new input
 # mandatory isobaric levels. `mcalc.log_interp` will interpolate over a specified dimension
 # with the `axis` argument. In this case, `axis=1` will correspond to interpolation on the
-# vertical axis.
+# vertical axis. The interpolated data is output in a list, so we will pull out each
+# variable for plotting.
 
-isobaric_levels = mcalc.log_interp(plevs, pres, hgt, temperature, axis=1)
-
-####################################
-# The interpolated data is output in a list, so we will pull out each variable for plotting.
-
-height = isobaric_levels[0]
-temp = isobaric_levels[1]
+height, temp = mcalc.log_interp(plevs, pres, hgt, temperature, axis=1)
 
 ####################################
 # **Plotting the Data for 700 hPa.**
@@ -96,8 +91,8 @@ plt.clabel(cs, fontsize=10, inline=1, inline_spacing=7,
 
 # Contour the temperature
 cf = ax.contourf(tlons, tlats, temp[FH, 0, :, :], range(-20, 20, 1), cmap=plt.cm.jet)
-cb = plt.colorbar(cf, orientation='horizontal', extend=max, aspect=65, shrink=0.5, pad=0.05,
-                  extendrect='True')
+cb = plt.colorbar(cf, orientation='horizontal', extend='max', aspect=65, shrink=0.5,
+                  pad=0.05, extendrect='True')
 cb.set_label('Celsius', size='x-large')
 
 ax.set_extent([-106.5, -90.4, 34.5, 46.75], crs=ccrs.PlateCarree())


### PR DESCRIPTION
This adresses issue #616.

Removed isobaric_levels variable and replace it with height and temp variables.

Correct the extend value in the colorbar call from a function max to a string 'max'.