### PR TITLE
Hodograph units

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - pytest-flake8
   - pytest-mpl
   - pytest-runner
-  - flake8-builtins!=1.1.0
+  - flake8-builtins!=1.4.0
   - flake8-comprehensions
   - flake8-copyright
   - flake8-docstrings

--- a/metpy/plots/tests/test_skewt.py
+++ b/metpy/plots/tests/test_skewt.py
@@ -311,3 +311,11 @@ def test_hodograph_wind_vectors():
     h.plot(u_wind, v_wind, linewidth=3)
     h.wind_vectors(u_wind, v_wind)
     return fig
+
+
+@pytest.mark.xfail
+def test_united_hodograph_range():
+    """Tests making a hodograph with a united ranged."""
+    fig = plt.figure(figsize=(6, 6))
+    ax = fig.add_subplot(1, 1, 1)
+    Hodograph(ax, component_range=60. * units.knots)

--- a/metpy/units.py
+++ b/metpy/units.py
@@ -339,7 +339,10 @@ except (AttributeError, RuntimeError):  # Pint's not available, try to enable ou
         @staticmethod
         def default_units(x, axis):
             """Get the default unit to use for the given combination of unit and axis."""
-            return getattr(x, 'units', None)
+            if isinstance(x, (tuple, list)):
+                return getattr(x[0], 'units', 'dimensionless')
+            else:
+                return getattr(x, 'units', 'dimensionless')
 
     # Register the class
     munits.registry[units.Quantity] = PintConverter(units)

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'doc': ['sphinx>=1.4', 'sphinx-gallery', 'doc8', 'recommonmark', 'netCDF4', 'pandas'],
         'examples': ['cartopy>=0.13.1', 'pandas'],
         'test': ['pandas', 'pytest>=2.4', 'pytest-runner', 'pytest-mpl', 'pytest-flake8',
-                 'cartopy>=0.13.1', 'flake8>3.2.0', 'flake8-builtins!=1.1.0',
+                 'cartopy>=0.13.1', 'flake8>3.2.0', 'flake8-builtins!=1.4.0',
                  'flake8-comprehensions', 'flake8-copyright',
                  'flake8-docstrings', 'flake8-import-order', 'flake8-mutable',
                  'flake8-pep3101', 'flake8-print', 'flake8-quotes',


### PR DESCRIPTION
Fixes #805 - sort of. We had a problem in unit handling of tuples and lists. This PR fixes that, but the next problem likes in matplotlib `set_ylim`. `self._process_unit_info(ydata=(bottom, top))` needs to be inserted at line 3225 of _base.py in matplotlib. This adds a failing test that can be easily switched from expected fail when the mpl issue is resolved. Opening another issue on that.