### PR TITLE
Change x to coordinates in gradient and laplacian interface

### DIFF
--- a/examples/calculations/Gradient.py
+++ b/examples/calculations/Gradient.py
@@ -36,7 +36,7 @@ y = np.array([[1, 1, 1],
 
 ###########################################
 # Calculate the gradient using the coordinates of the data
-grad = mpcalc.gradient(data, x=(y, x))
+grad = mpcalc.gradient(data, coordinates=(y, x))
 print('Gradient in y direction: ', grad[0])
 print('Gradient in x direction: ', grad[1])
 

--- a/metpy/calc/tests/test_tools.py
+++ b/metpy/calc/tests/test_tools.py
@@ -17,6 +17,7 @@ from metpy.calc import (find_bounding_indices, find_intersections, first_derivat
 from metpy.calc.tools import (_delete_masked_points, _get_bound_pressure_height,
                               _greater_or_close, _less_or_close, _next_non_masked_element,
                               DIR_STRS)
+from metpy.deprecation import MetpyDeprecationWarning
 from metpy.testing import assert_array_almost_equal, assert_array_equal
 from metpy.units import units
 
@@ -660,7 +661,7 @@ def test_second_derivative_scalar_delta():
 
 def test_laplacian(deriv_1d_data):
     """Test laplacian with simple 1D data."""
-    laplac = laplacian(deriv_1d_data.values, x=(deriv_1d_data.x,))
+    laplac = laplacian(deriv_1d_data.values, coordinates=(deriv_1d_data.x,))
 
     # Worked by hand
     truth = np.ones_like(deriv_1d_data.values) * 0.2133333 * units('delta_degC/cm**2')
@@ -670,7 +671,15 @@ def test_laplacian(deriv_1d_data):
 def test_laplacian_2d(deriv_2d_data):
     """Test lapacian with full 2D arrays."""
     laplac_true = 2 * (np.ones_like(deriv_2d_data.f) * (deriv_2d_data.a + deriv_2d_data.b))
-    laplac = laplacian(deriv_2d_data.f, x=(deriv_2d_data.y, deriv_2d_data.x))
+    laplac = laplacian(deriv_2d_data.f, coordinates=(deriv_2d_data.y, deriv_2d_data.x))
+    assert_array_almost_equal(laplac, laplac_true, 5)
+
+
+def test_laplacian_x_deprecation(deriv_2d_data):
+    """Test deprecation of x keyword argument."""
+    laplac_true = 2 * (np.ones_like(deriv_2d_data.f) * (deriv_2d_data.a + deriv_2d_data.b))
+    with pytest.warns(MetpyDeprecationWarning):
+        laplac = laplacian(deriv_2d_data.f, x=(deriv_2d_data.y, deriv_2d_data.x))
     assert_array_almost_equal(laplac, laplac_true, 5)
 
 
@@ -705,7 +714,22 @@ def test_parse_angle_mix_multiple():
 
 def test_gradient_2d(deriv_2d_data):
     """Test gradient with 2D arrays."""
-    res = gradient(deriv_2d_data.f, x=(deriv_2d_data.y, deriv_2d_data.x))
+    res = gradient(deriv_2d_data.f, coordinates=(deriv_2d_data.y, deriv_2d_data.x))
+    truth = (np.array([[-0.25, -0.25, -0.25],
+                       [1.75, 1.75, 1.75],
+                       [4.75, 4.75, 4.75],
+                       [5.75, 5.75, 5.75]]),
+             np.array([[-3, -1, 4],
+                       [-3, -1, 4],
+                       [-3, -1, 4],
+                       [-3, -1, 4]]))
+    assert_array_almost_equal(res, truth, 5)
+
+
+def test_gradient_x_deprecation(deriv_2d_data):
+    """Test deprecation of x keyword argument."""
+    with pytest.warns(MetpyDeprecationWarning):
+        res = gradient(deriv_2d_data.f, x=(deriv_2d_data.y, deriv_2d_data.x))
     truth = (np.array([[-0.25, -0.25, -0.25],
                        [1.75, 1.75, 1.75],
                        [4.75, 4.75, 4.75],

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -19,6 +19,7 @@ import numpy.ma as ma
 from scipy.spatial import cKDTree
 
 from . import height_to_pressure_std, pressure_to_height_std
+from ..deprecation import metpyDeprecation
 from ..package_tools import Exporter
 from ..units import atleast_1d, check_units, concatenate, diff, units
 from ..xarray import preprocess_xarray
@@ -1135,7 +1136,7 @@ def gradient(f, **kwargs):
     ----------
     f : array-like
         Array of values of which to calculate the derivative
-    x : array-like, optional
+    coordinates : array-like, optional
         Sequence of arrays containing the coordinate values corresponding to the
         grid points in `f` in axis order.
     deltas : array-like, optional
@@ -1150,6 +1151,11 @@ def gradient(f, **kwargs):
     See Also
     --------
     laplacian
+
+    Notes
+    -----
+    `gradient` previously accepted `x` as a parameter for coordinate values. This has been
+    deprecated in 0.9 in favor of `coordinates`.
 
     """
     pos_kwarg, positions = _process_gradient_args(kwargs)
@@ -1170,7 +1176,7 @@ def laplacian(f, **kwargs):
     ----------
     f : array-like
         Array of values of which to calculate the derivative
-    x : array-like, optional
+    coordinates : array-like, optional
         The coordinate values corresponding to the grid points in `f`
     deltas : array-like, optional
         Spacing between the grid points in `f`. There should be one item less than the size
@@ -1184,6 +1190,11 @@ def laplacian(f, **kwargs):
     See Also
     --------
     gradient
+
+    Notes
+    -----
+    `laplacian` previously accepted `x` as a parameter for coordinate values. This has been
+    deprecated in 0.9 in favor of `coordinates`.
 
     """
     pos_kwarg, positions = _process_gradient_args(kwargs)
@@ -1206,13 +1217,17 @@ def _broadcast_to_axis(arr, axis, ndim):
 def _process_gradient_args(kwargs):
     """Handle common processing of arguments for gradient and gradient-like functions."""
     if 'deltas' in kwargs:
-        if 'x' in kwargs:
-            raise ValueError('Cannot specify both "x" and "deltas".')
+        if 'coordinates' in kwargs or 'x' in kwargs:
+            raise ValueError('Cannot specify both "coordinates" and "deltas".')
         return 'delta', kwargs['deltas']
+    elif 'coordinates' in kwargs:
+        return 'x', kwargs['coordinates']
     elif 'x' in kwargs:
+        warnings.warn('The use of "x" as a parameter for coordinate values has been '
+                      'deprecated. Use "coordinates" instead.', metpyDeprecation)
         return 'x', kwargs['x']
     else:
-        raise ValueError('Must specify either "x" or "delta" for value positions.')
+        raise ValueError('Must specify either "coordinates" or "deltas" for value positions.')
 
 
 def _process_deriv_args(f, kwargs):


### PR DESCRIPTION
Fixes #842 by replacing the `x` keyword argument in `_process_gradient_args` with `coordinates`, and including `x` as a deprecated option. Also adds tests to verify that use of `x` as a keyword argument raises the deprecation warning.