### PR TITLE
Remove requirements text

### DIFF
--- a/docs/infrastructureguide.rst
+++ b/docs/infrastructureguide.rst
@@ -5,16 +5,6 @@ Infrastructure Guide
 This guide serves as an advanced version of the contributing documentation and contains the
 information on how we manage MetPy and the infrastructure behind it.
 
-------------
-Requirements
-------------
-
-- pytest >= 2.4
-- flake8
-- sphinx >= 1.3
-- sphinx-rtd-theme >= 0.1.7
-- nbconvert>=4.1
-
 ----------
 Versioning
 ----------

--- a/docs/installguide.rst
+++ b/docs/installguide.rst
@@ -35,29 +35,6 @@ In general, MetPy tries to support minor versions of dependencies released withi
 years. For Python itself, that means supporting the last two minor releases, as well as
 currently supporting Python 2.7.
 
-MetPy currently supports the following versions of required dependencies:
-  - Python 2.7 or >=3.4
-  - NumPy >= 1.10.0
-  - SciPy >= 0.14.0
-  - Matplotlib >= 1.4.0
-  - pint >= 0.8
-
-Installation Instructions for NumPy and SciPy can be found at:
-  https://www.scipy.org/scipylib/download.html
-
-Installation Instructions for Matplotlib can be found at:
-  https://matplotlib.org/downloads.html
-
-Pint is a pure python package and can be installed via ``pip install pint``.
-
-Python 2.7 requires the enum34 package, which is a backport
-of the enum standard library module. It can be installed via
-``pip install enum34``.
-
-PyProj is an optional dependency (if using the CDM interface to data files).
-It can also be installed via ``pip install pyproj``, though it does require
-the Proj.4 library and a compiled extension.
-
 ------------
 Installation
 ------------


### PR DESCRIPTION
Having the requirements text in the documentation doesn't really seem necessary:

* It's documented in `setup.py`
* Most users (if not all) install via pip or conda, so it's irrelevant.
* It is another place to manually update/forget to update.