### PR TITLE
Drop python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,6 @@ matrix:
         - VERSIONS="numpy==1.10.0 matplotlib==1.4.0 scipy==0.14.0 pint==0.8 xarray==0.9.6"
         - TASK="coverage"
         - TEST_OUTPUT_CONTROL=""
-    - python: 3.4
-      env:
     - python: 3.5
       env:
     - python: "3.6-dev"

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ still evolving (we won't break things just for fun, but many things are still ch
 work through design issues). Also, for a version `0.x.y`, we change `x` when we
 release new features, and `y` when we make a release with only bug fixes.
 
-We support Python >= 3.4 and currently support Python 2.7.
+We support Python >= 3.5 and currently support Python 2.7.
 
 NOTE: We are dropping support for Python 2.7 in Fall 2019. See
 `here <https://github.com/Unidata/MetPy/blob/master/docs/installguide.rst>`_ for more

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
                                   '_static/metpy_150x150.png', '_static/unidata_75x75.png',
                                   '_static/unidata_150x150.png']},
 
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     install_requires=['matplotlib>=1.4', 'numpy>=1.10.0', 'scipy>=0.14',
                       'pint>=0.8', 'xarray>=0.9.6', 'enum34;python_version<"3.4"'],
     extras_require={


### PR DESCRIPTION
As a part of #813, I've removed 3.4 from the `.travis.yml` matrix. Is this all that has to be done?