### PR TITLE
Isentropic updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,8 @@ release new features, and `y` when we make a release with only bug fixes.
 We support Python >= 3.4 and currently support Python 2.7.
 
 NOTE: We are dropping support for Python 2.7 in Fall 2019. See
-`here <https://github.com/Unidata/MetPy/docs/installguide.rst>`_ for more information.
+`here <https://github.com/Unidata/MetPy/blob/master/docs/installguide.rst>`_ for more
+information.
 
 Need Help?
 ----------

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -590,10 +590,12 @@ def test_isentropic_pressure():
     tmp[1, :] = 292.
     tmp[2, :] = 290
     tmp[3, :] = 288.
+    tmp[:, :, -1] = np.nan
     tmpk = tmp * units.kelvin
     isentlev = [296.] * units.kelvin
     isentprs = isentropic_interpolation(isentlev, lev, tmpk)
-    trueprs = 1000. * units.hPa
+    trueprs = np.ones((1, 5, 5)) * (1000. * units.hPa)
+    trueprs[:, :, -1] = np.nan
     assert isentprs[0].shape == (1, 5, 5)
     assert_almost_equal(isentprs[0], trueprs, 3)
 

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -685,7 +685,7 @@ def test_isentropic_pressure_interp():
     assert_almost_equal(isentprs[0][1], trueprs, 3)
 
 
-def test_isentropic_pressure_adition_args_interp():
+def test_isentropic_pressure_addition_args_interp():
     """Test calculation of isentropic pressure function, additional args."""
     lev = [100000., 95000., 90000., 85000.] * units.Pa
     tmp = np.ones((4, 5, 5))

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -598,6 +598,20 @@ def test_isentropic_pressure():
     assert_almost_equal(isentprs[0], trueprs, 3)
 
 
+def test_isentropic_pressure_masked_column():
+    """Test calculation of isentropic pressure function with a masked column (#769)."""
+    lev = [100000., 95000.] * units.Pa
+    tmp = np.ma.ones((len(lev), 5, 5))
+    tmp[0, :] = 296.
+    tmp[1, :] = 292.
+    tmp[:, :, -1] = np.ma.masked
+    isentprs = isentropic_interpolation([296.] * units.kelvin, lev, tmp * units.kelvin)
+    trueprs = np.ones((1, 5, 5)) * (1000. * units.hPa)
+    trueprs[:, :, -1] = np.nan
+    assert isentprs[0].shape == (1, 5, 5)
+    assert_almost_equal(isentprs[0], trueprs, 3)
+
+
 def test_isentropic_pressure_p_increase():
     """Test calculation of isentropic pressure function, p increasing order."""
     lev = [85000, 90000., 95000., 100000.] * units.Pa

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -594,7 +594,7 @@ def test_isentropic_pressure():
     isentlev = [296.] * units.kelvin
     isentprs = isentropic_interpolation(isentlev, lev, tmpk)
     trueprs = 1000. * units.hPa
-    assert_almost_equal(isentprs[0].shape, (1, 5, 5), 3)
+    assert isentprs[0].shape == (1, 5, 5)
     assert_almost_equal(isentprs[0], trueprs, 3)
 
 
@@ -756,7 +756,7 @@ def test_isentropic_pressure_4d():
     trueprs2 = 936.18057 * units.hPa
     trueprs3 = 879.446 * units.hPa
     truerh = 69.171 * units.percent
-    assert_almost_equal(isentprs[0].shape, (3, 3, 5, 5), 3)
+    assert isentprs[0].shape == (3, 3, 5, 5)
     assert_almost_equal(isentprs[0][:, 0, :], trueprs, 3)
     assert_almost_equal(isentprs[0][:, 1, :], trueprs2, 3)
     assert_almost_equal(isentprs[0][:, 2, :], trueprs3, 3)

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -593,7 +593,8 @@ def test_isentropic_pressure():
     tmp[:, :, -1] = np.nan
     tmpk = tmp * units.kelvin
     isentlev = [296.] * units.kelvin
