### PR TITLE
Xarray Conversion Decorator

### DIFF
--- a/examples/XArray_Projections.py
+++ b/examples/XArray_Projections.py
@@ -12,8 +12,7 @@ import cartopy.feature as cfeature
 import matplotlib.pyplot as plt
 import xarray as xr
 
-# Ensure xarray accessors are available
-import metpy.io  # noqa: F401
+# Any import of metpy will activate the accessors
 from metpy.testing import get_test_data
 
 ds = xr.open_dataset(get_test_data('narr_example.nc', as_file_obj=False))

--- a/metpy/__init__.py
+++ b/metpy/__init__.py
@@ -6,5 +6,6 @@
 # What do we want to pull into the top-level namespace?
 
 from ._version import get_versions
+from .xarray import *  # noqa: F401, F403
 __version__ = get_versions()['version']
 del get_versions

--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -19,11 +19,13 @@ import numpy as np
 from ..constants import G, g, me, omega, Rd, Re
 from ..package_tools import Exporter
 from ..units import atleast_1d, check_units, masked_array, units
+from ..xarray import preprocess_xarray
 
 exporter = Exporter(globals())
 
 
 @exporter.export
+@preprocess_xarray
 def get_wind_speed(u, v):
     r"""Compute the wind speed from u and v-components.
 
@@ -49,6 +51,7 @@ def get_wind_speed(u, v):
 
 
 @exporter.export
+@preprocess_xarray
 def get_wind_dir(u, v):
     r"""Compute the wind direction from u and v-components.
 
@@ -78,6 +81,7 @@ def get_wind_dir(u, v):
 
 
 @exporter.export
+@preprocess_xarray
 def get_wind_components(speed, wdir):
     r"""Calculate the U, V wind vector components from the speed and direction.
 
@@ -115,6 +119,7 @@ def get_wind_components(speed, wdir):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units(temperature='[temperature]', speed='[speed]')
 def windchill(temperature, speed, face_level_winds=False, mask_undefined=True):
     r"""Calculate the Wind Chill Temperature Index (WCTI).
@@ -176,6 +181,7 @@ def windchill(temperature, speed, face_level_winds=False, mask_undefined=True):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[temperature]')
 def heat_index(temperature, rh, mask_undefined=True):
     r"""Calculate the Heat Index from the current temperature and relative humidity.
@@ -230,6 +236,7 @@ def heat_index(temperature, rh, mask_undefined=True):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units(temperature='[temperature]', speed='[speed]')
 def apparent_temperature(temperature, rh, speed, face_level_winds=False):
     r"""Calculate the current apparent temperature.
@@ -292,6 +299,7 @@ def apparent_temperature(temperature, rh, speed, face_level_winds=False):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]')
 def pressure_to_height_std(pressure):
     r"""Convert pressure data to heights using the U.S. standard atmosphere.
@@ -320,6 +328,7 @@ def pressure_to_height_std(pressure):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[length]')
 def height_to_geopotential(height):
     r"""Compute geopotential for a given height.
@@ -358,6 +367,7 @@ def height_to_geopotential(height):
 
 
 @exporter.export
+@preprocess_xarray
 def geopotential_to_height(geopot):
     r"""Compute height from a given geopotential.
 
@@ -399,6 +409,7 @@ def geopotential_to_height(geopot):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[length]')
 def height_to_pressure_std(height):
     r"""Convert height data to pressures using the U.S. standard atmosphere.
@@ -427,6 +438,7 @@ def height_to_pressure_std(height):
 
 
 @exporter.export
+@preprocess_xarray
 def coriolis_parameter(latitude):
     r"""Calculate the coriolis parameter at each point.
 
@@ -448,6 +460,7 @@ def coriolis_parameter(latitude):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[length]')
 def add_height_to_pressure(pressure, height):
     r"""Calculate the pressure at a certain height above another pressure level.
@@ -476,6 +489,7 @@ def add_height_to_pressure(pressure, height):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[length]', '[pressure]')
 def add_pressure_to_height(height, pressure):
     r"""Calculate the height at a certain pressure above another height.
@@ -504,6 +518,7 @@ def add_pressure_to_height(height, pressure):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[dimensionless]', '[pressure]', '[pressure]')
 def sigma_to_pressure(sigma, psfc, ptop):
     r"""Calculate pressure from sigma values.

--- a/metpy/calc/indices.py
+++ b/metpy/calc/indices.py
@@ -9,11 +9,13 @@ from .tools import get_layer
 from ..constants import g, rho_l
 from ..package_tools import Exporter
 from ..units import atleast_1d, check_units, concatenate, units
