### PR TITLE
Wet Bulb Temperature

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -45,6 +45,12 @@ References
 .. [Hobbs2006] Hobbs, P. V., and J. M. Wallace, 2006: *Atmospheric Science: An Introductory
            Survey*. 2nd ed. Academic Press, 504 pp.
 
+.. [Knox2017] Knox, John A., David S. Nevius, and Pamela N. Knox., 2017: Two Simple and
+              Accurate Approximations for Wet-Bulb Temperature in Moist Conditions, with
+              Forecasting Applications. *Bulletin of the American Meteorological Society*,
+              **98.9**, 1897-1906, doi:
+              `10.1175/BAMS-D-16-0246.1 <https://doi.org/10.1175/BAMS-D-16-0246.1>`_.
+
 .. [Lackmann2011] Lackmann, G., 2011: *Midlatitude Synoptic Meteorology*. Amer. Meteor. Soc.,
            345 pp.
 

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -887,3 +887,27 @@ def test_wet_bulb_temperature():
     val = wet_bulb_temperature(1000 * units.hPa, 25 * units.degC, 15 * units.degC)
     truth = 18.34345936 * units.degC
     assert_almost_equal(val, truth)
+
+
+def test_wet_bulb_temperature_1d():
+    """Test wet bulb calculation with 1d list."""
+    pressures = [1013, 1000, 990] * units.hPa
+    temperatures = [25, 20, 15] * units.degC
+    dewpoints = [20, 15, 10] * units.degC
+    val = wet_bulb_temperature(pressures, temperatures, dewpoints)
+    truth = [21.4449794, 16.7368576, 12.0656909] * units.degC
+    assert_array_almost_equal(val, truth)
+
+
+def test_wet_bulb_temperature_2d():
+    """Test wet bulb calculation with 2d list."""
+    pressures = [[1013, 1000, 990],
+                 [1012, 999, 989]] * units.hPa
+    temperatures = [[25, 20, 15],
+                    [24, 19, 14]] * units.degC
+    dewpoints = [[20, 15, 10],
+                 [19, 14, 9]] * units.degC
+    val = wet_bulb_temperature(pressures, temperatures, dewpoints)
+    truth = [[21.4449794, 16.7368576, 12.0656909],
+             [20.5021631, 15.801218, 11.1361878]] * units.degC
+    assert_array_almost_equal(val, truth)

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -885,7 +885,7 @@ def test_brunt_vaisala_period():
 def test_wet_bulb_temperature():
     """Test wet bulb calculation with scalars."""
     val = wet_bulb_temperature(1000 * units.hPa, 25 * units.degC, 15 * units.degC)
-    truth = 18.34345936 * units.degC
+    truth = 18.34345936 * units.degC  # 18.59 from NWS calculator
     assert_almost_equal(val, truth)
 
 
@@ -896,6 +896,7 @@ def test_wet_bulb_temperature_1d():
     dewpoints = [20, 15, 10] * units.degC
     val = wet_bulb_temperature(pressures, temperatures, dewpoints)
     truth = [21.4449794, 16.7368576, 12.0656909] * units.degC
+    # 21.58, 16.86, 12.18 from NWS Calculator
     assert_array_almost_equal(val, truth)
 
 
@@ -910,4 +911,6 @@ def test_wet_bulb_temperature_2d():
     val = wet_bulb_temperature(pressures, temperatures, dewpoints)
     truth = [[21.4449794, 16.7368576, 12.0656909],
              [20.5021631, 15.801218, 11.1361878]] * units.degC
+    # 21.58, 16.86, 12.18
+    # 20.6, 15.9, 11.2 from NWS Calculator
     assert_array_almost_equal(val, truth)

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -24,7 +24,8 @@ from metpy.calc import (brunt_vaisala_frequency, brunt_vaisala_frequency_squared
                         specific_humidity_from_mixing_ratio,
                         surface_based_cape_cin, thickness_hydrostatic,
                         thickness_hydrostatic_from_relative_humidity, vapor_pressure,
-                        virtual_potential_temperature, virtual_temperature)
+                        virtual_potential_temperature, virtual_temperature,
+                        wet_bulb_temperature)
 from metpy.calc.thermo import _find_append_zero_crossings
 from metpy.testing import assert_almost_equal, assert_array_almost_equal, assert_nan
 from metpy.units import units
