### PR TITLE
ENH: Add Stack Overflow information (Fixes #782)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,5 +113,8 @@ running both the unit tests as well as the `flake8` code linter.
 ## Other Channels
 If you're interested in contacting us or being a part of the community in
 other ways, feel free to contact us in
-[MetPy's Gitter Channel](https://gitter.im/Unidata/MetPy) or through Unidata's
+[MetPy's Gitter Channel](https://gitter.im/Unidata/MetPy), ask questions using the
+["metpy" tag on Stack Overflow](https://stackoverflow.com/questions/tagged/metpy),
+email [Unidata's Python support address](mailto:support-python@unidata.ucar.edu),
+or through Unidata's
 [python-users](https://www.unidata.ucar.edu/support/#mailinglists) mailing list.

--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,7 @@ Important Links
 - HTML Documentation : http://unidata.github.io/MetPy
 - Unidata Python Gallery: https://unidata.github.io/python-gallery/
 - Issue tracker: http://github.com/Unidata/MetPy/issues
+- "metpy" tagged questions on Stack Overflow: https://stackoverflow.com/questions/tagged/metpy
 - Gitter chat room: https://gitter.im/Unidata/MetPy
 - Say Thanks: https://saythanks.io/to/unidata
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -5,9 +5,17 @@ are many ways to contact us:
 
 ## Help using MetPy
 Need some help using MetPy to solve your problem?
-* [Gitter Chatroom](https://gitter.im/Unidata/MetPy)
-* [Unidata Python User’s Mailing List](https://www.unidata.ucar.edu/support/#mailinglists)
+* [Stack Overflow](https://stackoverflow.com/questions/tagged/metpy): Ask a question using the
+  "metpy" tag. This is the highly preferred option as it allows the community to benefit from
+  answers to the questions, forming a readily-searched knowledge base. It's also likely to
+  result in the quickest response, as not only are the MetPy developers watching, but
+  community members can also chime in if they know the answer.
+* [Unidata Python Support email](mailto:support-python@unidata.ucar.edu): Send an email to
+  Unidata's Python support email address.
+* [Gitter](https://gitter.im/Unidata/MetPy): text-based chat with the developers; sign in
+  using GitHub or Twitter.
 * [MetPy on Twitter](https://twitter.com/MetPy)
+* [Unidata Python User’s Mailing List](https://www.unidata.ucar.edu/support/#mailinglists)
 
 ## Issues
 Find a problem with MetPy? Looking for a feature we don't have? File an issue!

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,19 +44,23 @@ We support Python 2.7 as well as Python >= 3.4.
 Contact Us
 ----------
 
-* For questions and discussion about MetPy, join Unidata's python-users_
-  mailing list
+* For questions about MetPy, please ask them using the "metpy" tag on StackOverflow_. Our
+  developers are actively monitoring for questions there.
+* You can also email `Unidata's
+  python support email address <mailto: support-python@unidata.ucar.edu>`_
 * The source code is available on GitHub_
 * Bug reports and feature requests should be directed to the
   `GitHub issue tracker`__
 * MetPy has a Gitter_ chatroom for more "live" communication
 * MetPy can also be found on Twitter_
 * If you use MetPy in a publication, please see :ref:`Citing_MetPy`.
+* For release announcements, join Unidata's python-users_ mailing list
 
 .. _python-users: https://www.unidata.ucar.edu/support/#mailinglists
 .. _GitHub: https://github.com/Unidata/MetPy
 .. _Gitter: https://gitter.im/Unidata/MetPy
 .. _Twitter: https://twitter.com/MetPy
+.. _StackOverflow: https://stackoverflow.com/questions/tagged/metpy
 __ https://github.com/Unidata/MetPy/issues
 
 -----


### PR DESCRIPTION
Updates all of the support, contact, etc. to include information about posting on Stack Overflow. Also mentions our support-python email.