### PR TITLE
Add downdraft CAPE calculation

### DIFF
--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -1048,13 +1048,17 @@ def test_dcape_custom_parcel_start():
                            13.1, 12.8, 12.7, 12.4, 12.4, 10, 7, 3.4]) * units.degC
     dewpoint = np.array([5.4, 3.6, 2.4, 1.8, 0.4, -0.2, 0.2, 0.4, 0.2, -5.5, -10.2,
                          -11.9, -21.4, -21.6, -21.8, -22, -21.4]) * units.degC
-    custom_parcel = (654.5 * units.hPa, 3.4 * units.degC)
+    custom_parcel = (670 * units.hPa, 3.5 * units.degC)
     dcape, dcape_pressure, dcape_temperature = downdraft_cape(pressure, temperature, dewpoint,
                                                               parcel=custom_parcel)
-    dcape_truth = 82.40213213698428 * units.joule / units.kilogram
-    dcape_pressure_truth = np.array([973, 943.5, 925, 910.6, 878.4]) * units.hPa
-    dcape_temperature_truth = np.array([17.95718657, 16.80836487,
-                                        16.06406211, 15.47121721, 14.1]) * units.degC
+    dcape_truth = 101.56717405359117 * units.joule / units.kilogram
+    dcape_pressure_truth = np.array([973, 943.5, 925, 910.6, 878.4, 865, 850, 848, 847.2,
+                                     816.9, 793, 787.8, 759.6, 759, 732.2, 700, 670]) * units.hPa
+    dcape_temperature_truth = np.array([19.0633538, 17.93772489, 17.20885559, 16.62853588,
+                                        15.2870874, 14.70992377, 14.04982066, 13.96065181,
+                                        13.92490675, 12.53726347, 11.39336396, 11.13832389,
+                                        9.71426456, 9.68318326, 8.25933429, 6.44940391,
+                                        4.65373642]) * units.degC
     assert_almost_equal(dcape, dcape_truth, 6)
     assert_almost_equal(dcape_pressure, dcape_pressure_truth, 6)
     assert_almost_equal(dcape_temperature, dcape_temperature_truth, 6)

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -1025,11 +1025,14 @@ def test_lfc_not_below_lcl():
 def test_dcape_defaults():
     """Test DCAPE with the default behavior."""
     pressure = np.array([973, 943.5, 925, 910.6, 878.4, 865, 850, 848, 847.2, 816.9,
-                        793, 787.8, 759.6, 759, 732.2, 700, 654.5]) * units.hPa
+                        793, 787.8, 759.6, 759, 732.2, 700, 654.5, 607.1,
+                        607, 580, 562, 549.]) * units.hPa
     temperature = np.array([23.4, 20.4, 18.4, 17.1, 14.1, 12.8, 13.2, 13.4, 13.4,
-                           13.1, 12.8, 12.7, 12.4, 12.4, 10, 7, 3.4]) * units.degC
+                           13.1, 12.8, 12.7, 12.4, 12.4, 10, 7, 3.4, -0.7,
+                           -0.7, -3.3, -5.5, -7.1]) * units.degC
     dewpoint = np.array([5.4, 3.6, 2.4, 1.8, 0.4, -0.2, 0.2, 0.4, 0.2, -5.5, -10.2,
-                         -11.9, -21.4, -21.6, -21.8, -22, -21.4]) * units.degC
+                         -11.9, -21.4, -21.6, -21.8, -22, -21.4, -20.7, -20.7,
+                         -38.3, -27.8, -20.1]) * units.degC
     dcape, dcape_pressure, dcape_temperature = downdraft_cape(pressure, temperature, dewpoint)
     dcape_truth = 74.11506371089433 * units.joule / units.kilogram
     dcape_pressure_truth = np.array([973, 943.5, 925, 910.6, 878.4]) * units.hPa

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -2110,7 +2110,7 @@ def dewpoint_from_specific_humidity(specific_humidity, temperature, pressure):
 @exporter.export
 @check_units('[pressure]', '[temperature]', '[temperature]')
 def downdraft_cape(pressure, temperature, dewpoint, parcel=None, bottom=None,
-                   heights=None, top_pressure=400 * units.hPa):
+                   heights=None, depth=400 * units.hPa):
     r"""Calculate downdraft CAPE.
 
     Calculate the downdraft convective available potential energy (CAPE).The minimum theta-e
@@ -2156,16 +2156,15 @@ def downdraft_cape(pressure, temperature, dewpoint, parcel=None, bottom=None,
     # If the user specified a parcel starting point, we'll use that instead of the default
     if parcel:
         parcel_starting_pressure, parcel_starting_temperature = parcel
-        profile_depth = np.nanmax(pressure) * pressure.units - parcel_starting_pressure
 
-        # Trim data to parcel starting point and below, interpolating the starting point
-        pressure, temperature = get_layer(pressure, temperature,
-                                          depth= profile_depth, heights=heights)
+        # Trim data to parcel starting point and below, as interpolating the starting point
+        #pressure, temperature = get_layer(pressure, temperature,
+                                          #depth=depth, heights=heights)
 
+        #profile_depth = np.nanmax(pressure) * pressure.units - parcel_starting_pressure - bottom
         # Trim data to be only above the bottom, interpolating if necessary. This must be done
         # in separate step as there is no way to specify the top of a layer, just depth.
-        pressure, temperature = get_layer(pressure, temperature, bottom=bottom,
-                                          depth= profile_depth, heights=heights)
+        pressure, temperature = get_layer(pressure, temperature, bottom=bottom, depth=depth, heights=heights)
 
     # The user did not give us a parcel, so we'll calculate a sensible default.
     else:

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -2156,18 +2156,16 @@ def downdraft_cape(pressure, temperature, dewpoint, parcel=None, bottom=None,
     # If the user specified a parcel starting point, we'll use that instead of the default
     if parcel:
         parcel_starting_pressure, parcel_starting_temperature = parcel
-        print(np.nanmax(pressure) * pressure.units - parcel_starting_pressure)
+        profile_depth = np.nanmax(pressure) * pressure.units - parcel_starting_pressure
+
         # Trim data to parcel starting point and below, interpolating the starting point
-        pressure, temperature, dewpoint = get_layer(pressure, temperature, dewpoint,
-                                                    depth=(np.nanmax(pressure) * pressure.units -
-                                                           parcel_starting_pressure),
-                                                    heights=heights)
+        pressure, temperature = get_layer(pressure, temperature,
+                                          depth= profile_depth, heights=heights)
 
         # Trim data to be only above the bottom, interpolating if necessary. This must be done
         # in separate step as there is no way to specify the top of a layer, just depth.
-        pressure, temperature, dewpoint = get_layer(pressure, temperature, dewpoint,
-                                                    bottom=bottom,
-                                                    heights=heights)
+        pressure, temperature = get_layer(pressure, temperature, bottom=bottom,
+                                          depth= profile_depth, heights=heights)
 
     # The user did not give us a parcel, so we'll calculate a sensible default.
     else:

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -2156,10 +2156,11 @@ def downdraft_cape(pressure, temperature, dewpoint, parcel=None, bottom=None,
     # If the user specified a parcel starting point, we'll use that instead of the default
     if parcel:
         parcel_starting_pressure, parcel_starting_temperature = parcel
-
+        print(np.nanmax(pressure) * pressure.units - parcel_starting_pressure)
         # Trim data to parcel starting point and below, interpolating the starting point
         pressure, temperature, dewpoint = get_layer(pressure, temperature, dewpoint,
-                                                    depth=np.nanmax(pressure) * pressure.units - parcel_starting_pressure,
+                                                    depth=(np.nanmax(pressure) * pressure.units -
+                                                           parcel_starting_pressure),
                                                     heights=heights)
 
         # Trim data to be only above the bottom, interpolating if necessary. This must be done
@@ -2168,13 +2169,18 @@ def downdraft_cape(pressure, temperature, dewpoint, parcel=None, bottom=None,
                                                     bottom=bottom,
                                                     heights=heights)
 
-
     # The user did not give us a parcel, so we'll calculate a sensible default.
     else:
 
+        # Determine the depth for this calculation and ensure that it's in the sounding
+        # range. If it's out of range, just use the available data.
+        calculation_depth = (np.nanmax(pressure) * pressure.units - top_pressure)
+        if _less_or_close(calculation_depth, np.nanmin(pressure) * pressure.units):
+            calculation_depth = None
+
         # Trim data to only top height and below as well as bottom height and above
         pressure, temperature, dewpoint = get_layer(pressure, temperature, dewpoint,
-                                                    depth=np.nanmax(pressure) * pressure.units - top_pressure,
+                                                    depth=calculation_depth,
                                                     bottom=bottom,
                                                     heights=heights)
 


### PR DESCRIPTION
Closes #728 by adding a downdraft CAPE calculation. As it stands there are still some things to discuss/clear up:

- [x] How should we let folks specify custom bounds for the integration? A custom parcel?
- [ ] Need to add tests

The main difficulty currently is that this does not appear to compare well with the SPC DCAPE values. Looking at their results I'm not sure there isn't a bug on one or both ends. Take the two soundings below. To me one should have positive DCAPE, the other negative as in one the parcel path is to the left of the environmental temperature, and it is to the right in the other. Also, to get values anywhere near as large as these I have to integrate the entire lower 400 hPa, not the surface up to the minimum theta-e in the lowest 400 hPa. Any comments welcome as we need to nail this down before testing and merging.
![oun-2](https://user-images.githubusercontent.com/325269/39194687-83e5542a-479b-11e8-873b-348f47e02603.gif)
![oun-3](https://user-images.githubusercontent.com/325269/39194688-83f70918-479b-11e8-9040-e2771ba9b31f.gif)

