### PR TITLE
Fix Level3File

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,13 +11,19 @@ plugins:
     config:
       test_patterns:
         - "metpy/**/tests/*.py"
+    checks:
+      python:S3776:
+        enabled: false
+      python:S107:
+        enabled: false
+      python:S1542:
+        enabled: false
+
   pep8:
     enabled: true
     checks:
       E501:
         enabled: false
-  radon:
-    enabled: true
 
 exclude_patterns:
 - "versioneer.py"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,9 +1,16 @@
-engines:
-#  duplication:
-#    enabled: true
-#    config:
-#      languages:
-#      - python
+version: "2"
+checks:
+  file-lines:
+    enabled: false
+  similar-code:
+    enabled: false
+
+plugins:
+  sonar-python:
+    enabled: true
+    config:
+      test_patterns:
+        - "metpy/**/tests/*.py"
   pep8:
     enabled: true
     checks:
@@ -12,11 +19,7 @@ engines:
   radon:
     enabled: true
 
-ratings:
-  paths:
-  - "**/*.py"
-
-exclude_paths:
+exclude_patterns:
 - "versioneer.py"
 - "metpy/_version.py"
 - "metpy/io/_nexrad_msgs/msg*.py"

--- a/metpy/io/nexrad.py
+++ b/metpy/io/nexrad.py
@@ -20,6 +20,7 @@ from scipy.constants import day, milli
 
 from ._tools import (Array, BitField, Bits, bits_to_code, DictStruct, Enum, IOBuffer,
                      NamedStruct, open_as_needed, zlib_decompress_all_frames)
+from ..cbook import is_string_like
 from ..package_tools import Exporter
 
 exporter = Exporter(globals())
@@ -1536,6 +1537,7 @@ class Level3File(object):
 
         """
         fobj = open_as_needed(filename)
+        self.filename = filename if is_string_like(filename) else 'No File'
 
         # Just read in the entire set of data at once
         with contextlib.closing(fobj):

--- a/metpy/io/tests/test_nexrad.py
+++ b/metpy/io/tests/test_nexrad.py
@@ -73,6 +73,8 @@ def test_level3_files(fname):
         if 'data' in block:
             f.map_data(block['data'])
 
+    assert f.filename == fname
+
 
 tdwr_nids_files = glob.glob(os.path.join(get_test_data('nids', as_file_obj=False),
                                          'Level3_MCI_*'))
@@ -90,6 +92,12 @@ def test_basic():
     assert f.metadata['prod_time'].replace(second=0) == datetime(2014, 4, 7, 18, 5)
     assert f.metadata['vol_time'].replace(second=0) == datetime(2014, 4, 7, 18, 5)
     assert f.metadata['msg_time'].replace(second=0) == datetime(2014, 4, 7, 18, 6)
+    assert f.filename == get_test_data('nids/Level3_FFC_N0Q_20140407_1805.nids',
+                                       as_file_obj=False)
+
+    # At this point, really just want to make sure that __str__ is able to run and produce
+    # something not empty, the format is still up for grabs.
+    assert str(f)
 
 
 def test_tdwr():


### PR DESCRIPTION
So when we refactored the handling of files, we removed the filename attribute from Level3File. This attribute, it turns out, is used in all of the logging for the class, as well as __str__. More disturbingly, not one test screamed about it being broken. Fixed all of that.

I'm also tweaking the Code Climate config in the hope of making it a bit more useful and less noisy.
