### PR TITLE
MNT: Tweak license text and update year

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ of the code you were using, as well as what operating system you are running.
 If possible, include complete, minimal example code that reproduces the problem.
 
 ## Pull Requests
-**Working on your first Pull Request?** You can learn how from this *free* video series [How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github), Aaron Meurer's [tutorial on the git workflow](http://www.asmeurer.com/git-workflow/), or the guide [“How to Contribute to Open Source"](https://opensource.guide/how-to-contribute/).
+**Working on your first Pull Request?** You can learn how from this *free* video series [How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github), Aaron Meurer's [tutorial on the git workflow](https://www.asmeurer.com/git-workflow/), or the guide [“How to Contribute to Open Source"](https://opensource.guide/how-to-contribute/).
 We love pull requests from everyone. Fork, then clone the repo:
 
     git clone git@github.com:your-username/metpy.git
@@ -113,7 +113,7 @@ Pull requests will automatically have tests run by Travis. This includes
 running both the unit tests as well as the `flake8` code linter.
 
 [pep8]: http://pep8.org
-[commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[commit]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 
 ## Other Channels
 If you're interested in contacting us or being a part of the community in

--- a/LICENSE
+++ b/LICENSE
@@ -1,30 +1,29 @@
-Copyright (c) 2008-2017, MetPy Developers.
+BSD 3-Clause License
+
+Copyright (c) 2008-2018, MetPy Developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
+modification, are permitted provided that the following conditions are met:
 
-    * Redistributions of source code must retain the above copyright
-       notice, this list of conditions and the following disclaimer.
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
 
-    * Redistributions in binary form must reproduce the above
-       copyright notice, this list of conditions and the following
-       disclaimer in the documentation and/or other materials provided
-       with the distribution.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
 
-    * Neither the name of the MetPy Developers nor the names of any
-       contributors may be used to endorse or promote products derived
-       from this software without specific prior written permission.
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/examples/formats/GINI_Water_Vapor.py
+++ b/examples/formats/GINI_Water_Vapor.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 MetPy Developers.
+# Copyright (c) 2015,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """

--- a/examples/formats/NEXRAD_Level_2_File.py
+++ b/examples/formats/NEXRAD_Level_2_File.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 MetPy Developers.
+# Copyright (c) 2015,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """

--- a/examples/formats/NEXRAD_Level_3_File.py
+++ b/examples/formats/NEXRAD_Level_3_File.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 MetPy Developers.
+# Copyright (c) 2015,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """

--- a/examples/isentropic_example.py
+++ b/examples/isentropic_example.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 MetPy Developers.
+# Copyright (c) 2017,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """

--- a/examples/sigma_to_pressure_interpolation.py
+++ b/examples/sigma_to_pressure_interpolation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 MetPy Developers.
+# Copyright (c) 2017,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """

--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009,2017 MetPy Developers.
+# Copyright (c) 2009,2017,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Contains calculation of kinematic parameters (e.g. divergence or vorticity)."""

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008,2015,2017 MetPy Developers.
+# Copyright (c) 2008,2015,2017,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Test the `kinematics` module."""

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008,2015,2016,2017 MetPy Developers.
+# Copyright (c) 2008,2015,2016,2017,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Test the `thermo` module."""

--- a/metpy/calc/tests/test_tools.py
+++ b/metpy/calc/tests/test_tools.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016,2017 MetPy Developers.
+# Copyright (c) 2016,2017,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Test the `tools` module."""

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008,2015,2016,2017 MetPy Developers.
+# Copyright (c) 2008,2015,2016,2017,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Contains a collection of thermodynamic calculations."""

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016,2017 MetPy Developers.
+# Copyright (c) 2016,2017,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Contains a collection of generally useful calculation tools."""

--- a/metpy/constants.py
+++ b/metpy/constants.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008,2015,2016 MetPy Developers.
+# Copyright (c) 2008,2015,2016,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/metpy/plots/_util.py
+++ b/metpy/plots/_util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015,2017 MetPy Developers.
+# Copyright (c) 2015,2017,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Utilities for use in making plots."""

--- a/metpy/plots/tests/test_util.py
+++ b/metpy/plots/tests/test_util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 MetPy Developers.
+# Copyright (c) 2017,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Tests for the `_util` module."""


### PR DESCRIPTION
Update to 2018.

Also pull a fresh copy of the license text from GitHub to hopefully fix the license detection. The changes in the text, besides line wrapping were:

- Replace "MetPy Developers" with "copyright holder" and "any contributors" with "its contributors" in the no endorsement clause
- Replace "COPYRIGHT OWNER" with "COPYRIGHT HOLDER" in the warranty disclaimer.