+from ..xarray import preprocess_xarray
 
 exporter = Exporter(globals())
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[temperature]', '[pressure]', '[pressure]')
 def precipitable_water(dewpt, pressure, bottom=None, top=None):
     r"""Calculate precipitable water through the depth of a sounding.
@@ -63,6 +65,7 @@ def precipitable_water(dewpt, pressure, bottom=None, top=None):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]')
 def mean_pressure_weighted(pressure, *args, **kwargs):
     r"""Calculate pressure-weighted mean of an arbitrary variable through a layer.
@@ -113,6 +116,7 @@ def mean_pressure_weighted(pressure, *args, **kwargs):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[speed]', '[speed]', '[length]')
 def bunkers_storm_motion(pressure, u, v, heights):
     r"""Calculate the Bunkers right-mover and left-mover storm motions and sfc-6km mean flow.
@@ -172,6 +176,7 @@ def bunkers_storm_motion(pressure, u, v, heights):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[speed]', '[speed]')
 def bulk_shear(pressure, u, v, heights=None, bottom=None, depth=None):
     r"""Calculate bulk shear through a layer.
@@ -214,6 +219,7 @@ def bulk_shear(pressure, u, v, heights=None, bottom=None, depth=None):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[energy] / [mass]', '[speed] * [speed]', '[speed]')
 def supercell_composite(mucape, effective_storm_helicity, effective_shear):
     r"""Calculate the supercell composite parameter.
@@ -255,6 +261,7 @@ def supercell_composite(mucape, effective_storm_helicity, effective_shear):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[energy] / [mass]', '[length]', '[speed] * [speed]', '[speed]')
 def significant_tornado(sbcape, surface_based_lcl_height, storm_helicity_1km, shear_6km):
     r"""Calculate the significant tornado parameter (fixed layer).
