### PR TITLE
Geod kwarg override

### DIFF
--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -707,7 +707,9 @@ def lat_lon_grid_deltas(longitude, latitude, **kwargs):
         longitude, latitude = np.meshgrid(longitude, latitude)
 
     geod_args = {'ellps': 'sphere'}
-    geod_args.update(**kwargs)
+    if kwargs:
+        geod_args = kwargs
+
     g = Geod(**geod_args)
 
     forward_az, _, dy = g.inv(longitude[:-1, :], latitude[:-1, :], longitude[1:, :],

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -844,3 +844,20 @@ def test_potential_vorticity_barotropic(pv_data):
     avor = absolute_vorticity(u.T, v.T, dx.T, dy.T, lats.T, dim_order='xy')
     truth = avor / heights.T
     assert_almost_equal(pv, truth, 10)
+
+
+def test_lat_lon_grid_deltas_geod_kwargs():
+    """Test that geod kwargs are overridden by users #774."""
+    lat = np.arange(40, 50, 2.5)
+    lon = np.arange(-100, -90, 2.5)
+    dx, dy = lat_lon_grid_deltas(lon, lat, a=4370997)
+    dx_truth = np.array([[146095.76101984, 146095.76101984, 146095.76101984],
+                         [140608.9751528, 140608.9751528, 140608.9751528],
+                         [134854.56713287, 134854.56713287, 134854.56713287],
+                         [128843.49645823, 128843.49645823, 128843.49645823]]) * units.meter
+    dy_truth = np.array([[190720.72311199, 190720.72311199, 190720.72311199, 190720.72311199],
+                         [190720.72311199, 190720.72311199, 190720.72311199, 190720.72311199],
+                         [190720.72311199, 190720.72311199, 190720.72311199,
+                          190720.72311199]]) * units.meter
+    assert_almost_equal(dx, dx_truth, 4)
+    assert_almost_equal(dy, dy_truth, 4)


### PR DESCRIPTION
Closes #774. Users could specify a custom Earth major/minor diameter and the output of the function would not change as the default `ellps` kwarg is sphere and apparently `geod` ignores everything else after that.