### PR TITLE
Improve logging in NEXRAD Level 3

### DIFF
--- a/metpy/gridding/interpolation.py
+++ b/metpy/gridding/interpolation.py
@@ -15,9 +15,8 @@ from ..package_tools import Exporter
 
 exporter = Exporter(globals())
 
+logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
-log.addHandler(logging.StreamHandler())  # Python 2.7 needs a handler set
-log.setLevel(logging.WARNING)
 
 
 @exporter.export

--- a/metpy/gridding/points.py
+++ b/metpy/gridding/points.py
@@ -10,9 +10,8 @@ import logging
 import numpy as np
 from scipy.spatial import cKDTree
 
+logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
-log.addHandler(logging.StreamHandler())  # Python 2.7 needs a handler set
-log.setLevel(logging.WARNING)
 
 
 def get_points_within_r(center_points, target_points, r):

--- a/metpy/io/_tools.py
+++ b/metpy/io/_tools.py
@@ -14,8 +14,8 @@ import zlib
 
 from ..units import UndefinedUnitError, units
 
+logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
-log.setLevel(logging.WARNING)
 
 
 # This works around problems on early Python 2.7 where Struct.unpack_from() can't handle

--- a/metpy/io/gini.py
+++ b/metpy/io/gini.py
@@ -21,9 +21,8 @@ from ..package_tools import Exporter
 
 exporter = Exporter(globals())
 
+logging.basicConfig(level=logging.WARN)
 log = logging.getLogger(__name__)
-log.addHandler(logging.StreamHandler())  # Python 2.7 needs a handler set
-log.setLevel(logging.WARN)
 
 
 def _make_datetime(s):

--- a/metpy/io/nexrad.py
+++ b/metpy/io/nexrad.py
@@ -1665,7 +1665,7 @@ class Level3File(object):
 
     def _process_wmo_header(self):
         # Read off the WMO header if necessary
-        data = self._buffer.get_next(64).decode('utf-8', 'ignore')
+        data = self._buffer.get_next(64).decode('ascii', 'ignore')
         match = self.wmo_finder.search(data)
         if match:
             self.wmo_code = match.groups()[0]

--- a/metpy/io/nexrad.py
+++ b/metpy/io/nexrad.py
@@ -25,9 +25,8 @@ from ..package_tools import Exporter
 
 exporter = Exporter(globals())
 
+logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
-log.addHandler(logging.StreamHandler())  # Python 2.7 needs a handler set
-log.setLevel(logging.WARNING)
 
 
 def version(val):

--- a/metpy/io/nexrad.py
+++ b/metpy/io/nexrad.py
@@ -1574,8 +1574,14 @@ class Level3File(object):
         # Unpack the message header and the product description block
         msg_start = self._buffer.set_mark()
         self.header = self._buffer.read_struct(self.header_fmt)
-        # print(self.header, len(self._buffer), self.header.msg_len - self.header_fmt.size)
-        assert self._buffer.check_remains(self.header.msg_len - self.header_fmt.size)
+        log.debug('Buffer size: %d (%d expected) Header: %s', len(self._buffer),
+                  self.header.msg_len, self.header)
+
+        if not self._buffer.check_remains(self.header.msg_len - self.header_fmt.size):
+            log.warning('Product contains an unexpected amount of data remaining--have: %d '
+                        'expected: %d. This product may not parse correctly.',
+                        len(self._buffer) - self._buffer._offset,
+                        self.header.msg_len - self.header_fmt.size)
 
         # Handle GSM and jump out
         if self.header.code == 2:

--- a/metpy/io/nexrad.py
+++ b/metpy/io/nexrad.py
@@ -1667,6 +1667,7 @@ class Level3File(object):
         # Read off the WMO header if necessary
         data = self._buffer.get_next(64).decode('ascii', 'ignore')
         match = self.wmo_finder.search(data)
+        log.debug('WMO Header: %s', match)
         if match:
             self.wmo_code = match.groups()[0]
             self.siteID = match.groups()[-1]
@@ -1676,6 +1677,7 @@ class Level3File(object):
 
     def _process_end_bytes(self):
         check_bytes = self._buffer[-4:-1]
+        log.debug('End Bytes: %s', check_bytes)
         if check_bytes in (b'\r\r\n', b'\xff\xff\n'):
             self._buffer.truncate(4)
 

--- a/metpy/io/tests/test_nexrad.py
+++ b/metpy/io/tests/test_nexrad.py
@@ -100,6 +100,18 @@ def test_basic():
     assert str(f)
 
 
+def test_bad_length(caplog):
+    """Test reading a product with too many bytes produces a log message."""
+    fname = get_test_data('nids/KOUN_SDUS84_DAATLX_201305202016', as_file_obj=False)
+    with open(fname, 'rb') as inf:
+        data = inf.read()
+        fobj = BytesIO(data + data)
+
+    with caplog.at_level(logging.WARNING, 'metpy.io.nexrad'):
+        Level3File(fobj)
+        assert 'This product may not parse correctly' in caplog.records[0].message
+
+
 def test_tdwr():
     """Test reading a specific TDWR file."""
     f = Level3File(get_test_data('nids/Level3_SLC_TV0_20160516_2359.nids'))

--- a/metpy/plots/ctables.py
+++ b/metpy/plots/ctables.py
@@ -52,9 +52,8 @@ from pkg_resources import resource_listdir, resource_stream
 
 TABLE_EXT = '.tbl'
 
+logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
-log.addHandler(logging.StreamHandler())  # Python 2.7 needs a handler set
-log.setLevel(logging.WARNING)
 
 
 def _parse(s):


### PR DESCRIPTION
This tries to improve some diagnostic information. The difficulty was exposed in trying to understand an occasional exception that was causes by a file that was actually two concatenated together. This PR:
- Changes to use `logging.basicConfig()` to set up the default stream handler/formatting/level. This sets only the default level, so that our modules don't override user settings
- Adds some logging messages when searching for the WMO header and the footer bytes
- Changes an assert to a logged warning message (since we can recover in parsing some times)
- Changes a commented out print to a debug log message