### PR TITLE
Fix mask propagation in gradient

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,8 @@ jobs:
             sudo apt-get install libgeos-dev libproj-dev
             python3 -m venv venv
             . venv/bin/activate
-            pip install ".[test,cdm]" "shapely<1.5.17.post1" -f https://unidata-python.s3.amazonaws.com/wheelhouse/index.html
+            pip install --upgrade pytest
+            pip install ".[test,cdm]" "shapely<1.5.17.post1" --upgrade --upgrade-strategy=eager -f https://unidata-python.s3.amazonaws.com/wheelhouse/index.html
 
       - save_cache:
           paths:
@@ -43,4 +44,3 @@ jobs:
       - store_artifacts:
           path: test-reports
           destination: test-reports
-          

--- a/.mailmap
+++ b/.mailmap
@@ -8,3 +8,5 @@ Brian Mapes <mapes@miami.edu>
 Kristen Pozsonyi <knpozson@millersville.edu>
 Daryl Herzmann <akrherz@iastate.edu>
 Kishan Mehta <kishan@mobifly.co.uk>
+Matt Wilson <matthew.wilson@valpo.edu>
+Andrew Huang <ahuang11@illinois.edu>

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ before_install:
   - touch $WHEELDIR/download_marker && ls -lrt $WHEELDIR;
   - travis_wait pip wheel -w $WHEELDIR $EXTRA_PACKAGES -f $WHEELHOUSE $PRE $VERSIONS;
   - pip install $EXTRA_PACKAGES --upgrade --upgrade-strategy=eager --no-index -f file://$PWD/$WHEELDIR $VERSIONS;
-  - travis_wait pip wheel -w $WHEELDIR ".[$EXTRA_INSTALLS]" $EXTRA_PACKAGES -f $WHEELHOUSE $PRE $VERSIONS;
+  - travis_wait 30 pip wheel -w $WHEELDIR ".[$EXTRA_INSTALLS]" $EXTRA_PACKAGES -f $WHEELHOUSE $PRE $VERSIONS;
   - rm -f $WHEELDIR/MetPy*.whl;
 
 install:

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -3,8 +3,12 @@ UCAR/Unidata
 Aaron Hill
 Abby Kenyon
 Alex Haberlie
+Andrew Huang
+Assela Pathirana
 Brian Mapes
 Bryan Guarente
+Claude Dicaire
+Dan Dawson
 Daryl Herzmann
 Denis Sergeev
 Eric Bruning

--- a/metpy/calc/tests/test_tools.py
+++ b/metpy/calc/tests/test_tools.py
@@ -614,6 +614,18 @@ def test_first_derivative_scalar_delta():
     assert_array_almost_equal(df_dx, np.array([1., 1., 1.]), 6)
 
 
+def test_first_derivative_masked():
+    """Test that first_derivative properly propagates masks."""
+    data = np.ma.arange(7)
+    data[3] = np.ma.masked
+    df_dx = first_derivative(data, delta=1)
+
+    truth = np.ma.array([1., 1., 1., 1., 1., 1., 1.],
+                        mask=[False, False, True, True, True, False, False])
+    assert_array_almost_equal(df_dx, truth)
+    assert_array_equal(df_dx.mask, truth.mask)
+
+
 def test_second_derivative(deriv_1d_data):
     """Test second_derivative with a simple 1D array."""
     d2v_dx2 = second_derivative(deriv_1d_data.values, x=deriv_1d_data.x)

--- a/metpy/units.py
+++ b/metpy/units.py
@@ -101,7 +101,13 @@ def concatenate(arrs, axis=0):
             a = a.to(dest).magnitude
         data.append(np.atleast_1d(a))
 
-    return units.Quantity(np.concatenate(data, axis=axis), dest)
+    # Use masked array concatenate to ensure masks are preserved, but convert to an
+    # array if there are no masked values.
+    data = np.ma.concatenate(data, axis=axis)
+    if not np.any(data.mask):
+        data = np.asarray(data)
+
+    return units.Quantity(data, dest)
 
 
 def diff(x, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
                 'netCDF4'],
         'examples': ['cartopy>=0.13.1'],
         'test': ['pytest>=2.4', 'pytest-runner', 'pytest-mpl', 'pytest-flake8',
-                 'cartopy>=0.13.1', 'flake8>3.2.0', 'flake8-builtins!=1.4.0',
+                 'cartopy>=0.16.0', 'flake8>3.2.0', 'flake8-builtins!=1.4.0',
                  'flake8-comprehensions', 'flake8-copyright',
                  'flake8-docstrings', 'flake8-import-order', 'flake8-mutable',
                  'flake8-pep3101', 'flake8-print', 'flake8-quotes',


### PR DESCRIPTION
Fixes #642.

The calculation propagates masked values fine, in that any calculation involving one more more masked values ends up as masked (similar to NaN propagation). The problem was using numpy's concatenate, which stripped masks. Use np.ma.concatentate instead, dropping to a regular array if there are no masked values.

Went ahead and also fixed our CircleCi build, which revealed an implicit testing dependence on a newer version of CartoPy than we listed.

Will rebase on master for release, but I want to see if the travis_wait change helps the build on travis python nightlies.