### PR TITLE
Remove `keys()`

### DIFF
--- a/metpy/calc/tests/test_turbulence.py
+++ b/metpy/calc/tests/test_turbulence.py
@@ -239,9 +239,7 @@ def test_kf_2d_axis_last_zero_mean(uvw_and_known_kf_zero_mean):
     u = np.array([u, u, u])
     v = np.array([v, v, v])
     w = np.array([w, w, w])
-    for key in kf_true.keys():
-        tmp = kf_true[key]
-        kf_true[key] = np.array([tmp, tmp, tmp])
+
     assert_array_equal(kinematic_flux(u, v, perturbation=False, axis=-1),
                        kf_true['uv'])
     assert_array_equal(kinematic_flux(u, w, perturbation=False, axis=-1),
@@ -264,9 +262,7 @@ def test_kf_2d_axis_last_nonzero_mean(uvw_and_known_kf_nonzero_mean):
     u = np.array([u, u, u])
     v = np.array([v, v, v])
     w = np.array([w, w, w])
-    for key in kf_true.keys():
-        tmp = kf_true[key]
-        kf_true[key] = np.array([tmp, tmp, tmp])
+
     assert_array_equal(kinematic_flux(u, v, perturbation=False, axis=-1),
                        kf_true['uv'])
     assert_array_equal(kinematic_flux(u, w, perturbation=False, axis=-1),
@@ -281,9 +277,7 @@ def test_kf_2d_axis_first_zero_mean(uvw_and_known_kf_zero_mean):
     u = np.array([u, u, u]).transpose()
     v = np.array([v, v, v]).transpose()
     w = np.array([w, w, w]).transpose()
-    for key in kf_true.keys():
-        tmp = kf_true[key]
-        kf_true[key] = np.array([tmp, tmp, tmp]).transpose()
+
     assert_array_equal(kinematic_flux(u, v, perturbation=False, axis=0),
                        kf_true['uv'])
     assert_array_equal(kinematic_flux(u, w, perturbation=False, axis=0),
@@ -306,9 +300,7 @@ def test_kf_2d_axis_first_nonzero_mean(uvw_and_known_kf_nonzero_mean):
     u = np.array([u, u, u]).transpose()
     v = np.array([v, v, v]).transpose()
     w = np.array([w, w, w]).transpose()
-    for key in kf_true.keys():
-        tmp = kf_true[key]
-        kf_true[key] = np.array([tmp, tmp, tmp]).transpose()
+
     assert_array_equal(kinematic_flux(u, v, perturbation=False, axis=0),
                        kf_true['uv'])
     assert_array_equal(kinematic_flux(u, w, perturbation=False, axis=0),
@@ -364,9 +356,7 @@ def test_u_star_2d_axis_last_zero_mean(uvw_and_known_u_star_zero_mean):
     u = np.array([u, u, u])
     v = np.array([v, v, v])
     w = np.array([w, w, w])
-    for key in u_star_true.keys():
-        tmp = u_star_true[key]
-        u_star_true[key] = np.array([tmp, tmp, tmp])
+
     assert_almost_equal(friction_velocity(u, w, perturbation=False,
                         axis=-1), u_star_true['uw'])
     assert_almost_equal(friction_velocity(u, w, v=v, perturbation=False,
@@ -379,9 +369,7 @@ def test_u_star_2d_axis_last_nonzero_mean(uvw_and_known_u_star_nonzero_mean):
     u = np.array([u, u, u])
     v = np.array([v, v, v])
     w = np.array([w, w, w])
-    for key in u_star_true.keys():
-        tmp = u_star_true[key]
-        u_star_true[key] = np.array([tmp, tmp, tmp])
+
     assert_almost_equal(friction_velocity(u, w, perturbation=False,
                         axis=-1), u_star_true['uw'])
     assert_almost_equal(friction_velocity(u, w, v=v, perturbation=False,
@@ -394,9 +382,7 @@ def test_u_star_2d_axis_first_zero_mean(uvw_and_known_u_star_zero_mean):
     u = np.array([u, u, u]).transpose()
     v = np.array([v, v, v]).transpose()
     w = np.array([w, w, w]).transpose()
-    for key in u_star_true.keys():
-        tmp = u_star_true[key]
-        u_star_true[key] = np.array([tmp, tmp, tmp]).transpose()
+
     assert_almost_equal(friction_velocity(u, w, perturbation=False,
                         axis=0), u_star_true['uw'])
     assert_almost_equal(friction_velocity(u, w, v=v, perturbation=False,
@@ -409,9 +395,7 @@ def test_u_star_2d_axis_first_nonzero_mean(uvw_and_known_u_star_nonzero_mean):
     u = np.array([u, u, u]).transpose()
     v = np.array([v, v, v]).transpose()
     w = np.array([w, w, w]).transpose()
-    for key in u_star_true.keys():
-        tmp = u_star_true[key]
-        u_star_true[key] = np.array([tmp, tmp, tmp]).transpose()
+
     assert_almost_equal(friction_velocity(u, w, perturbation=False,
                         axis=0), u_star_true['uw'])
     assert_almost_equal(friction_velocity(u, w, v=v, perturbation=False,

--- a/metpy/io/nexrad.py
+++ b/metpy/io/nexrad.py
@@ -265,7 +265,7 @@ class Level2File(object):
         # Check if we have any message segments still in the buffer
         if self._msg_buf:
             log.warning('Remaining buffered messages segments for message type(s): %s',
-                        ' '.join(map(str, self._msg_buf.keys())))
+                        ' '.join(map(str, self._msg_buf)))
 
         del self._msg_buf
 

--- a/metpy/plots/ctables.py
+++ b/metpy/plots/ctables.py
@@ -28,7 +28,7 @@ specific set of constraints (e.g. step size) for mapping.
        for ax in axes:
            ax.set_axis_off()
 
-   cmaps = list(ctables.registry.keys())
+   cmaps = list(ctables.registry)
    cmaps = [name for name in cmaps if name[-2:]!='_r']
    nrows = len(cmaps)
    gradient = np.linspace(0, 1, 256)

--- a/talks/2015 Unidata Users Workshop.ipynb
+++ b/talks/2015 Unidata Users Workshop.ipynb
@@ -846,7 +846,7 @@
     "\n",
     "# Get the Data\n",
     "data = ncss.get_data(query)\n",
-    "list(data.variables.keys())"
+    "list(data.variables)"
    ]
   },
   {


### PR DESCRIPTION
Removing unneeded uses of the `dict.keys()` method.