### PR TITLE
Clean up examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
   include:
     - python: 2.7
       env:
-        - VERSIONS="numpy==1.10.0 matplotlib==1.4.0 scipy==0.14.0 pint==0.8 xarray==0.9.0"
+        - VERSIONS="numpy==1.10.0 matplotlib==1.4.0 scipy==0.14.0 pint==0.8 xarray==0.9.6"
         - TASK="coverage"
         - TEST_OUTPUT_CONTROL=""
     - python: 3.4

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - scipy
   - matplotlib
   - pint
-  - netcdf4!=1.4
+  - netcdf4
   - xarray
   - pandas
   - jupyter

--- a/examples/sigma_to_pressure_interpolation.py
+++ b/examples/sigma_to_pressure_interpolation.py
@@ -33,9 +33,9 @@ lat = data.variables['lat'][:]
 lon = data.variables['lon'][:]
 time = data.variables['time']
 vtimes = num2date(time[:], time.units)
-temperature = data.variables['temperature'][:] * units(data.variables['temperature'].units)
-pres = data.variables['pressure'][:] * units(data.variables['pressure'].units)
-hgt = data.variables['height'][:] * units(data.variables['height'].units)
+temperature = data.variables['temperature'][:] * units.celsius
+pres = data.variables['pressure'][:] * units.pascal
+hgt = data.variables['height'][:] * units.meter
 
 ####################################
 # Array of desired pressure levels
@@ -59,12 +59,6 @@ height, temp = mpcalc.log_interp(plevs, pres, hgt, temperature, axis=1)
 # Set up our projection
 crs = ccrs.LambertConformal(central_longitude=-100.0, central_latitude=45.0)
 
-# Set up our array of latitude and longitude values and transform to
-# the desired projection.
-tlatlons = crs.transform_points(ccrs.PlateCarree(), lon, lat)
-tlons = tlatlons[:, :, 0]
-tlats = tlatlons[:, :, 1]
-
 # Set the forecast hour
 FH = 1
 
@@ -78,13 +72,14 @@ ax.add_feature(cfeature.COASTLINE.with_scale('50m'), linewidth=0.75)
 ax.add_feature(cfeature.STATES, linewidth=0.5)
 
 # Plot the heights
