### PR TITLE
Additional changes to drop python 3.4

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@ still evolving (we won't break things just for fun, but many things are still ch
 work through design issues). Also, for a version `0.x.y`, we change `x` when we
 release new features, and `y` when we make a release with only bug fixes.
 
-We support Python >= 3.4 and currently support Python 2.7.
+We support Python >= 3.5 and currently support Python 2.7.
 
 .. warning::
   We are dropping support for Python 2.7 in the Fall of 2019. For more details and rationale

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
                  'Programming Language :: Python :: 2',
                  'Programming Language :: Python :: 2.7',
                  'Programming Language :: Python :: 3',
-                 'Programming Language :: Python :: 3.4',
                  'Programming Language :: Python :: 3.5',
                  'Programming Language :: Python :: 3.6',
                  'Topic :: Scientific/Engineering',


### PR DESCRIPTION
As mentioned in #873, I didn't quite catch everything...this PR additionally takes care of needed changes in `docs/index.rst` and `setup.py`.