@@ -308,6 +315,7 @@ def significant_tornado(sbcape, surface_based_lcl_height, storm_helicity_1km, sh
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[speed]', '[speed]', '[length]', '[speed]', '[speed]')
 def critical_angle(pressure, u, v, heights, stormu, stormv):
     r"""Calculate the critical angle.

--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -9,13 +9,14 @@ import warnings
 
 import numpy as np
 
-from ..calc import coriolis_parameter
-from ..calc.tools import first_derivative, get_layer_heights, gradient
+from . import coriolis_parameter
+from .tools import first_derivative, get_layer_heights, gradient
 from ..cbook import is_string_like, iterable
 from ..constants import Cp_d, g, Rd
 from ..deprecation import deprecated
 from ..package_tools import Exporter
 from ..units import atleast_2d, check_units, concatenate, units
+from ..xarray import preprocess_xarray
 
 exporter = Exporter(globals())
 
@@ -90,6 +91,7 @@ def ensure_yx_order(func):
 
 
 @exporter.export
+@preprocess_xarray
 @ensure_yx_order
 def vorticity(u, v, dx, dy):
     r"""Calculate the vertical vorticity of the horizontal wind.
@@ -121,6 +123,7 @@ def vorticity(u, v, dx, dy):
 
 
 @exporter.export
+@preprocess_xarray
 @deprecated('0.7', addendum=' This function has been renamed vorticity.',
             pending=False)
 def v_vorticity(u, v, dx, dy, dim_order='xy'):
@@ -134,6 +137,7 @@ v_vorticity.__doc__ = (vorticity.__doc__ +
 
 
 @exporter.export
+@preprocess_xarray
 @ensure_yx_order
 def divergence(u, v, dx, dy):
     r"""Calculate the horizontal divergence of the horizontal wind.
@@ -165,6 +169,7 @@ def divergence(u, v, dx, dy):
 
 
 @exporter.export
+@preprocess_xarray
 @deprecated('0.7', addendum=' This function has been replaced by divergence.',
             pending=False)
 def h_convergence(u, v, dx, dy, dim_order='xy'):
@@ -178,6 +183,7 @@ h_convergence.__doc__ = (divergence.__doc__ +
 
 
 @exporter.export
+@preprocess_xarray
 @deprecated('0.7', addendum=' Use divergence and/or vorticity instead.',
             pending=False)
 @ensure_yx_order
@@ -218,6 +224,7 @@ def convergence_vorticity(u, v, dx, dy, dim_order='xy'):
 
 
 @exporter.export
+@preprocess_xarray
 @ensure_yx_order
 def shearing_deformation(u, v, dx, dy):
     r"""Calculate the shearing deformation of the horizontal wind.
@@ -249,6 +256,7 @@ def shearing_deformation(u, v, dx, dy):
 
 
 @exporter.export
+@preprocess_xarray
 @ensure_yx_order
 def stretching_deformation(u, v, dx, dy):
     r"""Calculate the stretching deformation of the horizontal wind.
@@ -280,6 +288,7 @@ def stretching_deformation(u, v, dx, dy):
 
 
 @exporter.export
+@preprocess_xarray
 @deprecated('0.7', addendum=' Use stretching_deformation and/or shearing_deformation instead.',
             pending=False)
 @ensure_yx_order
@@ -321,6 +330,7 @@ def shearing_stretching_deformation(u, v, dx, dy):
 
 
 @exporter.export
+@preprocess_xarray
 @ensure_yx_order
 def total_deformation(u, v, dx, dy):
     r"""Calculate the horizontal total deformation of the horizontal wind.
@@ -354,6 +364,7 @@ def total_deformation(u, v, dx, dy):
 
 
 @exporter.export
+@preprocess_xarray
 @ensure_yx_order
 def advection(scalar, wind, deltas):
     r"""Calculate the advection of a scalar field by the wind.
@@ -403,6 +414,7 @@ def advection(scalar, wind, deltas):
 
 
 @exporter.export
+@preprocess_xarray
 @ensure_yx_order
 def frontogenesis(thta, u, v, dx, dy, dim_order='yx'):
     r"""Calculate the 2D kinematic frontogenesis of a temperature field.
@@ -467,6 +479,7 @@ def frontogenesis(thta, u, v, dx, dy, dim_order='yx'):
 
 
 @exporter.export
+@preprocess_xarray
 @ensure_yx_order
 def geostrophic_wind(heights, f, dx, dy):
     r"""Calculate the geostrophic wind given from the heights or geopotential.
@@ -501,6 +514,7 @@ def geostrophic_wind(heights, f, dx, dy):
 
 
 @exporter.export
+@preprocess_xarray
 @ensure_yx_order
 def ageostrophic_wind(heights, f, dx, dy, u, v, dim_order='yx'):
     r"""Calculate the ageostrophic wind given from the heights or geopotential.
@@ -535,6 +549,7 @@ def ageostrophic_wind(heights, f, dx, dy, u, v, dim_order='yx'):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[length]', '[temperature]')
 def montgomery_streamfunction(height, temperature):
     r"""Compute the Montgomery Streamfunction on isentropic surfaces.
@@ -576,6 +591,7 @@ def montgomery_streamfunction(height, temperature):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[speed]', '[speed]', '[length]', '[length]', '[length]',
              '[speed]', '[speed]')
 def storm_relative_helicity(u, v, heights, depth, bottom=0 * units.m,
@@ -636,6 +652,7 @@ def storm_relative_helicity(u, v, heights, depth, bottom=0 * units.m,
                             ' 0.11.',
             pending=False)
 @exporter.export
+@preprocess_xarray
 def lat_lon_grid_spacing(longitude, latitude, **kwargs):
     r"""Calculate the distance between grid points that are in a latitude/longitude format.
 
@@ -672,6 +689,7 @@ def lat_lon_grid_spacing(longitude, latitude, **kwargs):
 
 
 @exporter.export
+@preprocess_xarray
 def lat_lon_grid_deltas(longitude, latitude, **kwargs):
     r"""Calculate the delta between grid points that are in a latitude/longitude format.
 
@@ -725,6 +743,7 @@ def lat_lon_grid_deltas(longitude, latitude, **kwargs):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[speed]', '[speed]', '[length]', '[length]')
 def absolute_vorticity(u, v, dx, dy, lats, dim_order='yx'):
     """Calculate the absolute vorticity of the horizontal wind.
@@ -754,6 +773,7 @@ def absolute_vorticity(u, v, dx, dy, lats, dim_order='yx'):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[temperature]', '[pressure]', '[speed]', '[speed]',
              '[length]', '[length]', '[dimensionless]')
 def potential_vorticity_baroclinic(potential_temperature, pressure, u, v, dx, dy, lats,
@@ -813,6 +833,7 @@ def potential_vorticity_baroclinic(potential_temperature, pressure, u, v, dx, dy
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[length]', '[speed]', '[speed]', '[length]', '[length]', '[dimensionless]')
 def potential_vorticity_barotropic(heights, u, v, dx, dy, lats, dim_order='yx'):
     r"""Calculate the barotropic (Rossby) potential vorticity.
@@ -847,6 +868,7 @@ def potential_vorticity_barotropic(heights, u, v, dx, dy, lats, dim_order='yx'):
 
 
 @exporter.export
+@preprocess_xarray
 def inertial_advective_wind(u, v, u_geostrophic, v_geostrophic, dx, dy, lats):
     r"""Calculate the inertial advective wind.
 
@@ -908,6 +930,7 @@ def inertial_advective_wind(u, v, u_geostrophic, v_geostrophic, dx, dy, lats):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[speed]', '[speed]', '[temperature]', '[pressure]', '[length]', '[length]')
 def q_vector(u, v, temperature, pressure, dx, dy, static_stability=1):
     r"""Calculate Q-vector at a given pressure level using the u, v winds and temperature.

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 import pytest
+import xarray as xr
 
 from metpy.calc import (brunt_vaisala_frequency, brunt_vaisala_frequency_squared,
                         brunt_vaisala_period, cape_cin, density, dewpoint,
@@ -45,6 +46,13 @@ def test_relative_humidity_from_dewpoint_with_f():
     """Test Relative Humidity accepts temperature in Fahrenheit."""
     assert_almost_equal(relative_humidity_from_dewpoint(70. * units.degF, 55. * units.degF),
                         58.935 * units.percent, 3)
+
+
+def test_relative_humidity_from_dewpoint_xarray():
+    """Test Relative Humidity calculation with xarray data arrays."""
+    temp = xr.DataArray(25., attrs={'units': 'degC'})
+    dewp = xr.DataArray(15., attrs={'units': 'degC'})
+    assert_almost_equal(relative_humidity_from_dewpoint(temp, dewp), 53.80 * units.percent, 2)
 
 
 def test_exner_function():

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -17,6 +17,7 @@ from .tools import (_greater_or_close, _less_or_close, broadcast_indices,
 from ..constants import Cp_d, epsilon, g, kappa, Lv, P0, Rd
 from ..package_tools import Exporter
 from ..units import atleast_1d, check_units, concatenate, units
+from ..xarray import preprocess_xarray
 
 exporter = Exporter(globals())
 
@@ -24,6 +25,7 @@ sat_pressure_0c = 6.112 * units.millibar
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[temperature]', '[temperature]')
 def relative_humidity_from_dewpoint(temperature, dewpt):
     r"""Calculate the relative humidity.
@@ -54,6 +56,7 @@ def relative_humidity_from_dewpoint(temperature, dewpt):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[pressure]')
 def exner_function(pressure, reference_pressure=P0):
     r"""Calculate the Exner function.
@@ -87,6 +90,7 @@ def exner_function(pressure, reference_pressure=P0):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]')
 def potential_temperature(pressure, temperature):
     r"""Calculate the potential temperature.
@@ -128,6 +132,7 @@ def potential_temperature(pressure, temperature):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]')
 def temperature_from_potential_temperature(pressure, theta):
     r"""Calculate the temperature from a given potential temperature.
@@ -172,6 +177,7 @@ def temperature_from_potential_temperature(pressure, theta):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]')
 def dry_lapse(pressure, temperature):
     r"""Calculate the temperature at a level assuming only dry processes.
@@ -204,6 +210,7 @@ def dry_lapse(pressure, temperature):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]')
 def moist_lapse(pressure, temperature):
     r"""Calculate the temperature at a level assuming liquid saturation processes.
@@ -253,6 +260,7 @@ def moist_lapse(pressure, temperature):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]', '[temperature]')
 def lcl(pressure, temperature, dewpt, max_iters=50, eps=1e-5):
     r"""Calculate the lifted condensation level (LCL) using from the starting point.
@@ -309,6 +317,7 @@ def lcl(pressure, temperature, dewpt, max_iters=50, eps=1e-5):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]', '[temperature]', '[temperature]')
 def lfc(pressure, temperature, dewpt, parcel_temperature_profile=None):
     r"""Calculate the level of free convection (LFC).
@@ -370,6 +379,7 @@ def lfc(pressure, temperature, dewpt, parcel_temperature_profile=None):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]', '[temperature]', '[temperature]')
 def el(pressure, temperature, dewpt, parcel_temperature_profile=None):
     r"""Calculate the equilibrium level.
