### PR TITLE
Documentation updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,10 @@ MetPy is still in an early stage of development, and as such
 just for fun, many things may still change as we work through
 design issues.
 
-We support Python 2.7 as well as Python >= 3.4.
+We support Python >= 3.4 and currently support Python 2.7.
+
+NOTE: We are dropping support for Python 2.7 in Fall 2019. See
+`here <https://github.com/Unidata/MetPy/docs/installguide.rst>`_ for more information.
 
 Need Help?
 ----------
@@ -105,7 +108,7 @@ Other required packages:
 - Matplotlib
 - Pint
 
-Python versions older than 3.4 require the enum34 package, which is a backport
+Python 2.7 requires the enum34 package, which is a backport
 of the standard library enum module.
 
 There is also an optional dependency on the pyproj library for geographic

--- a/README.rst
+++ b/README.rst
@@ -71,10 +71,11 @@ MetPy
 MetPy is a collection of tools in Python for reading, visualizing and
 performing calculations with weather data.
 
-MetPy is still in an early stage of development, and as such
-**no APIs are considered stable.** While we won't break things
-just for fun, many things may still change as we work through
-design issues.
+MetPy follows `semantic versioning <https://semver.org>`_ in its version number. With our
+current 0.x version, that implies that MetPy's APIs (application programming interfaces) are
+still evolving (we won't break things just for fun, but many things are still changing as we
+work through design issues). Also, for a version `0.x.y`, we change `x` when we
+release new features, and `y` when we make a release with only bug fixes.
 
 We support Python >= 3.4 and currently support Python 2.7.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,10 +28,11 @@ MetPy
 MetPy is a collection of tools in Python for reading, visualizing, and
 performing calculations with weather data.
 
-MetPy is still in an early stage of development, and as such
-**no APIs are considered stable.** While we won't break things
-just for fun, many things may still change as we work through
-design issues.
+MetPy follows `semantic versioning <https://semver.org>`_ in its version number. With our
+current 0.x version, that implies that MetPy's APIs (application programming interfaces) are
+still evolving (we won't break things just for fun, but many things are still changing as we
+work through design issues). Also, for a version `0.x.y`, we change `x` when we
+release new features, and `y` when we make a release with only bug fixes.
 
 We support Python >= 3.4 and currently support Python 2.7.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,3 @@
-.. MetPy documentation master file, created by
-   sphinx-quickstart on Wed Apr 22 15:27:44 2015.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 .. image:: _static/sounding.png
    :width: 150 px
    :align: left
@@ -38,7 +33,11 @@ MetPy is still in an early stage of development, and as such
 just for fun, many things may still change as we work through
 design issues.
 
-We support Python 2.7 as well as Python >= 3.4.
+We support Python >= 3.4 and currently support Python 2.7.
+
+.. warning::
+  We are dropping support for Python 2.7 in the Fall of 2019. For more details and rationale
+  behind this decision, see :ref:`python27`.
 
 ----------
 Contact Us

--- a/docs/installguide.rst
+++ b/docs/installguide.rst
@@ -2,12 +2,41 @@
 Installation Guide
 ==================
 
+.. _python27:
+
+------------------
+Python 2.7 Support
+------------------
+In the Fall 2019, we will be dropping support for Python 2.7. This follows movement from
+other packages within the `scientific Python ecosystem <http://python3statement.org/>`_.
+This includes:
+
+* Core Python developers will
+  `stop support for Python 2.7 January 1, 2020 <https://pythonclock.org/>`_
+* NumPy feature releases will be
+  `Python 3 only starting January 1, 2019 <https://docs.scipy.org/doc/numpy/neps/dropping-python2.7-proposal.html>`_,
+  and support for the last release supporting Python 2 will end January 1, 2020.
+* XArray will drop
+  `2.7 January 1, 2019 as well <https://github.com/pydata/xarray/issues/1830>`_
+* Matplotlib's 3.0 release, tentatively Summer 2018,
+  `will be Python 3 only <https://mail.python.org/pipermail/matplotlib-devel/2017-October/000892.html>`_;
+  the current 2.2 release will be the last long term release that supports 2.7, and its support
+  will cease January 1, 2020.
+
+The last release of MetPy before this time (Spring or Summer 2019) will be the last that
+support Python 2.7. This version of MetPy will **not** receive any long term support or
+additional bug fix releases after the next minor release. The packages for this version *will*
+remain available on Conda or PyPI.
+
 ------------
 Requirements
 ------------
-MetPy supports Python 2.7 as well as Python >= 3.4. Python 3.6 is the recommended version.
+In general, MetPy tries to support minor versions of dependencies released within the last two
+years. For Python itself, that means supporting the last two minor releases, as well as
+currently supporting Python 2.7.
 
-MetPy requires the following packages:
+MetPy currently supports the following versions of required dependencies:
+  - Python 2.7 or >=3.4
   - NumPy >= 1.10.0
   - SciPy >= 0.14.0
   - Matplotlib >= 1.4.0
@@ -21,7 +50,7 @@ Installation Instructions for Matplotlib can be found at:
 
 Pint is a pure python package and can be installed via ``pip install pint``.
 
-Python versions older than 3.4 require the enum34 package, which is a backport
+Python 2.7 requires the enum34 package, which is a backport
 of the enum standard library module. It can be installed via
 ``pip install enum34``.
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
                                   '_static/metpy_150x150.png', '_static/unidata_75x75.png',
                                   '_static/unidata_150x150.png']},
 
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=['matplotlib>=1.4', 'numpy>=1.10.0', 'scipy>=0.14',
                       'pint>=0.8', 'enum34;python_version<"3.4"'],
     extras_require={


### PR DESCRIPTION
Adds sections on semantic versioning (#802) and dropping Python 2.7 (#803). Also prepares `setup.py` for our future drop of Python 2.7.