### PR TITLE
Pandas unit helper

### DIFF
--- a/metpy/units.py
+++ b/metpy/units.py
@@ -32,6 +32,41 @@ units.define(pint.unit.UnitDefinition('percent', '%', (),
              pint.converters.ScaleConverter(0.01)))
 
 
+def pandas_dataframe_to_unit_arrays(df, column_units=None):
+    """Attach units to data in pandas dataframes and return united arrays.
+
+    Parameters
+    ----------
+    df : `pandas.DataFrame`
+        Data in pandas dataframe.
+
+    column_units : dict
+        Dictionary of units to attach to columns of the dataframe. Overrides
+        the units attribute if it is attached to the dataframe.
+
+    Returns
+    -------
+        Dictionary containing united arrays with keys corresponding to the dataframe
+        column names.
+
+    """
+    if not column_units:
+        try:
+            column_units = df.units
+        except AttributeError:
+            raise ValueError('No units attribute attached to pandas '
+                             'dataframe and col_units not given.')
+
+    # Iterate through columns attaching units if we have them, if not, don't touch it
+    res = {}
+    for column in df:
+        if column in column_units and column_units[column]:
+            res[column] = df[column].values * units(column_units[column])
+        else:
+            res[column] = df[column].values
+    return res
+
+
 def concatenate(arrs, axis=0):
     r"""Concatenate multiple values into a new unitized object.
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         'dev': ['ipython[all]>=3.1'],
         'doc': ['sphinx>=1.4', 'sphinx-gallery', 'doc8', 'recommonmark', 'netCDF4', 'pandas'],
         'examples': ['cartopy>=0.13.1', 'pandas'],
-        'test': ['pytest>=2.4', 'pytest-runner', 'pytest-mpl', 'pytest-flake8',
+        'test': ['pandas', 'pytest>=2.4', 'pytest-runner', 'pytest-mpl', 'pytest-flake8',
                  'cartopy>=0.13.1', 'flake8>3.2.0', 'flake8-builtins!=1.1.0',
                  'flake8-comprehensions', 'flake8-copyright',
                  'flake8-docstrings', 'flake8-import-order', 'flake8-mutable',


### PR DESCRIPTION
Closes #797 by providing a helper to make dealing with pandas data frames easier. It can attach units from a units attribute on the dataframe or from a dictionary provided by the user. Unspecified columns are returned as plain numpy arrays.