@@ -417,6 +427,7 @@ def el(pressure, temperature, dewpt, parcel_temperature_profile=None):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]', '[temperature]')
 def parcel_profile(pressure, temperature, dewpt):
     r"""Calculate the profile a parcel takes through the atmosphere.
@@ -468,6 +479,7 @@ def parcel_profile(pressure, temperature, dewpt):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[dimensionless]')
 def vapor_pressure(pressure, mixing):
     r"""Calculate water vapor (partial) pressure.
@@ -504,6 +516,7 @@ def vapor_pressure(pressure, mixing):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[temperature]')
 def saturation_vapor_pressure(temperature):
     r"""Calculate the saturation water vapor (partial) pressure.
@@ -539,6 +552,7 @@ def saturation_vapor_pressure(temperature):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[temperature]', '[dimensionless]')
 def dewpoint_rh(temperature, rh):
     r"""Calculate the ambient dewpoint given air temperature and relative humidity.
@@ -566,6 +580,7 @@ def dewpoint_rh(temperature, rh):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]')
 def dewpoint(e):
     r"""Calculate the ambient dewpoint given the vapor pressure.
@@ -598,6 +613,7 @@ def dewpoint(e):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[pressure]', '[dimensionless]')
 def mixing_ratio(part_press, tot_press, molecular_weight_ratio=epsilon):
     r"""Calculate the mixing ratio of a gas.