-    isentprs = isentropic_interpolation(isentlev, lev, tmpk)
+    with pytest.warns(RuntimeWarning, match='invalid value'):
+        isentprs = isentropic_interpolation(isentlev, lev, tmpk)
     trueprs = np.ones((1, 5, 5)) * (1000. * units.hPa)
     trueprs[:, :, -1] = np.nan
     assert isentprs[0].shape == (1, 5, 5)

--- a/metpy/calc/tests/test_tools.py
+++ b/metpy/calc/tests/test_tools.py
@@ -467,6 +467,16 @@ def test_interp_end_point():
     assert_array_almost_equal(y_interp, y_interp_truth, 7)
 
 
+def test_interp_masked_units():
+    """Test interpolating with masked arrays with units."""
+    x = np.ma.array([1., 2., 3., 4.]) * units.m
+    y = np.ma.array([50., 60., 70., 80.]) * units.degC
+    x_interp = np.array([250., 350.]) * units.cm
+    y_interp_truth = np.array([65., 75.]) * units.degC
+    y_interp = interp(x_interp, x, y)
+    assert_array_almost_equal(y_interp, y_interp_truth, 7)
+
+
 def test_greater_or_close():
     """Test floating point greater or close to."""
     x = np.array([0.0, 1.0, 1.49999, 1.5, 1.5000, 1.7])

--- a/metpy/calc/tests/test_tools.py
+++ b/metpy/calc/tests/test_tools.py
@@ -9,10 +9,11 @@ import numpy as np
 import numpy.ma as ma
 import pytest
 
-from metpy.calc import (find_intersections, first_derivative, get_layer, get_layer_heights,
-                        gradient, interp, interpolate_nans, laplacian, log_interp,
-                        nearest_intersection_idx, parse_angle, pressure_to_height_std,
-                        reduce_point_density, resample_nn_1d, second_derivative)
+from metpy.calc import (find_bounding_indices, find_intersections, first_derivative, get_layer,
+                        get_layer_heights, gradient, interp, interpolate_nans, laplacian,
+                        log_interp, nearest_intersection_idx, parse_angle,
+                        pressure_to_height_std, reduce_point_density, resample_nn_1d,
+                        second_derivative)
 from metpy.calc.tools import (_delete_masked_points, _get_bound_pressure_height,
                               _greater_or_close, _less_or_close, _next_non_masked_element,
                               DIR_STRS)
@@ -684,3 +685,23 @@ def test_gradient_2d(deriv_2d_data):
                        [-3, -1, 4],
                        [-3, -1, 4]]))
     assert_array_almost_equal(res, truth, 5)
