### PR TITLE
Coriolis units to 1/s

### DIFF
--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -382,7 +382,7 @@ def coriolis_parameter(latitude):
 
     """
     latitude = _check_radians(latitude, max_radians=np.pi / 2)
-    return 2. * omega * np.sin(latitude)
+    return (2. * omega * np.sin(latitude)).to('1/s')
 
 
 @exporter.export

--- a/metpy/calc/tests/test_basic.py
+++ b/metpy/calc/tests/test_basic.py
@@ -310,3 +310,9 @@ def test_coriolis_warning():
         coriolis_parameter(50)
     with pytest.warns(UserWarning):
         coriolis_parameter(-50)
+
+
+def test_coriolis_units():
+    """Test that coriolis returns units of 1/second."""
+    f = coriolis_parameter(50 * units.degrees)
+    assert f.units == units('1/second')


### PR DESCRIPTION
Closes #773 by forcing the output of Coriolis parameter calculations to be 1/s. This makes geostrophic wind units much more pleasant. It's also just a more useful default output.