### PR TITLE
Add Q-vector and Static Stability Calculations

### DIFF
--- a/docs/gempak.rst
+++ b/docs/gempak.rst
@@ -1109,17 +1109,17 @@ blue is uncertain of parity, and white is unevaluated.
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">QVEC(S, V)</td>
-        <td class="tg-notimplemented">Q-vector at a level</td>
-        <td class="tg-notimplemented"><a href="https://github.com/Unidata/MetPy/issues/661">Issue #661</a></td>
+        <td class="tg-implemented">QVEC(S, V)</td>
+        <td class="tg-implemented">Q-vector at a level</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.q_vector.html#metpy.calc.q_vector">metpy.calc.q_vector</a></td>
         <td></td>
         <td></td>
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">QVCL(THTA, V)</td>
-        <td class="tg-notimplemented">Q-vector of a layer</td>
-        <td class="tg-notimplemented"><a href="https://github.com/Unidata/MetPy/issues/661">Issue #661</a></td>
+        <td class="tg-implemented">QVCL(THTA, V)</td>
+        <td class="tg-implemented">Q-vector of a layer</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.q_vector.html#metpy.calc.q_vector">metpy.calc.q_vector</a> (use with <a href="api/generated/metpy.calc.mixed_layer.html#metpy.calc.mixed_layer">metpy.calc.mixed_layer</a> to obtain layer average of each component)</td>
         <td></td>
         <td></td>
         <td></td>

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -11,6 +11,10 @@ References
            doi:`10.1175/1520-0450(1964)003%3C0396:ATFMDI%3E2.0.CO;2
            <https://doi.org/10.1175/1520-0450(1964)003%3C0396:ATFMDI%3E2.0.CO;2>`_.
 
+.. [Bluestein1992] Bluestein, H. B., 1992: *Principles of Kinematics and Dynamics.
+           Vol. 1, Synoptic-Dynamic Meteorology in Midlatitudes*. Oxford University Press,
+           448 pp.
+
 .. [Bluestein1993] Bluestein, H. B., 1993: *Observations and Theory of Weather Systems.
            Vol. 2, Synoptic-Dynamic Meteorology in Midlatitudes*. Oxford University Press,
            608 pp.

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -22,7 +22,7 @@ from metpy.calc import (brunt_vaisala_frequency, brunt_vaisala_frequency_squared
                         saturation_equivalent_potential_temperature,
                         saturation_mixing_ratio,
                         saturation_vapor_pressure,
-                        specific_humidity_from_mixing_ratio,
+                        specific_humidity_from_mixing_ratio, static_stability,
                         surface_based_cape_cin, temperature_from_potential_temperature,
                         thickness_hydrostatic,
                         thickness_hydrostatic_from_relative_humidity, vapor_pressure,
@@ -942,3 +942,29 @@ def test_wet_bulb_temperature_2d():
     # 21.58, 16.86, 12.18
     # 20.6, 15.9, 11.2 from NWS Calculator
     assert_array_almost_equal(val, truth)
+
+
+def test_static_stability_adiabatic():
+    """Test static stability calculation with a dry adiabatic profile."""
+    pressures = [1000., 900., 800., 700., 600., 500.] * units.hPa
+    temperature_start = 20 * units.degC
+    temperatures = dry_lapse(pressures, temperature_start)
+    sigma = static_stability(pressures, temperatures)
+    truth = np.zeros_like(pressures) * units('J kg^-1 hPa^-2')
+    # Should be zero with a dry adiabatic profile
+    assert_almost_equal(sigma, truth, 6)
+
+
+def test_static_stability_cross_section():
+    """Test static stability calculation with a 2D cross-section."""
+    pressures = [[850., 700., 500.],
+                 [850., 700., 500.],
+                 [850., 700., 500.]] * units.hPa
+    temperatures = [[17., 11., -10.],
+                    [16., 10., -11.],
+                    [11., 6., -12.]] * units.degC
+    sigma = static_stability(pressures, temperatures, axis=1)
+    truth = [[0.02819452, 0.02016804, 0.00305262],
+             [0.02808841, 0.01999462, 0.00274956],
+             [0.02840196, 0.02366708, 0.0131604]] * units('J kg^-1 hPa^-2')
+    assert_almost_equal(sigma, truth, 6)

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -2023,3 +2023,34 @@ def wet_bulb_temperature(pressure, temperature, dewpoint):
     if it.operands[3].size == 1:
         return it.operands[3][0] * moist_adiabat_temperatures.units
     return it.operands[3] * moist_adiabat_temperatures.units
+
+
+@exporter.export
+@check_units('[pressure]', '[temperature]')
+def static_stability(pressure, temperature, axis=0):
+    r"""Calculate the static stability within a vertical profile.
+
+    .. math:: \sigma = -\frac{RT}{p} \frac{\partial \ln \theta}{\partial p}
+
+    This formuala is based on equation 4.3.6 in [Bluestein1992]_.
+
+    Parameters
+    ----------
+    pressure : array-like
+        Profile of atmospheric pressure
+    temperature : array-like
+        Profile of temperature
+    axis : int, optional
+        The axis corresponding to vertical in the pressure and temperature arrays, defaults
+        to 0.
+
+    Returns
+    -------
+    array-like
+        The profile of static stability.
+
+    """
+    theta = potential_temperature(pressure, temperature)
+
+    return - Rd * temperature / pressure * first_derivative(np.log(theta / units.K),
+                                                            x=pressure, axis=axis)


### PR DESCRIPTION
Implements the Q-vector and static stability calculations as discussed in #661, based of formulas from Bluestein 1992. Closes #661.

Also, I don't know what the best way to test these functions is, since I've only really worked with Q-vectors in a graphical context, and static stability in a qualitative context. So, feedback on the tests is especially appreciated!