+
+
+def test_bounding_indices():
+    """Test finding bounding indices."""
+    data = np.array([[1, 2, 3, 1], [5, 6, 7, 8]])
+    above, below, good = find_bounding_indices(data, [1.5, 7], axis=1, from_below=True)
+
+    assert_array_equal(above[1], np.array([[1, 0], [0, 3]]))
+    assert_array_equal(below[1], np.array([[0, -1], [-1, 2]]))
+    assert_array_equal(good, np.array([[True, False], [False, True]]))
+
+
+def test_bounding_indices_above():
+    """Test finding bounding indices from above."""
+    data = np.array([[1, 2, 3, 1], [5, 6, 7, 8]])
+    above, below, good = find_bounding_indices(data, [1.5, 7], axis=1, from_below=False)
+
+    assert_array_equal(above[1], np.array([[3, 0], [0, 3]]))
+    assert_array_equal(below[1], np.array([[2, -1], [-1, 2]]))
+    assert_array_equal(good, np.array([[True, False], [False, True]]))

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -1419,28 +1419,25 @@ def isentropic_interpolation(theta_levels, pressure, temperature, *args, **kwarg
 
     slices = [np.newaxis] * ndim
     slices[axis] = slice(None)
-    pres = pres[slices]
-    pres = np.broadcast_to(pres, temperature.shape) * pres.units
+    pres = np.broadcast_to(pres[slices], temperature.shape) * pres.units
 
     # Sort input data
     sort_pres = np.argsort(pres.m, axis=axis)
     sort_pres = np.swapaxes(np.swapaxes(sort_pres, 0, axis)[::-1], 0, axis)
     sorter = broadcast_indices(pres, sort_pres, ndim, axis)
     levs = pres[sorter]
-    theta_levels = np.asanyarray(theta_levels.to('kelvin')).reshape(-1)
-    sort_isentlevs = np.argsort(theta_levels)
     tmpk = temperature[sorter]
-    isentlevels = theta_levels[sort_isentlevs]
+
+    theta_levels = np.asanyarray(theta_levels.to('kelvin')).reshape(-1)
+    isentlevels = theta_levels[np.argsort(theta_levels)]
 
     # Make the desired isentropic levels the same shape as temperature
-    isentlevs_nd = isentlevels
-    isentlevs_nd = isentlevs_nd[slices]
     shape = list(temperature.shape)
     shape[axis] = isentlevels.size
-    isentlevs_nd = np.broadcast_to(isentlevs_nd, shape)
+    isentlevs_nd = np.broadcast_to(isentlevels[slices], shape)
 
     # exponent to Poisson's Equation, which is imported above
-    ka = kappa.to('dimensionless').m
+    ka = kappa.m_as('dimensionless')
 
     # calculate theta for each point
     pres_theta = potential_temperature(levs, tmpk)

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -1480,28 +1480,20 @@ def isentropic_interpolation(theta_levels, pressure, temperature, *args, **kwarg
     isentprs[isentprs > np.max(pressure.m)] = np.nan
 
     # create list for storing output data
-    ret = []
-    ret.append(isentprs * units.hPa)
+    ret = [isentprs * units.hPa]
 
     # if tmpk_out = true, calculate temperature and output as last item in list
     if tmpk_out:
         ret.append((isentlevs_nd / ((P0.m / isentprs) ** ka)) * units.kelvin)
 
-    # check to see if any additional arguments were given, if so, interpolate to
-    # new isentropic levels
-    try:
-        args[0]
-    except IndexError:
-        return ret
-    else:
-        # do an interpolation for each additional argument
-        for arr in args:
-            var = arr[sorter]
-            # interpolate to isentropic levels and add to temporary output array
-            arg_out = interp(isentlevels, pres_theta.m, var, axis=axis)
-            ret.append(arg_out)
+    # do an interpolation for each additional argument
+    if args:
+        others = interp(isentlevels, pres_theta.m, *(arr[sorter] for arr in args), axis=axis)
+        if len(args) > 1:
+            ret.extend(others)
+        else:
+            ret.append(others)
 
-    # output values as a list
     return ret
 
 

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -1472,6 +1472,10 @@ def isentropic_interpolation(theta_levels, pressure, temperature, *args, **kwarg
     # calculate first guess for interpolation
     isentprs = 0.5 * (log_p[above] + log_p[below])
 
+    # Make sure we ignore any nans in the data for solving; checking a is enough since it
+    # combines log_p and tmpk.
+    good &= ~np.isnan(a)
+
     # iterative interpolation using scipy.optimize.fixed_point and _isen_iter defined above
     log_p_solved = so.fixed_point(_isen_iter, isentprs[good],
                                   args=(isentlevs_nd[good], ka, a[good], b[good], pok.m),

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -715,9 +715,11 @@ def interp(x, xp, *args, **kwargs):
 
     # Calculate interpolation for each variable
     for var in variables:
-        var_interp = var[below] + ((x_array - xp[below]) /
-                                   (xp[above] - xp[below])) * (var[above] -
-                                                               var[below])
+        # Var needs to be on the *left* of the multiply to ensure that if it's a pint
+        # Quantity, it gets to control the operation--at least until we make sure
+        # masked arrays and pint play together better. See https://github.com/hgrecco/pint#633
+        var_interp = var[below] + (var[above] - var[below]) * ((x_array - xp[below]) /
+                                                               (xp[above] - xp[below]))
 
         # Set points out of bounds to fill value.
         var_interp[minv == xp.shape[axis]] = fill_value

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -736,6 +736,94 @@ def interp(x, xp, *args, **kwargs):
         return ret
 
 
+@exporter.export
+def find_bounding_indices(arr, values, axis, from_below=True):
+    """Find the indices surrounding the values within arr along axis.
+
+    Returns a set of above, below, good. Above and below are lists of arrays of indices.
+    These lists are formulated such that they can be used directly to index into a numpy
+    array and get the expected results (no extra slices or ellipsis necessary). `good` is
+    a boolean array indicating the "columns" that actually had values to bound the desired
+    value(s).
+
+    Parameters
+    ----------
+    arr : array-like
+        Array to search for values
+
+    values: array-like
+        One or more values to search for in `arr`
+
+    axis : int
+        The dimension of `arr` along which to search.
+
+    from_below : bool, optional
+        Whether to search from "below" (i.e. low indices to high indices). If `False`,
+        the search will instead proceed from high indices to low indices. Defaults to `True`.
+
+    Returns
+    -------
+    above : list of arrays
+        List of broadcasted indices to the location above the desired value
+
+    below : list of arrays
+        List of broadcasted indices to the location below the desired value
+
+    good : array
+        Boolean array indicating where the search found proper bounds for the desired value
+
+    """
+    # The shape of generated indices is the same as the input, but with the axis of interest
+    # replaced by the number of values to search for.
+    indices_shape = list(arr.shape)
+    indices_shape[axis] = len(values)
+
+    # Storage for the found indices and the mask for good locations
+    indices = np.empty(indices_shape, dtype=np.int)
+    good = np.empty(indices_shape, dtype=np.bool)
+
+    # Used to put the output in the proper location
+    store_slice = [slice(None)] * arr.ndim
+
+    # Loop over all of the values and for each, see where the value would be found from a
+    # linear search
+    for level_index, value in enumerate(values):
+        # Look for changes in the value of the test for <= value in consecutive points
+        # Taking abs() because we only care if there is a flip, not which direction.
+        switches = np.abs(np.diff((arr <= value).astype(np.int), axis=axis))
+
+        # Good points are those where it's not just 0's along the whole axis
+        good_search = np.any(switches, axis=axis)
+
+        if from_below:
+            # Look for the first switch; need to add 1 to the index since argmax is giving the
+            # index within the difference array, which is one smaller.
+            index = switches.argmax(axis=axis) + 1
+        else:
+            # Generate a list of slices to reverse the axis of interest so that searching from
+            # 0 to N is starting at the "top" of the axis.
+            arr_slice = [slice(None)] * arr.ndim
+            arr_slice[axis] = slice(None, None, -1)
+
+            # Same as above, but we use the slice to come from the end; then adjust those
+            # indices to measure from the front.
+            index = arr.shape[axis] - 1 - switches[arr_slice].argmax(axis=axis)
+
+        # Set all indices where the results are not good to 0
+        index[~good_search] = 0
+
+        # Put the results in the proper slice
+        store_slice[axis] = level_index
+        indices[store_slice] = index
+        good[store_slice] = good_search
+
+    # Create index values for broadcasting arrays
+    above = broadcast_indices(arr, indices, arr.ndim, axis)
+    below = broadcast_indices(arr, indices - 1, arr.ndim, axis)
+
+    return above, below, good
+
+
 def broadcast_indices(x, minv, ndim, axis):
     """Calculate index values to properly broadcast index array within data array.
 


### PR DESCRIPTION
A lot of clean up of the existing code, as well as improvements to:
- Handling masked arrays/columns of nans (Fixes #769)
- Improved searching for isentropic levels to use a linear search rather than `np.searchsorted`, which isn't strictly correct. It doesn't impact the results in our example at all, but the new version is about 10% faster (due I suspect to the removal of `apply_along_axis`). (Fixes #798)
- Can now control which direction to search (which makes minimal difference in our example)