### PR TITLE
Fix return types in docstrings of logo functions

### DIFF
--- a/metpy/plots/_util.py
+++ b/metpy/plots/_util.py
@@ -121,8 +121,8 @@ def add_metpy_logo(fig, x=10, y=25, zorder=100, size='small', **kwargs):
 
     Returns
     -------
-    fig : `matplotlib.figure`
-       The `figure` instance used for plotting
+    `matplotlib.image.FigureImage`
+       The `matplotlib.image.FigureImage` instance created
 
     """
     return _add_logo(fig, x=x, y=y, zorder=zorder, which='metpy', size=size, **kwargs)
@@ -149,8 +149,8 @@ def add_unidata_logo(fig, x=10, y=25, zorder=100, size='small', **kwargs):
 
     Returns
     -------
-    fig : `matplotlib.figure`
-       The `figure` instance used for plotting
+    `matplotlib.image.FigureImage`
+       The `matplotlib.image.FigureImage` instance created
 
     """
     return _add_logo(fig, x=x, y=y, zorder=zorder, which='unidata', size=size, **kwargs)


### PR DESCRIPTION
Closes #701.

Fixed return types in docstrings for add_metpy_logo and add_unidata_logo functions.