@@ -879,3 +880,10 @@ def test_brunt_vaisala_period():
              [545.80233643, np.nan, np.nan, 385.94053328]] * units('s')
     bv_period = brunt_vaisala_period(bv_data()[0], bv_data()[1])
     assert_almost_equal(bv_period, truth, 6)
+
+
+def test_wet_bulb_temperature():
+    """Test wet bulb calculation with scalars."""
+    val = wet_bulb_temperature(1000 * units.hPa, 25 * units.degC, 15 * units.degC)
+    truth = 18.34345936 * units.degC
+    assert_almost_equal(val, truth)

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -1837,6 +1837,7 @@ def wet_bulb_temperature(pressure, temperature, dewpoint):
 
     This function calculates the wet-bulb temperature using the Normand method. The LCL is
     computed, and that parcel brought down to the starting pressure along a moist adiabat.
+    Norman method (and others) described and compared by [Knox2017]_.
 
     Parameters
     ----------

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -1858,7 +1858,6 @@ def wet_bulb_temperature(pressure, temperature, dewpoint):
     lcl, moist_lapse
 
     """
-
     if not hasattr(pressure, 'shape'):
         pressure = atleast_1d(pressure)
         temperature = atleast_1d(temperature)
@@ -1868,12 +1867,12 @@ def wet_bulb_temperature(pressure, temperature, dewpoint):
                    op_dtypes=['float', 'float', 'float', 'float'],
                    flags=['buffered'])
 
-    for p, T, Td, ret in it:
-        p = p * pressure.units
-        T = T * temperature.units
-        Td = Td * dewpoint.units
-        lcl_pressure, lcl_temperature = lcl(p, T, Td)
-        moist_adiabat_temperatures = moist_lapse(concatenate([lcl_pressure, p]),
+    for press, temp, dewp, ret in it:
+        press = press * pressure.units
+        temp = temp * temperature.units
+        dewp = dewp * dewpoint.units
+        lcl_pressure, lcl_temperature = lcl(press, temp, dewp)
+        moist_adiabat_temperatures = moist_lapse(concatenate([lcl_pressure, press]),
                                                  lcl_temperature)
         ret[...] = moist_adiabat_temperatures[-1]
 

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -1828,3 +1828,36 @@ def brunt_vaisala_period(heights, potential_temperature, axis=0):
     bv_freq_squared[bv_freq_squared.magnitude <= 0] = np.nan
 
     return 2 * np.pi / np.sqrt(bv_freq_squared)
+
+
+@exporter.export
+@check_units('[pressure]', '[temperature]', '[temperature]')
+def wet_bulb_temperature(pressure, temperature, dewpoint):
+    """Calculate the wet-bulb temperature using Normand's rule.
+
+    This function calculates the wet-bulb temperature using the Normand method. The LCL is
+    computed, and that parcel brought down to the starting pressure along a moist adiabat.
+
+    Parameters
+    ----------
+    pressure : `pint.Quantity`
+        Initial atmospheric pressure
+    temperature : `pint.Quantity`
+        Initial atmospheric temperature
+    dewpoint : `pint.Quantity`
+        Initial atmospheric dewpoint
+
+    Returns
+    -------
+    array-like
+        Wet-bulb temperature
+
+    See Also
+    --------
+    lcl, moist_lapse
+
+    """
+    lcl_pressure, lcl_temperature = lcl(pressure, temperature, dewpoint)
+    moist_adiabat_temperatures = moist_lapse(concatenate([lcl_pressure, pressure]),
+                                             lcl_temperature)
+    return moist_adiabat_temperatures[-1]


### PR DESCRIPTION
Add web bulb temperature calculation using Normand's rule. Closes #409 

A few implementation questions:
- [x] Currently this only takes scalar values, passing arrays results in weird and no-so-wonderful behavior as LCL tries to operate on all of them at once. Do we check for length and iterate or only allow scalars?

- [x] @dopplershift - do you foresee any problems running `moist_lapse` backwards like this?

- [x] Need a real reference

- [x] Need tests

I'm getting within a few tenths of a degree of https://www.weather.gov/epz/wxcalc_dewpoint FWIW.