### PR TITLE
Add calls to 'add_timestamp' to examples

### DIFF
--- a/examples/formats/GINI_Water_Vapor.py
+++ b/examples/formats/GINI_Water_Vapor.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 
 from metpy.cbook import get_test_data
 from metpy.io import GiniFile
-from metpy.plots import add_metpy_logo, ctables, add_timestamp
+from metpy.plots import add_metpy_logo, add_timestamp, ctables
 
 ###########################################
 

--- a/examples/formats/GINI_Water_Vapor.py
+++ b/examples/formats/GINI_Water_Vapor.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 
 from metpy.cbook import get_test_data
 from metpy.io import GiniFile
-from metpy.plots import add_metpy_logo, ctables
+from metpy.plots import add_metpy_logo, ctables, add_timestamp
 
 ###########################################
 
@@ -54,5 +54,6 @@ wv_cmap.set_under('k')
 im = ax.imshow(dat[:], cmap=wv_cmap, norm=wv_norm, zorder=0,
                extent=ds.img_extent, origin='upper')
 ax.coastlines(resolution='50m', zorder=2, color='black')
+add_timestamp(ax, f.prod_desc.datetime, y=0.02, high_contrast=True)
 
 plt.show()

--- a/examples/formats/NEXRAD_Level_2_File.py
+++ b/examples/formats/NEXRAD_Level_2_File.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from metpy.cbook import get_test_data
 from metpy.io import Level2File
-from metpy.plots import add_metpy_logo, ctables
+from metpy.plots import add_metpy_logo, add_timestamp, ctables
 
 ###########################################
 
@@ -42,7 +42,7 @@ rho = np.array([ray[4][b'RHO'][1] for ray in f.sweeps[sweep]])
 
 ###########################################
 fig, axes = plt.subplots(1, 2, figsize=(15, 8))
-add_metpy_logo(fig, 1200, 85, size='large')
+add_metpy_logo(fig, 190, 85, size='large')
 for var_data, var_range, ax in zip((ref, rho), (ref_range, rho_range), axes):
     # Turn into an array, then mask
     data = np.ma.array(var_data)
@@ -58,5 +58,6 @@ for var_data, var_range, ax in zip((ref, rho), (ref_range, rho_range), axes):
     ax.set_aspect('equal', 'datalim')
     ax.set_xlim(-40, 20)
     ax.set_ylim(-30, 30)
+    add_timestamp(ax, f.dt, y=0.02, high_contrast=True)
 
 plt.show()

--- a/examples/formats/NEXRAD_Level_3_File.py
+++ b/examples/formats/NEXRAD_Level_3_File.py
@@ -12,11 +12,11 @@ import numpy as np
 
 from metpy.cbook import get_test_data
 from metpy.io import Level3File
-from metpy.plots import add_metpy_logo, ctables
+from metpy.plots import add_metpy_logo, add_timestamp, ctables
 
 ###########################################
 fig, axes = plt.subplots(1, 2, figsize=(15, 8))
-add_metpy_logo(fig, 1200, 85, size='large')
+add_metpy_logo(fig, 190, 85, size='large')
 for v, ctable, ax in zip(('N0Q', 'N0U'), ('NWSReflectivity', 'NWSVelocity'), axes):
     # Open the file
     name = get_test_data('nids/KOUN_SDUS54_{}TLX_201305202016'.format(v), as_file_obj=False)
@@ -43,5 +43,6 @@ for v, ctable, ax in zip(('N0Q', 'N0U'), ('NWSReflectivity', 'NWSVelocity'), axe
     ax.set_aspect('equal', 'datalim')
     ax.set_xlim(-40, 20)
     ax.set_ylim(-30, 30)
+    add_timestamp(ax, f.metadata['prod_time'], y=0.02, high_contrast=True)
 
 plt.show()

--- a/examples/isentropic_example.py
+++ b/examples/isentropic_example.py
@@ -19,7 +19,7 @@ import numpy as np
 
 import metpy.calc as mcalc
 from metpy.cbook import get_test_data
-from metpy.plots import add_metpy_logo
+from metpy.plots import add_metpy_logo, add_timestamp
 from metpy.units import units
 
 #######################################
@@ -166,6 +166,7 @@ plt.title('{:.0f} K Isentropic Pressure (hPa), Wind (kt), Relative Humidity (per
           loc='left')
 plt.title('VALID: {:s}'.format(str(vtimes[0])), loc='right')
 plt.tight_layout()
+add_timestamp(ax, vtimes[0], y=0.02, high_contrast=True)
 
 ######################################
 # **Montgomery Streamfunction**
@@ -212,4 +213,6 @@ plt.title('{:.0f} K Montgomery Streamfunction '.format(isentlevs[level].m) +
           'Wind (kt), Relative Humidity (percent)', loc='left')
 plt.title('VALID: {:s}'.format(str(vtimes[0])), loc='right')
 plt.tight_layout()
+add_timestamp(ax, vtimes[0], y=0.02, high_contrast=True)
+
 plt.show()

--- a/examples/sigma_to_pressure_interpolation.py
+++ b/examples/sigma_to_pressure_interpolation.py
@@ -17,7 +17,7 @@ from netCDF4 import Dataset, num2date
 
 import metpy.calc as mcalc
 from metpy.cbook import get_test_data
-from metpy.plots import add_metpy_logo
+from metpy.plots import add_metpy_logo, add_timestamp
 from metpy.units import units
 
 ######################################
@@ -103,4 +103,6 @@ ax.set_title('{:.0f} hPa Heights (m) and Temperature (C)'.format(plevs[0].m), lo
 
 # Set the figure title
 fig.suptitle('WRF-ARW Forecast VALID: {:s} UTC'.format(str(vtimes[FH])), fontsize=14)
+add_timestamp(ax, vtimes[FH], y=0.02, high_contrast=True)
+
 plt.show()


### PR DESCRIPTION
Closes #708 

Added 'add_timestamp' to the imports in GINI example file then called 'add_timestamp' at the end of the code to display the timestamp on the product.

- [X] added to GINI_Water_Vapor.py file

Could be added to these files:

- [X] added to sigma_to_pressure_interpolation.py file
- [X] added to isentropic_example.py file
- [X] added to formats/NEXRAD_Level_2_File.py file
- [X] added to formats/NEXRAD_Level_3_File.py file