-cs = ax.contour(tlons, tlats, height[FH, 0, :, :],
+cs = ax.contour(lon, lat, height[FH, 0, :, :], transform=ccrs.PlateCarree(),
                 colors='k', linewidths=1.0, linestyles='solid')
 ax.clabel(cs, fontsize=10, inline=1, inline_spacing=7,
           fmt='%i', rightside_up=True, use_clabeltext=True)
 
 # Contour the temperature
-cf = ax.contourf(tlons, tlats, temp[FH, 0, :, :], range(-20, 20, 1), cmap=plt.cm.RdBu_r)
+cf = ax.contourf(lon, lat, temp[FH, 0, :, :], range(-20, 20, 1), cmap=plt.cm.RdBu_r,
+                 transform=ccrs.PlateCarree())
 cb = fig.colorbar(cf, orientation='horizontal', extend='max', aspect=65, shrink=0.5,
                   pad=0.05, extendrect='True')
 cb.set_label('Celsius', size='x-large')

--- a/metpy/calc/tests/test_tools.py
+++ b/metpy/calc/tests/test_tools.py
@@ -487,6 +487,15 @@ def test_greater_or_close():
     assert_array_equal(res, truth)
 
 
+def test_greater_or_close_mixed_types():
+    """Test _greater_or_close with mixed Quantity and array errors."""
+    with pytest.raises(ValueError):
+        _greater_or_close(1000. * units.mbar, 1000.)
+
+    with pytest.raises(ValueError):
+        _greater_or_close(1000., 1000. * units.mbar)
+
+
 def test_less_or_close():
     """Test floating point less or close to."""
     x = np.array([0.0, 1.0, 1.49999, 1.5, 1.5000, 1.7])
@@ -494,6 +503,15 @@ def test_less_or_close():
     truth = np.array([True, True, True, True, True, False])
     res = _less_or_close(x, comparison_value)
     assert_array_equal(res, truth)
+
+
+def test_less_or_close_mixed_types():
+    """Test _less_or_close with mixed Quantity and array errors."""
+    with pytest.raises(ValueError):
+        _less_or_close(1000. * units.mbar, 1000.)
+
+    with pytest.raises(ValueError):
+        _less_or_close(1000., 1000. * units.mbar)
 
 
 def test_get_layer_heights_interpolation():

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -467,7 +467,7 @@ def parcel_profile(pressure, temperature, dewpt):
     t1 = dry_lapse(press_lower, temperature)
 
     # If the pressure profile doesn't make it to the lcl, we can stop here
-    if _greater_or_close(np.nanmin(pressure), lcl_pressure):
+    if _greater_or_close(np.nanmin(pressure), lcl_pressure.m):
         return t1[:-1]
 
     # Find moist pseudo-adiabatic profile starting at the LCL

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -925,7 +925,7 @@ def _greater_or_close(a, value, **kwargs):
         Boolean array where values are greater than or nearly equal to value.
 
     """
-    return np.greater(a, value) | np.isclose(a, value, **kwargs)
+    return (a > value) | np.isclose(a, value, **kwargs)
 
 
 def _less_or_close(a, value, **kwargs):
@@ -947,7 +947,7 @@ def _less_or_close(a, value, **kwargs):
         Boolean array where values are less than or nearly equal to value.
 
     """
-    return np.less(a, value) | np.isclose(a, value, **kwargs)
+    return (a < value) | np.isclose(a, value, **kwargs)
 
 
 @exporter.export

--- a/metpy/plots/_util.py
+++ b/metpy/plots/_util.py
@@ -55,7 +55,7 @@ def add_timestamp(ax, time=None, x=0.99, y=-0.04, ha='right', high_contrast=Fals
     text_args.update(**kwargs)
     if not time:
         time = datetime.utcnow()
-    timestr = pretext + datetime.strftime(time, time_format)
+    timestr = pretext + time.strftime(time_format)
     return ax.text(x, y, timestr, ha=ha, transform=ax.transAxes, **text_args)
 
 

--- a/metpy/tests/test_xarray.py
+++ b/metpy/tests/test_xarray.py
@@ -118,3 +118,9 @@ def test_preprocess_xarray():
         return a.to('m') + b
 
     assert_array_equal(func(data, b=data2), np.array([1001, 1001, 1001]) * units.m)
+
+
+def test_strftime():
+    """Test our monkey-patched xarray strftime."""
+    data = xr.DataArray(np.datetime64('2000-01-01 01:00:00'))
+    assert '2000-01-01 01:00:00' == data.dt.strftime('%Y-%m-%d %H:%M:%S')

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
 
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=['matplotlib>=1.4', 'numpy>=1.10.0', 'scipy>=0.14',
-                      'pint>=0.8', 'xarray>=0.9.0', 'enum34;python_version<"3.4"'],
+                      'pint>=0.8', 'xarray>=0.9.6', 'enum34;python_version<"3.4"'],
     extras_require={
         'cdm': ['pyproj>=1.9.4'],
         'dev': ['ipython[all]>=3.1'],

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         'cdm': ['pyproj>=1.9.4'],
         'dev': ['ipython[all]>=3.1'],
         'doc': ['sphinx>=1.4', 'sphinx-gallery', 'doc8', 'recommonmark',
-                'netCDF4!=1.4'],
+                'netCDF4'],
         'examples': ['cartopy>=0.13.1'],
         'test': ['pytest>=2.4', 'pytest-runner', 'pytest-mpl', 'pytest-flake8',
                  'cartopy>=0.13.1', 'flake8>3.2.0', 'flake8-builtins!=1.4.0',


### PR DESCRIPTION
- Fix weird warning "'numpy.float64' object has no attribute '_units’" in Advanced Sounding. Turns out we were comparing `Quantity` with a bare `array` and things didn't error.
- Make `add_timestamp` call the `strftime` method on the passed in datetime rather than force calling `strftime` from the `datetime` module. This paves the way for using "date times" from xarray
- Move the isentropic interpolation and four panel map examples to use xarray (and in the case of the former better use cartopy)
- Make the sigma interpolation example work with netcdf4 1.4 by hard-coding units rather than parsing. This seemed the least horrible of many horrible-looking solutions. Would be nice to use xarray, but alas there are complications.

Fixes #836 .