@@ -639,6 +655,7 @@ def mixing_ratio(part_press, tot_press, molecular_weight_ratio=epsilon):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]')
 def saturation_mixing_ratio(tot_press, temperature):
     r"""Calculate the saturation mixing ratio of water vapor.
@@ -663,6 +680,7 @@ def saturation_mixing_ratio(tot_press, temperature):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]', '[temperature]')
 def equivalent_potential_temperature(pressure, temperature, dewpoint):
     r"""Calculate equivalent potential temperature.
@@ -719,6 +737,7 @@ def equivalent_potential_temperature(pressure, temperature, dewpoint):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]')
 def saturation_equivalent_potential_temperature(pressure, temperature):
     r"""Calculate saturation equivalent potential temperature.
@@ -785,6 +804,7 @@ def saturation_equivalent_potential_temperature(pressure, temperature):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[temperature]', '[dimensionless]', '[dimensionless]')
 def virtual_temperature(temperature, mixing, molecular_weight_ratio=epsilon):
     r"""Calculate virtual temperature.
@@ -818,6 +838,7 @@ def virtual_temperature(temperature, mixing, molecular_weight_ratio=epsilon):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]', '[dimensionless]', '[dimensionless]')
 def virtual_potential_temperature(pressure, temperature, mixing,
                                   molecular_weight_ratio=epsilon):
@@ -854,6 +875,7 @@ def virtual_potential_temperature(pressure, temperature, mixing,
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]', '[dimensionless]', '[dimensionless]')
 def density(pressure, temperature, mixing, molecular_weight_ratio=epsilon):
     r"""Calculate density.
@@ -889,6 +911,7 @@ def density(pressure, temperature, mixing, molecular_weight_ratio=epsilon):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[temperature]', '[temperature]', '[pressure]')
 def relative_humidity_wet_psychrometric(dry_bulb_temperature, web_bulb_temperature,
                                         pressure, **kwargs):
@@ -930,6 +953,7 @@ def relative_humidity_wet_psychrometric(dry_bulb_temperature, web_bulb_temperatu
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[temperature]', '[temperature]', '[pressure]')
 def psychrometric_vapor_pressure_wet(dry_bulb_temperature, wet_bulb_temperature, pressure,
                                      psychrometer_coefficient=6.21e-4 / units.kelvin):
@@ -979,6 +1003,7 @@ def psychrometric_vapor_pressure_wet(dry_bulb_temperature, wet_bulb_temperature,
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[dimensionless]', '[temperature]', '[pressure]')
 def mixing_ratio_from_relative_humidity(relative_humidity, temperature, pressure):
     r"""Calculate the mixing ratio from relative humidity, temperature, and pressure.
@@ -1018,6 +1043,7 @@ def mixing_ratio_from_relative_humidity(relative_humidity, temperature, pressure
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[dimensionless]', '[temperature]', '[pressure]')
 def relative_humidity_from_mixing_ratio(mixing_ratio, temperature, pressure):
     r"""Calculate the relative humidity from mixing ratio, temperature, and pressure.
@@ -1055,6 +1081,7 @@ def relative_humidity_from_mixing_ratio(mixing_ratio, temperature, pressure):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[dimensionless]')
 def mixing_ratio_from_specific_humidity(specific_humidity):
     r"""Calculate the mixing ratio from specific humidity.
@@ -1091,6 +1118,7 @@ def mixing_ratio_from_specific_humidity(specific_humidity):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[dimensionless]')
 def specific_humidity_from_mixing_ratio(mixing_ratio):
     r"""Calculate the specific humidity from the mixing ratio.
@@ -1127,6 +1155,7 @@ def specific_humidity_from_mixing_ratio(mixing_ratio):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[dimensionless]', '[temperature]', '[pressure]')
 def relative_humidity_from_specific_humidity(specific_humidity, temperature, pressure):
     r"""Calculate the relative humidity from specific humidity, temperature, and pressure.
@@ -1165,6 +1194,7 @@ def relative_humidity_from_specific_humidity(specific_humidity, temperature, pre
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]', '[temperature]', '[temperature]')
 def cape_cin(pressure, temperature, dewpt, parcel_profile):
     r"""Calculate CAPE and CIN.
@@ -1301,6 +1331,7 @@ def _find_append_zero_crossings(x, y):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]', '[temperature]')
 def most_unstable_parcel(pressure, temperature, dewpoint, heights=None,
                          bottom=None, depth=300 * units.hPa):
@@ -1347,6 +1378,7 @@ def most_unstable_parcel(pressure, temperature, dewpoint, heights=None,
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[temperature]', '[pressure]', '[temperature]')
 def isentropic_interpolation(theta_levels, pressure, temperature, *args, **kwargs):
     r"""Interpolate data in isobaric coordinates to isentropic coordinates.
@@ -1503,6 +1535,7 @@ def isentropic_interpolation(theta_levels, pressure, temperature, *args, **kwarg
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]', '[temperature]')
 def surface_based_cape_cin(pressure, temperature, dewpoint):
     r"""Calculate surface-based CAPE and CIN.
@@ -1540,6 +1573,7 @@ def surface_based_cape_cin(pressure, temperature, dewpoint):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]', '[temperature]')
 def most_unstable_cape_cin(pressure, temperature, dewpoint, **kwargs):
     r"""Calculate most unstable CAPE/CIN.
@@ -1581,6 +1615,7 @@ def most_unstable_cape_cin(pressure, temperature, dewpoint, **kwargs):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]', '[temperature]')
 def mixed_parcel(p, temperature, dewpt, parcel_start_pressure=None,
                  heights=None, bottom=None, depth=100 * units.hPa, interpolate=True):
