### PR TITLE
Add new metpy/calc/tools parse_angle

### DIFF
--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -23,6 +23,15 @@ from ..units import atleast_1d, check_units, concatenate, diff, units
 
 exporter = Exporter(globals())
 
+DIR_STRS = [
+    'N', 'NNE', 'NE', 'ENE',
+    'E', 'ESE', 'SE', 'SSE',
+    'S', 'SSW', 'SW', 'WSW',
+    'W', 'WNW', 'NW', 'NNW'
+]
+
+BASE_DEGREE_MULTIPLIER = 22.5 * units.degree
+
 
 @exporter.export
 def resample_nn_1d(a, centers):
@@ -1126,3 +1135,44 @@ def _process_deriv_args(f, kwargs):
         raise ValueError('Must specify either "x" or "delta" for value positions.')
 
     return n, axis, delta
+
+
+@exporter.export
+def parse_angle(input_dir):
+    """Calculate the meteorological angle from directional text.
+
+    Works for abbrieviations or whole words (E -> 90 | South -> 180)
+    and also is able to parse 22.5 degreee angles such as ESE/East South East
+
+    Parameters
+    ----------
+    input_dir : string or array-like strings
+        Directional text such as west, [south-west, ne], etc
+
+    Returns
+    -------
+    angle
+        The angle in degrees
+
+    """
+    if len(input_dir) > 1 and not isinstance(input_dir, str):
+        return [parse_angle(single_dir) for single_dir in input_dir]
+    else:
+        input_dir = _abbrieviate_direction(input_dir)
+        for i, dir_str in enumerate(DIR_STRS):
+            if input_dir.upper() == dir_str:
+                return i * BASE_DEGREE_MULTIPLIER
+
+
+def _abbrieviate_direction(ext_dir_str):
+    """Convert extended (non-abbrievated) directions to abbrieviation."""
+    return (ext_dir_str
+            .upper()
+            .replace('_', '')
+            .replace('-', '')
+            .replace(' ', '')
+            .replace('NORTH', 'N')
+            .replace('EAST', 'E')
+            .replace('SOUTH', 'S')
+            .replace('WEST', 'W')
+            )


### PR DESCRIPTION
and its subfunction _abbrieviate_direction

parse_angle allows users to easily convert directional text into a degree/radian value
such as N becomes 0 deg, east becomes 90 deg, south_east becomes (135 deg) etc

First time contributing so a bit uncertain about the process!