### PR TITLE
MNT: use `mpcalc` as import alias for `metpy.calc`

### DIFF
--- a/examples/calculations/Dewpoint_and_Mixing_Ratio.py
+++ b/examples/calculations/Dewpoint_and_Mixing_Ratio.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 MetPy Developers.
+# Copyright (c) 2015-2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """
@@ -12,7 +12,7 @@ a value for vapor pressure assuming both 1000mb and 850mb ambient air
 pressure values. It also demonstrates converting the resulting dewpoint
 temperature to degrees Fahrenheit.
 """
-import metpy.calc as mcalc
+import metpy.calc as mpcalc
 from metpy.units import units
 
 ###########################################
@@ -23,7 +23,7 @@ print(mixing)
 ###########################################
 # Now throw that value with units into the function to calculate
 # the corresponding vapor pressure, given a surface pressure of 1000 mb
-e = mcalc.vapor_pressure(1000. * units.mbar, mixing)
+e = mpcalc.vapor_pressure(1000. * units.mbar, mixing)
 print(e)
 
 ###########################################
@@ -32,7 +32,7 @@ print(e.to(units.mbar))
 
 ###########################################
 # Take the raw vapor pressure and throw into the dewpoint function
-td = mcalc.dewpoint(e)
+td = mpcalc.dewpoint(e)
 print(td)
 
 ###########################################
@@ -41,10 +41,10 @@ print(td.to('degF'))
 
 ###########################################
 # Now do the same thing for 850 mb, approximately the pressure of Denver
-e = mcalc.vapor_pressure(850. * units.mbar, mixing)
+e = mpcalc.vapor_pressure(850. * units.mbar, mixing)
 print(e.to(units.mbar))
 
 ###########################################
 # And print the corresponding dewpoint
-td = mcalc.dewpoint(e)
+td = mpcalc.dewpoint(e)
 print(td, td.to('degF'))

--- a/examples/isentropic_example.py
+++ b/examples/isentropic_example.py
@@ -6,7 +6,7 @@
 Isentropic Analysis
 ===================
 
-The MetPy function `mcalc.isentropic_interpolation` allows for isentropic analysis from model
+The MetPy function `mpcalc.isentropic_interpolation` allows for isentropic analysis from model
 analysis data in isobaric coordinates.
 """
 
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 from netCDF4 import Dataset, num2date
 import numpy as np
 
-import metpy.calc as mcalc
+import metpy.calc as mpcalc
 from metpy.cbook import get_test_data
 from metpy.plots import add_metpy_logo, add_timestamp
 from metpy.units import units
@@ -72,14 +72,14 @@ isentlevs = [296.] * units.kelvin
 # levels, and temperature be input. Any additional inputs (in this case relative humidity, u,
 # and v wind components) will be linearly interpolated to isentropic space.
 
-isent_anal = mcalc.isentropic_interpolation(isentlevs,
-                                            lev,
-                                            tmp,
-                                            spech,
-                                            uwnd,
-                                            vwnd,
-                                            hgt,
-                                            tmpk_out=True)
+isent_anal = mpcalc.isentropic_interpolation(isentlevs,
+                                             lev,
+                                             tmp,
+                                             spech,
+                                             uwnd,
+                                             vwnd,
+                                             hgt,
+                                             tmpk_out=True)
 
 #####################################
 # The output is a list, so now we will separate the variables to different names before
@@ -107,7 +107,7 @@ print(isenthgt.shape)
 # The NARR only gives specific humidity on isobaric vertical levels, so relative humidity will
 # have to be calculated after the interpolation to isentropic space.
 
-isentrh = 100 * mcalc.relative_humidity_from_specific_humidity(isentspech, isenttmp, isentprs)
+isentrh = 100 * mpcalc.relative_humidity_from_specific_humidity(isentspech, isenttmp, isentprs)
 
 #######################################
 # **Plotting the Isentropic Analysis**
@@ -173,11 +173,11 @@ add_timestamp(ax, vtimes[0], y=0.02, high_contrast=True)
 #
 # The Montgomery Streamfunction, :math:`{\psi} = gdz + CpT`, is often desired because its
 # gradient is proportional to the geostrophic wind in isentropic space. This can be easily
-# calculated with `mcalc.montgomery_streamfunction`.
+# calculated with `mpcalc.montgomery_streamfunction`.
 
 
 # Calculate Montgomery Streamfunction and scale by 10^-2 for plotting
-msf = mcalc.montgomery_streamfunction(isenthgt, isenttmp) / 100.
+msf = mpcalc.montgomery_streamfunction(isenthgt, isenttmp) / 100.
 
 # Choose a level to plot, in this case 296 K
 level = 0

--- a/examples/sigma_to_pressure_interpolation.py
+++ b/examples/sigma_to_pressure_interpolation.py
@@ -15,7 +15,7 @@ import cartopy.feature as cfeature
 import matplotlib.pyplot as plt
 from netCDF4 import Dataset, num2date
 
-import metpy.calc as mcalc
+import metpy.calc as mpcalc
 from metpy.cbook import get_test_data
 from metpy.plots import add_metpy_logo, add_timestamp
 from metpy.units import units
@@ -46,12 +46,12 @@ plevs = [700.] * units.hPa
 #
 # Now that the data is ready, we can interpolate to the new isobaric levels. The data is
 # interpolated from the irregular pressure values for each sigma level to the new input
