### PR TITLE
Update Wind Functions

### DIFF
--- a/examples/Advanced_Sounding.py
+++ b/examples/Advanced_Sounding.py
@@ -31,8 +31,8 @@ col_names = ['pressure', 'height', 'temperature', 'dewpoint', 'direction', 'spee
 df = pd.read_fwf(get_test_data('may4_sounding.txt', as_file_obj=False),
                  skiprows=5, usecols=[0, 1, 2, 3, 6, 7], names=col_names)
 
-df['u_wind'], df['v_wind'] = mpcalc.get_wind_components(df['speed'],
-                                                        np.deg2rad(df['direction']))
+df['u_wind'], df['v_wind'] = mpcalc.wind_components(df['speed'],
+                                                    np.deg2rad(df['direction']))
 
 # Drop any rows with all NaN values for T, Td, winds
 df = df.dropna(subset=('temperature', 'dewpoint', 'direction', 'speed',
@@ -47,7 +47,7 @@ T = df['temperature'].values * units.degC
 Td = df['dewpoint'].values * units.degC
 wind_speed = df['speed'].values * units.knots
 wind_dir = df['direction'].values * units.degrees
-u, v = mpcalc.get_wind_components(wind_speed, wind_dir)
+u, v = mpcalc.wind_components(wind_speed, wind_dir)
 
 ###########################################
 # Create a new figure. The dimensions here give a good aspect ratio.

--- a/examples/gridding/Wind_SLP_Interpolation.py
+++ b/examples/gridding/Wind_SLP_Interpolation.py
@@ -15,7 +15,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from metpy.calc import get_wind_components
+from metpy.calc import wind_components
 from metpy.cbook import get_test_data
 from metpy.gridding.gridding_functions import interpolate, remove_nan_observations
 from metpy.plots import add_metpy_logo
@@ -62,7 +62,7 @@ wind_dir = wind_dir[good_indices]
 # Calculate u and v components of wind and then interpolate both.
 #
 # Both will have the same underlying grid so throw away grid returned from v interpolation.
-u, v = get_wind_components(wind_speed, wind_dir)
+u, v = wind_components(wind_speed, wind_dir)
 
 windgridx, windgridy, uwind = interpolate(x_masked, y_masked, np.array(u),
                                           interp_type='cressman', search_radius=400000,

--- a/examples/plots/Hodograph_Inset.py
+++ b/examples/plots/Hodograph_Inset.py
@@ -27,8 +27,8 @@ col_names = ['pressure', 'height', 'temperature', 'dewpoint', 'direction', 'spee
 df = pd.read_fwf(get_test_data('may4_sounding.txt', as_file_obj=False),
                  skiprows=5, usecols=[0, 1, 2, 3, 6, 7], names=col_names)
 
-df['u_wind'], df['v_wind'] = mpcalc.get_wind_components(df['speed'],
-                                                        np.deg2rad(df['direction']))
+df['u_wind'], df['v_wind'] = mpcalc.wind_components(df['speed'],
+                                                    np.deg2rad(df['direction']))
 
 # Drop any rows with all NaN values for T, Td, winds
 df = df.dropna(subset=('temperature', 'dewpoint', 'direction', 'speed',
@@ -43,7 +43,7 @@ T = df['temperature'].values * units.degC
 Td = df['dewpoint'].values * units.degC
 wind_speed = df['speed'].values * units.knots
 wind_dir = df['direction'].values * units.degrees
-u, v = mpcalc.get_wind_components(wind_speed, wind_dir)
+u, v = mpcalc.wind_components(wind_speed, wind_dir)
 
 ###########################################
 

--- a/examples/plots/Simple_Sounding.py
+++ b/examples/plots/Simple_Sounding.py
@@ -33,8 +33,8 @@ col_names = ['pressure', 'height', 'temperature', 'dewpoint', 'direction', 'spee
 df = pd.read_fwf(get_test_data('jan20_sounding.txt', as_file_obj=False),
                  skiprows=5, usecols=[0, 1, 2, 3, 6, 7], names=col_names)
 
-df['u_wind'], df['v_wind'] = mpcalc.get_wind_components(df['speed'],
-                                                        np.deg2rad(df['direction']))
+df['u_wind'], df['v_wind'] = mpcalc.wind_components(df['speed'],
+                                                    np.deg2rad(df['direction']))
 
 # Drop any rows with all NaN values for T, Td, winds
 df = df.dropna(subset=('temperature', 'dewpoint', 'direction', 'speed',
@@ -49,7 +49,7 @@ T = df['temperature'].values * units.degC
 Td = df['dewpoint'].values * units.degC
 wind_speed = df['speed'].values * units.knots
 wind_dir = df['direction'].values * units.degrees
-u, v = mpcalc.get_wind_components(wind_speed, wind_dir)
+u, v = mpcalc.wind_components(wind_speed, wind_dir)
 
 ###########################################
 

--- a/examples/plots/Skew-T_Layout.py
+++ b/examples/plots/Skew-T_Layout.py
@@ -27,8 +27,8 @@ col_names = ['pressure', 'height', 'temperature', 'dewpoint', 'direction', 'spee
 df = pd.read_fwf(get_test_data('may4_sounding.txt', as_file_obj=False),
                  skiprows=5, usecols=[0, 1, 2, 3, 6, 7], names=col_names)
 
-df['u_wind'], df['v_wind'] = mpcalc.get_wind_components(df['speed'],
-                                                        np.deg2rad(df['direction']))
+df['u_wind'], df['v_wind'] = mpcalc.wind_components(df['speed'],
+                                                    np.deg2rad(df['direction']))
 
 # Drop any rows with all NaN values for T, Td, winds
 df = df.dropna(subset=('temperature', 'dewpoint', 'direction', 'speed',
@@ -43,7 +43,7 @@ T = df['temperature'].values * units.degC
 Td = df['dewpoint'].values * units.degC
 wind_speed = df['speed'].values * units.knots
 wind_dir = df['direction'].values * units.degrees
-u, v = mpcalc.get_wind_components(wind_speed, wind_dir)
+u, v = mpcalc.wind_components(wind_speed, wind_dir)
 
 ###########################################
 

--- a/examples/plots/Station_Plot.py
+++ b/examples/plots/Station_Plot.py
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from metpy.calc import get_wind_components
+from metpy.calc import wind_components
 from metpy.calc import reduce_point_density
 from metpy.cbook import get_test_data
 from metpy.plots import add_metpy_logo, current_weather, sky_cover, StationPlot, wx_code_map
@@ -60,8 +60,8 @@ data = data[reduce_point_density(point_locs, 300000.)]
 
 # Get the wind components, converting from m/s to knots as will be appropriate
 # for the station plot.
-u, v = get_wind_components((data['wind_speed'].values * units('m/s')).to('knots'),
-                           data['wind_dir'].values * units.degree)
+u, v = wind_components((data['wind_speed'].values * units('m/s')).to('knots'),
+                       data['wind_dir'].values * units.degree)
 
 # Convert the fraction value into a code of 0-8 and compensate for NaN values,
 # which can be used to pull out the appropriate symbol

--- a/examples/plots/Station_Plot.py
+++ b/examples/plots/Station_Plot.py
@@ -17,8 +17,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from metpy.calc import wind_components
 from metpy.calc import reduce_point_density
+from metpy.calc import wind_components
 from metpy.cbook import get_test_data
 from metpy.plots import add_metpy_logo, current_weather, sky_cover, StationPlot, wx_code_map
 from metpy.units import units

--- a/examples/plots/Station_Plot_with_Layout.py
+++ b/examples/plots/Station_Plot_with_Layout.py
@@ -22,7 +22,7 @@ import cartopy.feature as cfeature
 import matplotlib.pyplot as plt
 import pandas as pd
 
-from metpy.calc import get_wind_components
+from metpy.calc import wind_components
 from metpy.cbook import get_test_data
 from metpy.plots import (add_metpy_logo, simple_layout, StationPlot,
                          StationPlotLayout, wx_code_map)
@@ -91,8 +91,8 @@ data['air_pressure_at_sea_level'] = data_arr['slp'].values * units('mbar')
 
 # Get the wind components, converting from m/s to knots as will be appropriate
 # for the station plot
-u, v = get_wind_components(data_arr['wind_speed'].values * units('m/s'),
-                           data_arr['wind_dir'].values * units.degree)
+u, v = wind_components(data_arr['wind_speed'].values * units('m/s'),
+                       data_arr['wind_dir'].values * units.degree)
 data['eastward_wind'], data['northward_wind'] = u, v
 
 # Convert the fraction value into a code of 0-8, which can be used to pull out

--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -17,6 +17,7 @@ import warnings
 import numpy as np
 
 from ..constants import G, g, me, omega, Rd, Re
+from ..deprecation import deprecated
 from ..package_tools import Exporter
 from ..units import atleast_1d, check_units, masked_array, units
 from ..xarray import preprocess_xarray
@@ -26,7 +27,7 @@ exporter = Exporter(globals())
 
 @exporter.export
 @preprocess_xarray
-def get_wind_speed(u, v):
+def wind_speed(u, v):
     r"""Compute the wind speed from u and v-components.
 
     Parameters
@@ -43,7 +44,7 @@ def get_wind_speed(u, v):
 
     See Also
     --------
-    get_wind_components
+    wind_components
 
     """
     speed = np.sqrt(u * u + v * v)
@@ -52,7 +53,7 @@ def get_wind_speed(u, v):
 
 @exporter.export
 @preprocess_xarray
-def get_wind_dir(u, v):
+def wind_direction(u, v):
     r"""Compute the wind direction from u and v-components.
 
     Parameters
@@ -70,7 +71,7 @@ def get_wind_dir(u, v):
 
     See Also
     --------
-    get_wind_components
+    wind_components
 
     """
     wdir = 90. * units.deg - np.arctan2(-v, -u)
@@ -82,7 +83,7 @@ def get_wind_dir(u, v):
 
 @exporter.export
 @preprocess_xarray
-def get_wind_components(speed, wdir):
+def wind_components(speed, wdir):
     r"""Calculate the U, V wind vector components from the speed and direction.
 
     Parameters
@@ -101,13 +102,13 @@ def get_wind_components(speed, wdir):
 
     See Also
     --------
-    get_wind_speed
-    get_wind_dir
+    wind_speed
+    wind_direction
 
     Examples
     --------
     >>> from metpy.units import units
-    >>> metpy.calc.get_wind_components(10. * units('m/s'), 225. * units.deg)
+    >>> metpy.calc.wind_components(10. * units('m/s'), 225. * units.deg)
     (<Quantity(7.071067811865475, 'meter / second')>,
      <Quantity(7.071067811865477, 'meter / second')>)
 
@@ -116,6 +117,49 @@ def get_wind_components(speed, wdir):
     u = -speed * np.sin(wdir)
     v = -speed * np.cos(wdir)
     return u, v
+
+
+@exporter.export
+@preprocess_xarray
+@deprecated('0.9', addendum=' This function has been renamed wind_speed.',
+            pending=False)
+def get_wind_speed(u, v):
+    """Wrap wind_speed for deprecated get_wind_speed function."""
+    return wind_speed(u, v)
+
+
+get_wind_speed.__doc__ = (wind_speed.__doc__ +
+                          '\n    .. deprecated:: 0.9.0\n        Function has been renamed to '
+                          '`wind_speed` and will be removed from MetPy in 0.12.0.')
+
+
+@exporter.export
+@preprocess_xarray
+@deprecated('0.9', addendum=' This function has been renamed wind_direction.',
+            pending=False)
+def get_wind_dir(u, v):
+    """Wrap wind_direction for deprecated get_wind_dir function."""
+    return wind_direction(u, v)
+
+
+get_wind_dir.__doc__ = (wind_direction.__doc__ +
+                        '\n    .. deprecated:: 0.9.0\n        Function has been renamed to '
+                        '`wind_direction` and will be removed from MetPy in 0.12.0.')
+
+
+@exporter.export
+@preprocess_xarray
+@deprecated('0.9', addendum=' This function has been renamed wind_components.',
+            pending=False)
+def get_wind_components(u, v):
+    """Wrap wind_components for deprecated get_wind_components function."""
+    return wind_components(u, v)
+
+
+get_wind_components.__doc__ = (wind_components.__doc__ +
+                               '\n    .. deprecated:: 0.9.0\n        Function has been '
+                               'renamed to `wind_components` and will be removed from MetPy '
+                               'in 0.12.0.')
 
 
 @exporter.export

--- a/metpy/calc/tests/test_basic.py
+++ b/metpy/calc/tests/test_basic.py
@@ -31,6 +31,20 @@ def test_wind_comps_basic():
     assert_array_almost_equal(true_v, v, 4)
 
 
+def test_wind_comps_with_north_and_calm():
+    """Test that the wind component calculation handles northerly and calm winds."""
+    speed = np.array([0, 5, 5]) * units.mph
+    dirs = np.array([0, 360, 0]) * units.deg
+
+    u, v = wind_components(speed, dirs)
+
+    true_u = np.array([0, 0, 0]) * units.mph
+    true_v = np.array([0, -5, -5]) * units.mph
+
+    assert_array_almost_equal(true_u, u, 4)
+    assert_array_almost_equal(true_v, v, 4)
+
+
 def test_wind_comps_scalar():
     """Test wind components calculation with scalars."""
     u, v = wind_components(8 * units('m/s'), 150 * units.deg)
@@ -58,9 +72,39 @@ def test_direction():
 
     direc = wind_direction(u, v)
 
-    true_dir = np.array([270., 225., 180., 270.]) * units.deg
+    true_dir = np.array([270., 225., 180., 0.]) * units.deg
 
     assert_array_almost_equal(true_dir, direc, 4)
+
+
+def test_direction_with_north_and_calm():
+    """Test how wind direction handles northerly and calm winds."""
+    u = np.array([0., -0., 0.]) * units('m/s')
+    v = np.array([0., 0., -5.]) * units('m/s')
+
+    direc = wind_direction(u, v)
+
+    true_dir = np.array([0., 0., 360.]) * units.deg
+
+    assert_array_almost_equal(true_dir, direc, 4)
+
+
+def test_direction_without_units():
+    """Test calculating wind direction without units."""
+    u = np.array([0., -5., -4., -3.])
+    v = np.array([0., 5., 0., -3.])
+
+    direc = wind_direction(u, v)
+
+    true_dir = np.array([0., 135., 90., 45.]) * units.deg
+
+    assert_array_almost_equal(true_dir, direc, 4)
+
+
+def test_direction_dimensions():
+    """Verify wind_direction returns degrees."""
+    d = wind_direction(3. * units('m/s'), 4. * units('m/s'))
+    assert str(d.units) == 'degree'
 
 
 def test_speed_direction_roundtrip():

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -8,13 +8,13 @@ import pytest
 
 from metpy.calc import (absolute_vorticity, advection, ageostrophic_wind,
                         convergence_vorticity, divergence,
-                        frontogenesis, geostrophic_wind, get_wind_components, h_convergence,
+                        frontogenesis, geostrophic_wind, h_convergence,
                         inertial_advective_wind, lat_lon_grid_deltas, lat_lon_grid_spacing,
                         montgomery_streamfunction, potential_vorticity_baroclinic,
                         potential_vorticity_barotropic, q_vector, shearing_deformation,
                         shearing_stretching_deformation, static_stability,
                         storm_relative_helicity, stretching_deformation, total_deformation,
-                        v_vorticity, vorticity)
+                        v_vorticity, vorticity, wind_components)
 from metpy.constants import g, omega, Re
 from metpy.deprecation import MetpyDeprecationWarning
 from metpy.testing import assert_almost_equal, assert_array_equal
@@ -494,7 +494,7 @@ def test_storm_relative_helicity():
     dir_int = np.arange(180, 272.25, 2.25)
     spd_int = np.zeros((hgt_int.shape[0]))
     spd_int[:] = 2.
-    u_int, v_int = get_wind_components(spd_int * units('m/s'), dir_int * units.degree)
+    u_int, v_int = wind_components(spd_int * units('m/s'), dir_int * units.degree)
 
     # Put in the correct value of SRH for a eighth-circle, 2 m/s hodograph
     # (SRH = 2 * area under hodo, in this case...)
@@ -1082,7 +1082,7 @@ def q_vector_data():
                      [190., 180., 180., 170.],
                      [170., 180., 180., 190.],
                      [150., 170., 190., 210.]]) * units('degrees')
-    u, v = get_wind_components(speed, wdir)
+    u, v = wind_components(speed, wdir)
 
     temp = np.array([[[18., 18., 18., 18.],
                       [17., 17., 17., 17.],

--- a/metpy/testing.py
+++ b/metpy/testing.py
@@ -13,7 +13,7 @@ import numpy.testing
 from pint import DimensionalityError
 import pytest
 
-from metpy.calc import get_wind_components
+from metpy.calc import wind_components
 from metpy.cbook import get_test_data
 from .units import units
 
@@ -74,7 +74,7 @@ def get_upper_air_data(date, station):
     direc = direc * units.degrees
     spd = spd * units.knots
 
-    u, v = get_wind_components(spd, direc)
+    u, v = wind_components(spd, direc)
 
     return {'pressure': p, 'height': z, 'temperature': t,
             'dewpoint': td, 'direction': direc, 'speed': spd, 'u_wind': u, 'v_wind': v}

--- a/tutorials/upperair_soundings.py
+++ b/tutorials/upperair_soundings.py
@@ -37,8 +37,8 @@ col_names = ['pressure', 'height', 'temperature', 'dewpoint', 'direction', 'spee
 df = pd.read_fwf(get_test_data('nov11_sounding.txt', as_file_obj=False),
                  skiprows=5, usecols=[0, 1, 2, 3, 6, 7], names=col_names)
 
-df['u_wind'], df['v_wind'] = mpcalc.get_wind_components(df['speed'],
-                                                        np.deg2rad(df['direction']))
+df['u_wind'], df['v_wind'] = mpcalc.wind_components(df['speed'],
+                                                    np.deg2rad(df['direction']))
 
 # Drop any rows with all NaN values for T, Td, winds
 df = df.dropna(subset=('temperature', 'dewpoint', 'direction', 'speed',
@@ -54,7 +54,7 @@ T = df['temperature'].values * units.degC
 Td = df['dewpoint'].values * units.degC
 wind_speed = df['speed'].values * units.knots
 wind_dir = df['direction'].values * units.degrees
-u, v = mpcalc.get_wind_components(wind_speed, wind_dir)
+u, v = mpcalc.wind_components(wind_speed, wind_dir)
 
 ##########################################################################
 # Thermodynamic Calculations


### PR DESCRIPTION
This PR addresses two issues relating to the wind functions in `calc/basics.py`. First, fixes #865 by renaming the functions as described in the issue and deprecating the old functions. Additionally, fixes #794 by ~~adding a flag to specify the behavior for `wind_direction` (formerly `get_wind_dir`) in regards to calm and north winds~~ specifying calm winds as 0 degrees and north as 360 degrees.

Also, I think that we will need to open a "Removals/Deprecations in 0.12" issue once the renaming goes through.

Feedback, especially on the approach of handling the calm and north wind issue, is greatly appreciated!