@@ -1642,6 +1677,7 @@ def mixed_parcel(p, temperature, dewpt, parcel_start_pressure=None,
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]')
 def mixed_layer(p, *args, **kwargs):
     r"""Mix variable(s) over a layer, yielding a mass-weighted average.
@@ -1692,6 +1728,7 @@ def mixed_layer(p, *args, **kwargs):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[length]', '[temperature]')
 def dry_static_energy(heights, temperature):
     r"""Calculate the dry static energy of parcels.
@@ -1723,6 +1760,7 @@ def dry_static_energy(heights, temperature):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[length]', '[temperature]', '[dimensionless]')
 def moist_static_energy(heights, temperature, specific_humidity):
     r"""Calculate the moist static energy of parcels.
@@ -1757,6 +1795,7 @@ def moist_static_energy(heights, temperature, specific_humidity):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]')
 def thickness_hydrostatic(pressure, temperature, **kwargs):
     r"""Calculate the thickness of a layer via the hypsometric equation.
@@ -1829,6 +1868,7 @@ def thickness_hydrostatic(pressure, temperature, **kwargs):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]')
 def thickness_hydrostatic_from_relative_humidity(pressure, temperature, relative_humidity,
                                                  **kwargs):
@@ -1883,6 +1923,7 @@ def thickness_hydrostatic_from_relative_humidity(pressure, temperature, relative
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[length]', '[temperature]')
 def brunt_vaisala_frequency_squared(heights, potential_temperature, axis=0):
     r"""Calculate the square of the Brunt-Vaisala frequency.
@@ -1922,6 +1963,7 @@ def brunt_vaisala_frequency_squared(heights, potential_temperature, axis=0):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[length]', '[temperature]')
 def brunt_vaisala_frequency(heights, potential_temperature, axis=0):
     r"""Calculate the Brunt-Vaisala frequency.
@@ -1962,6 +2004,7 @@ def brunt_vaisala_frequency(heights, potential_temperature, axis=0):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[length]', '[temperature]')
 def brunt_vaisala_period(heights, potential_temperature, axis=0):
     r"""Calculate the Brunt-Vaisala period.
@@ -2000,6 +2043,7 @@ def brunt_vaisala_period(heights, potential_temperature, axis=0):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]', '[temperature]')
 def wet_bulb_temperature(pressure, temperature, dewpoint):
     """Calculate the wet-bulb temperature using Normand's rule.
@@ -2052,6 +2096,7 @@ def wet_bulb_temperature(pressure, temperature, dewpoint):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[temperature]')
 def static_stability(pressure, temperature, axis=0):
     r"""Calculate the static stability within a vertical profile.
@@ -2083,6 +2128,7 @@ def static_stability(pressure, temperature, axis=0):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[dimensionless]', '[temperature]', '[pressure]')
 def dewpoint_from_specific_humidity(specific_humidity, temperature, pressure):
     r"""Calculate the dewpoint from specific humidity, temperature, and pressure.

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -20,6 +20,7 @@ from scipy.spatial import cKDTree
 from . import height_to_pressure_std, pressure_to_height_std
 from ..package_tools import Exporter
 from ..units import atleast_1d, check_units, concatenate, diff, units
+from ..xarray import preprocess_xarray
 
 exporter = Exporter(globals())
 
@@ -34,6 +35,7 @@ BASE_DEGREE_MULTIPLIER = 22.5 * units.degree
 
 
 @exporter.export
+@preprocess_xarray
 def resample_nn_1d(a, centers):
     """Return one-dimensional nearest-neighbor indexes based on user-specified centers.
 
@@ -59,6 +61,7 @@ def resample_nn_1d(a, centers):
 
 
 @exporter.export
+@preprocess_xarray
 def nearest_intersection_idx(a, b):
     """Determine the index of the point just before two lines with common x values.
 
@@ -86,6 +89,7 @@ def nearest_intersection_idx(a, b):
 
 
 @exporter.export
+@preprocess_xarray
 @units.wraps(('=A', '=B'), ('=A', '=B', '=B'))
 def find_intersections(x, a, b, direction='all'):
     """Calculate the best estimate of intersection.
@@ -163,6 +167,7 @@ def find_intersections(x, a, b, direction='all'):
 
 
 @exporter.export
+@preprocess_xarray
 def interpolate_nans(x, y, kind='linear'):
     """Interpolate NaN values in y.
 
@@ -248,6 +253,7 @@ def _delete_masked_points(*arrs):
 
 
 @exporter.export
+@preprocess_xarray
 def reduce_point_density(points, radius, priority=None):
     r"""Return a mask to reduce the density of points in irregularly-spaced data.
 
@@ -419,6 +425,7 @@ def _get_bound_pressure_height(pressure, bound, heights=None, interpolate=True):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[length]')
 def get_layer_heights(heights, depth, *args, **kwargs):
     """Return an atmospheric layer from upper air data with the requested bottom and depth.
@@ -510,6 +517,7 @@ def get_layer_heights(heights, depth, *args, **kwargs):
 
 
 @exporter.export
+@preprocess_xarray
 @check_units('[pressure]')
 def get_layer(pressure, *args, **kwargs):
     r"""Return an atmospheric layer from upper air data with the requested bottom and depth.
@@ -616,6 +624,7 @@ def get_layer(pressure, *args, **kwargs):
 
 
 @exporter.export
+@preprocess_xarray
 @units.wraps(None, ('=A', '=A'))
 def interp(x, xp, *args, **kwargs):
     r"""Interpolates data with any shape over a specified axis.
@@ -737,6 +746,7 @@ def interp(x, xp, *args, **kwargs):
 
 
 @exporter.export
+@preprocess_xarray
 def find_bounding_indices(arr, values, axis, from_below=True):
     """Find the indices surrounding the values within arr along axis.
 
@@ -842,6 +852,7 @@ def broadcast_indices(x, minv, ndim, axis):
 
 
 @exporter.export
+@preprocess_xarray
 @units.wraps(None, ('=A', '=A'))
 def log_interp(x, xp, *args, **kwargs):
     r"""Interpolates data with logarithmic x-scale over a specified axis.
@@ -940,6 +951,7 @@ def _less_or_close(a, value, **kwargs):
 
 
 @exporter.export
+@preprocess_xarray
 def first_derivative(f, **kwargs):
     """Calculate the first derivative of a grid of values.
 
@@ -1024,6 +1036,7 @@ def first_derivative(f, **kwargs):
 
 
 @exporter.export
+@preprocess_xarray
 def second_derivative(f, **kwargs):
     """Calculate the second derivative of a grid of values.
 
@@ -1107,6 +1120,7 @@ def second_derivative(f, **kwargs):
 
 
 @exporter.export
+@preprocess_xarray
 def gradient(f, **kwargs):
     """Calculate the gradient of a grid of values.
 
@@ -1141,6 +1155,7 @@ def gradient(f, **kwargs):
 
 
 @exporter.export
+@preprocess_xarray
 def laplacian(f, **kwargs):
     """Calculate the laplacian of a grid of values.
 
@@ -1229,6 +1244,7 @@ def _process_deriv_args(f, kwargs):
 
 
 @exporter.export
+@preprocess_xarray
 def parse_angle(input_dir):
     """Calculate the meteorological angle from directional text.
 

--- a/metpy/calc/turbulence.py
+++ b/metpy/calc/turbulence.py
@@ -6,11 +6,13 @@ r"""Contains calculations related to turbulence and time series perturbations.""
 import numpy as np
 
 from ..package_tools import Exporter
+from ..xarray import preprocess_xarray
 
 exporter = Exporter(globals())
 
 
 @exporter.export
+@preprocess_xarray
 def get_perturbation(ts, axis=-1):
     r"""Compute the perturbation from the mean of a time series.
 
@@ -50,6 +52,7 @@ def get_perturbation(ts, axis=-1):
 
 
 @exporter.export
+@preprocess_xarray
 def tke(u, v, w, perturbation=False, axis=-1):
     r"""Compute turbulence kinetic energy.
 
@@ -115,6 +118,7 @@ def tke(u, v, w, perturbation=False, axis=-1):
 
 
 @exporter.export
+@preprocess_xarray
 def kinematic_flux(vel, b, perturbation=False, axis=-1):
     r"""Compute the kinematic flux from two time series.
 
@@ -183,6 +187,7 @@ def kinematic_flux(vel, b, perturbation=False, axis=-1):
 
 
 @exporter.export
+@preprocess_xarray
 def friction_velocity(u, w, v=None, perturbation=False, axis=-1):
     r"""Compute the friction velocity from the time series of velocity components.
 

--- a/metpy/io/__init__.py
+++ b/metpy/io/__init__.py
@@ -9,8 +9,6 @@ that are already in memory (using :class:`python:io.StringIO`) or remote files
 
 from .gini import *  # noqa: F403
 from .nexrad import *  # noqa: F403
-from .xarray import *  # noqa: F403
 
 __all__ = gini.__all__[:]  # pylint: disable=undefined-variable
 __all__.extend(nexrad.__all__)  # pylint: disable=undefined-variable
-__all__.extend(xarray.__all__)  # pylint: disable=undefined-variable

--- a/metpy/tests/test_xarray.py
+++ b/metpy/tests/test_xarray.py
@@ -2,14 +2,13 @@
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Test the operation of MetPy's XArray accessors."""
+from __future__ import absolute_import
 
 import cartopy.crs as ccrs
 import numpy as np
 import pytest
 import xarray as xr
 
-# Get activate the xarray accessors
-import metpy.io  # noqa: F401
 from metpy.testing import assert_almost_equal, get_test_data
 from metpy.units import units
 

--- a/metpy/tests/test_xarray.py
+++ b/metpy/tests/test_xarray.py
@@ -9,8 +9,9 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from metpy.testing import assert_almost_equal, get_test_data
+from metpy.testing import assert_almost_equal, assert_array_equal, get_test_data
 from metpy.units import units
+from metpy.xarray import preprocess_xarray
 
 
 @pytest.fixture
@@ -105,3 +106,15 @@ def test_missing_grid_mapping_var():
 
     with pytest.warns(UserWarning, match='Could not find'):
         ds.metpy.parse_cf('data')
+
+
+def test_preprocess_xarray():
+    """Test xarray preprocessing decorator."""
+    data = xr.DataArray(np.ones(3), attrs={'units': 'km'})
+    data2 = xr.DataArray(np.ones(3), attrs={'units': 'm'})
+
+    @preprocess_xarray
+    def func(a, b):
+        return a.to('m') + b
+
+    assert_array_equal(func(data, b=data2), np.array([1001, 1001, 1001]) * units.m)

--- a/metpy/xarray.py
+++ b/metpy/xarray.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 
 import xarray as xr
 
-from ..units import DimensionalityError, units
+from .units import DimensionalityError, units
 
 __all__ = []
 
@@ -59,7 +59,7 @@ class CFConventionHandler(object):
 
     def parse_cf(self, varname):
         """Parse Climate and Forecasting (CF) convention metadata."""
-        from ..plots.mapping import CFProjection
+        from .plots.mapping import CFProjection
 
         var = self._dataset[varname]
         if 'grid_mapping' in var.attrs:

--- a/metpy/xarray.py
+++ b/metpy/xarray.py
@@ -4,6 +4,8 @@
 """Provide accessors to enhance interoperability between XArray and MetPy."""
 from __future__ import absolute_import
 
+import functools
+
 import xarray as xr
 
 from .units import DimensionalityError, units
@@ -120,3 +122,17 @@ class CFConventionHandler(object):
                     scaled_vals = new_data_array.metpy.unit_array * (height * units.meters)
                     new_data_array.metpy.unit_array = scaled_vals.to('meters')
                     var.coords[coord_name] = new_data_array
+
+
+def preprocess_xarray(func):
+    """Decorate a function to convert all DataArray arguments to pint.Quantities.
+
+    This uses the metpy xarray accessors to do the actual conversion.
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        args = tuple(a.metpy.unit_array if isinstance(a, xr.DataArray) else a for a in args)
+        kwargs = {name: (v.metpy.unit_array if isinstance(v, xr.DataArray) else v)
+                  for name, v in kwargs.items()}
+        return func(*args, **kwargs)
+    return wrapper


### PR DESCRIPTION
This adds a decorator, which automatically converts `DataArray` instances to `pint.Quantity` instances (using the `.metpy.unit_array` accessor) to all the calculation functions. I added an independent test of the decorator, as well as a test for one calculation. Ideally we'd have tests for each calculation that `DataArray`s work (ensuring that the decorator has been added), but that seems a little repetitive to bite off right now.

I also moved the `xarray.py` out of `io` and into a top-level module, which is imported by the top-level `__init__.py`. This causes the accessors to be loaded with any import of metpy, which seems like a better solution than forcing random imports of `metpy.io`.