### PR TITLE
LFC above LCL

### DIFF
--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -1003,3 +1003,20 @@ def test_dewpoint_specific_humidity():
     q = 0.012 * units.dimensionless
     td = dewpoint_from_specific_humidity(q, temperature, p)
     assert_almost_equal(td, 16.973 * units.degC, 3)
+
+
+def test_lfc_not_below_lcl():
+    """Test sounding where LFC appears to be (but isn't) below LCL."""
+    levels = np.array([1002.5, 1001.7, 1001., 1000.3, 999.7, 999., 998.2, 977.9,
+                       966.2, 952.3, 940.6, 930.5, 919.8, 909.1, 898.9, 888.4,
+                       878.3, 868.1, 858., 848., 837.2, 827., 816.7, 805.4]) * units.hPa
+    temperatures = np.array([17.9, 17.9, 17.8, 17.7, 17.7, 17.6, 17.5, 16.,
+                             15.2, 14.5, 13.8, 13., 12.5, 11.9, 11.4, 11.,
+                             10.3, 9.7, 9.2, 8.7, 8., 7.4, 6.8, 6.1]) * units.degC
+    dewpoints = np.array([13.6, 13.6, 13.5, 13.5, 13.5, 13.5, 13.4, 12.5,
+                          12.1, 11.8, 11.4, 11.3, 11., 9.3, 10., 8.7, 8.9,
+                          8.6, 8.1, 7.6, 7., 6.5, 6., 5.4]) * units.degC
+    lfc_pressure, lfc_temp = lfc(levels, temperatures, dewpoints)
+    # Before patch, LFC pressure would show 1000.5912165339967 hPa
+    assert_almost_equal(lfc_pressure, 811.8456357 * units.mbar, 6)
+    assert_almost_equal(lfc_temp, 6.4992871 * units.celsius, 6)

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -345,7 +345,13 @@ def lfc(pressure, temperature, dewpt, parcel_temperature_profile=None):
     # that point to get the real first intersection for the LFC calculation.
     x, y = find_intersections(pressure[1:], parcel_temperature_profile[1:],
                               temperature[1:], direction='increasing')
-    # Two possible cases here: LFC = LCL, or LFC doesn't exist
+
+    # The LFC could:
+    # 1) Not exist
+    # 2) Exist but be equal to the LCL
+    # 3) Exist and be above the LCL
+
+    # LFC does not exist or is LCL
     if len(x) == 0:
         if np.all(_less_or_close(parcel_temperature_profile, temperature)):
             # LFC doesn't exist
@@ -353,7 +359,12 @@ def lfc(pressure, temperature, dewpt, parcel_temperature_profile=None):
         else:  # LFC = LCL
             x, y = lcl(pressure[0], temperature[0], dewpt[0])
             return x, y
+
+    # LFC exists and is not LCL. Make sure it is above the LCL.
     else:
+        idx = x < lcl(pressure[0], temperature[0], dewpt[0])[0]
+        x = x[idx]
+        y = y[idx]
         return x[0], y[0]
 
 


### PR DESCRIPTION
A user emailed with the attached sounding data file in which the LFC calculated was below the LCL. After looking in the sounding manual and discussing with @kgoebber - it's safe to say that the LFC *must* be at or above the LCL. This adds a check for that.

Reading example:
```python
data= '04261800z.rtso'

df = pd.read_csv(data,sep='\s{1,}',skiprows=10,engine='python',names=["flightTime","pressure","temperature","relhumidity",\
                                     "height","dewpoint","refractiveindex",\
                                     "gradrefractindex","modrefracindex",\
                                     "speedofsound","density","vaporpress",\
                                     "potentialtemp","virtualtemp","spechum",\
                                     "spare1","spare2","spare3","spare4",\
                                     "utcsecs","speed","direction","vcomp",\
                                     "ucomp","vertwind","long","lat",\
                                     "geometricheight"],na_values=('/////./',\
                                     '////./','///./','//./','/////.//'))

df = df.dropna(subset=('temperature', 'dewpoint', 'direction', 'speed',
                       'vcomp', 'ucomp'), how='any').reset_index(drop=True)

df = df.drop_duplicates('pressure')

p = df['pressure'].values * units.hPa
T = df['temperature'].values * units.degC
Td = df['dewpoint'].values * units.degC
```

[04261800z.rtso.txt](https://github.com/Unidata/MetPy/files/1956742/04261800z.rtso.txt)
