### PR TITLE
MNT: Fix some non-standard naming

### DIFF
--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -504,14 +504,14 @@ def test_storm_relative_helicity():
     # negative SRH will be zero.
     srh_true_t = srh_true_p
     srh_true_n = 0 * units('m^2/s^2')
-    p_srh, n_srh, T_srh = storm_relative_helicity(u_int, v_int,
+    p_srh, n_srh, t_srh = storm_relative_helicity(u_int, v_int,
                                                   hgt_int, 1000 * units('meter'),
                                                   bottom=0 * units('meter'),
                                                   storm_u=0 * units.knot,
                                                   storm_v=0 * units.knot)
     assert_almost_equal(p_srh, srh_true_p, 2)
     assert_almost_equal(n_srh, srh_true_n, 2)
-    assert_almost_equal(T_srh, srh_true_t, 2)
+    assert_almost_equal(t_srh, srh_true_t, 2)
 
 
 def test_storm_relative_helicity_agl():

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -251,8 +251,8 @@ def test_lfc_ml():
     levels = np.array([959., 779.2, 751.3, 724.3, 700., 269.]) * units.mbar
     temperatures = np.array([22.2, 14.6, 12., 9.4, 7., -49.]) * units.celsius
     dewpoints = np.array([19., -11.2, -10.8, -10.4, -10., -53.2]) * units.celsius
-    __, T_mixed, Td_mixed = mixed_parcel(levels, temperatures, dewpoints)
-    mixed_parcel_prof = parcel_profile(levels, T_mixed, Td_mixed)
+    __, t_mixed, td_mixed = mixed_parcel(levels, temperatures, dewpoints)
+    mixed_parcel_prof = parcel_profile(levels, t_mixed, td_mixed)
     lfc_pressure, lfc_temp = lfc(levels, temperatures, dewpoints, mixed_parcel_prof)
     assert_almost_equal(lfc_pressure, 631.794 * units.mbar, 2)
     assert_almost_equal(lfc_temp, -1.862 * units.degC, 2)
@@ -373,8 +373,8 @@ def test_el_ml():
     levels = np.array([959., 779.2, 751.3, 724.3, 700., 400., 269.]) * units.mbar
     temperatures = np.array([22.2, 14.6, 12., 9.4, 7., -25., -35.]) * units.celsius
     dewpoints = np.array([19., -11.2, -10.8, -10.4, -10., -35., -53.2]) * units.celsius
-    __, T_mixed, Td_mixed = mixed_parcel(levels, temperatures, dewpoints)
-    mixed_parcel_prof = parcel_profile(levels, T_mixed, Td_mixed)
+    __, t_mixed, td_mixed = mixed_parcel(levels, temperatures, dewpoints)
+    mixed_parcel_prof = parcel_profile(levels, t_mixed, td_mixed)
     el_pressure, el_temperature = el(levels, temperatures, dewpoints, mixed_parcel_prof)
     assert_almost_equal(el_pressure, 355.834 * units.mbar, 3)
     assert_almost_equal(el_temperature, -28.371 * units.degC, 3)

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -1370,11 +1370,11 @@ def most_unstable_parcel(pressure, temperature, dewpoint, heights=None,
     get_layer
 
     """
-    p_layer, T_layer, Td_layer = get_layer(pressure, temperature, dewpoint, bottom=bottom,
+    p_layer, t_layer, td_layer = get_layer(pressure, temperature, dewpoint, bottom=bottom,
                                            depth=depth, heights=heights, interpolate=False)
-    theta_e = equivalent_potential_temperature(p_layer, T_layer, Td_layer)
+    theta_e = equivalent_potential_temperature(p_layer, t_layer, td_layer)
     max_idx = np.argmax(theta_e)
-    return p_layer[max_idx], T_layer[max_idx], Td_layer[max_idx], max_idx
+    return p_layer[max_idx], t_layer[max_idx], td_layer[max_idx], max_idx
 
 
 @exporter.export


### PR DESCRIPTION
Capitalized names are reserved for classes. Picked up by pep8-naming 0.7.