### PR TITLE
Potential vorticity

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,6 +6,9 @@ checks:
     enabled: false
   method-lines:
     enabled: false
+  argument-count:
+    config:
+      threshold: 10
 
 plugins:
   sonar-python:


### PR DESCRIPTION
Addresses #650 by adding a potential vorticity calculation that is versatile in terms of array ordering (x, y, levels) or (levels, x, y) for example. From my understanding of PV if the user gives us winds on an isentropic surface this is IPV (theta is constant across each of the three layers given, pressure varies) and if the user gives us winds on an isobaric surface it is isobaric PV (theta varies across three layers of constant pressure). A few things to consider here:

* [x] I have more tests in a notebook, but this test is rather highly coupled. I like it because we're making the derivative something we can easily do by hand. Also doing some subtraction to a zeroed out answer makes the test objective very clear. It's more computation to do it this way and we lose units (that would be covered in another test). Thoughts?

* [x] Am I missing anything on isentropic vs isobaric here? @kgoebber 

* [x] I think we'll need a bit more narrative documentation before this goes in. 

* [x] Any preference on the reference? I'm thinking *book of Holton*