-# mandatory isobaric levels. `mcalc.log_interp` will interpolate over a specified dimension
+# mandatory isobaric levels. `mpcalc.log_interp` will interpolate over a specified dimension
 # with the `axis` argument. In this case, `axis=1` will correspond to interpolation on the
 # vertical axis. The interpolated data is output in a list, so we will pull out each
 # variable for plotting.
 
-height, temp = mcalc.log_interp(plevs, pres, hgt, temperature, axis=1)
+height, temp = mpcalc.log_interp(plevs, pres, hgt, temperature, axis=1)
 
 ####################################
 # **Plotting the Data for 700 hPa.**

--- a/talks/2015 Unidata Users Workshop.ipynb
+++ b/talks/2015 Unidata Users Workshop.ipynb
@@ -454,7 +454,7 @@
    },
    "outputs": [],
    "source": [
-    "import metpy.calc as mcalc\n",
+    "import metpy.calc as mpcalc\n",
     "from metpy.units import units\n",
     "temp = 86 * units.degF\n",
     "press = 860. * units.mbar\n",
@@ -489,7 +489,7 @@
     }
    ],
    "source": [
-    "dewpt = mcalc.dewpoint_rh(temp, humidity).to('degF')\n",
+    "dewpt = mpcalc.dewpoint_rh(temp, humidity).to('degF')\n",
     "dewpt"
    ]
   },
@@ -532,7 +532,7 @@
     }
    ],
    "source": [
-    "mcalc.lcl(press, temp, dewpt)"
+    "mpcalc.lcl(press, temp, dewpt)"
    ]
   },
   {
@@ -576,7 +576,7 @@
    "source": [
     "import numpy as np\n",
     "pressure_levels = np.array([860., 850., 700., 500., 300.]) * units.mbar\n",
-    "mcalc.parcel_profile(pressure_levels, temp, dewpt)"
+    "mpcalc.parcel_profile(pressure_levels, temp, dewpt)"
    ]
   },
   {
@@ -967,7 +967,7 @@
     "# Pull out data with some units\n",
     "p = (data['vertCoord'] * units('Pa')).to('mbar')\n",
     "T = data['Temperature_isobaric'] * units('kelvin')\n",
-    "Td = mcalc.dewpoint_rh(T, data['Relative_humidity_isobaric'] / 100.)\n",
+    "Td = mpcalc.dewpoint_rh(T, data['Relative_humidity_isobaric'] / 100.)\n",
     "u = data['ucomponent_of_wind_isobaric'] * units('m/s')\n",
     "v = data['vcomponent_of_wind_isobaric'] * units('m/s')\n",
     "\n",
@@ -1059,8 +1059,8 @@
     "\n",
     "# Some unit conversions\n",
     "speed = data['wind_speed'] * units('m/s')\n",
-    "data['u'],data['v'] = mcalc.get_wind_components(speed.to('knots'),\n",
-    "                                                data['wind_from_direction'] * units('degree'))\n",
+    "data['u'],data['v'] = mpcalc.get_wind_components(speed.to('knots'),\n",
+    "                                                 data['wind_from_direction'] * units('degree'))\n",
     "\n",
     "# Plot using basemap for now\n",
     "from mpl_toolkits.basemap import Basemap\n",

--- a/talks/MetPy Exercise.ipynb
+++ b/talks/MetPy Exercise.ipynb
@@ -12,7 +12,7 @@
     "from siphon.catalog import TDSCatalog\n",
     "from siphon.ncss import NCSS\n",
     "import numpy as np\n",
-    "import metpy.calc as mcalc\n",
+    "import metpy.calc as mpcalc\n",
     "from metpy.units import units, concatenate\n",
     "from metpy.plots import SkewT"
    ]
@@ -195,8 +195,8 @@
    },
    "outputs": [],
    "source": [
-    "e = mcalc.saturation_vapor_pressure(data['dew_point_temperature'])\n",
-    "e_s = mcalc.saturation_vapor_pressure(data['air_temperature'])\n",
+    "e = mpcalc.saturation_vapor_pressure(data['dew_point_temperature'])\n",
+    "e_s = mpcalc.saturation_vapor_pressure(data['air_temperature'])\n",
     "rh = e / e_s"
    ]
   },
@@ -216,7 +216,7 @@
    "outputs": [],
    "source": [
     "# RH should be [0, 100]\n",
-    "hi = mcalc.heat_index(data['air_temperature'], rh * 100)"
+    "hi = mpcalc.heat_index(data['air_temperature'], rh * 100)"
    ]
   },
   {
@@ -412,7 +412,7 @@
    },
    "outputs": [],
    "source": [
-    "prof = mcalc.parcel_profile(p[::-1], T[-1], Td[-1])\n",
+    "prof = mpcalc.parcel_profile(p[::-1], T[-1], Td[-1])\n",
     "skew.plot(p[::-1], prof.to('degC'), 'k', linewidth=2)\n",
     "fig"
    ]
@@ -432,8 +432,8 @@
    },
    "outputs": [],
    "source": [
-    "lcl = mcalc.lcl(p[-1], T[-1], Td[-1])\n",
-    "lcl_temp = mcalc.dry_lapse(concatenate((p[-1], lcl)), T[-1])[-1].to('degC')\n",
+    "lcl = mpcalc.lcl(p[-1], T[-1], Td[-1])\n",
+    "lcl_temp = mpcalc.dry_lapse(concatenate((p[-1], lcl)), T[-1])[-1].to('degC')\n",
     "skew.plot(lcl, lcl_temp, 'bo')\n",
     "skew.ax.axvline(0, color='blue', linestyle='--', linewidth=2)\n",
     "fig"


### PR DESCRIPTION
fixes #756