### PR TITLE
MNT: Fix Travis testing with CartoPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ before_install:
   - pkg-config --modversion proj;
   - if [[ $TASK == "docs" ]]; then
       export EXTRA_INSTALLS="cdm,doc,examples";
-      export EXTRA_PACKAGES="$EXTRA_PACKAGES Cython pillow sphinx_rtd_theme==0.2.5b1.post1 pytest";
+      export EXTRA_PACKAGES="$EXTRA_PACKAGES pillow sphinx_rtd_theme==0.2.5b1.post1 pytest";
     else
       export TEST_OPTS="--flake8 --mpl";
       if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then
@@ -97,6 +97,8 @@ before_install:
       fi;
     fi;
   - mkdir $WHEELDIR;
+  # Cython needs to be installed before even downloading CartoPy
+  - pip install Cython;
   - pip download -d $WHEELDIR ".[$EXTRA_INSTALLS]" $EXTRA_PACKAGES -f $WHEELHOUSE $PRE $VERSIONS;
   - touch $WHEELDIR/download_marker && ls -lrt $WHEELDIR;
   - travis_wait pip wheel -w $WHEELDIR $EXTRA_PACKAGES -f $WHEELHOUSE $PRE $VERSIONS;

--- a/metpy/plots/tests/test_station_plot.py
+++ b/metpy/plots/tests/test_station_plot.py
@@ -270,7 +270,7 @@ def test_barb_projection():
     # Plot and check barbs (they should align with grid lines)
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1, projection=ccrs.LambertConformal())
-    ax.gridlines()
+    ax.gridlines(xlocs=[-135, -120, -105, -90, -75, -60, -45])
     sp = StationPlot(ax, x, y, transform=ccrs.PlateCarree())
     sp.plot_barb(u, v)
 


### PR DESCRIPTION
Need to explicitly install Cython for CartoPy to build. This needs to be
a global extra package since we use CartoPy for at least one test.