### PR TITLE
Add conversions between omega and w

### DIFF
--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -29,6 +29,7 @@ from metpy.calc import (brunt_vaisala_frequency, brunt_vaisala_frequency_squared
                         surface_based_cape_cin, temperature_from_potential_temperature,
                         thickness_hydrostatic,
                         thickness_hydrostatic_from_relative_humidity, vapor_pressure,
+                        vertical_velocity, vertical_velocity_pressure,
                         virtual_potential_temperature, virtual_temperature,
                         wet_bulb_temperature)
 from metpy.calc.thermo import _find_append_zero_crossings
@@ -1069,3 +1070,36 @@ def test_parcel_profile_below_lcl():
                       260.15057861]) * units.kelvin
     profile = parcel_profile(pressure, 3.2 * units.degC, -10.8 * units.degC)
     assert_almost_equal(profile, truth, 6)
+
+
+def test_vertical_velocity_pressure_dry_air():
+    """Test conversion of w to omega assuming dry air."""
+    w = 1 * units('cm/s')
+    omega_truth = -1.250690495 * units('microbar/second')
+    omega_test = vertical_velocity_pressure(w, 1000. * units.mbar, 273.15 * units.K)
+    assert_almost_equal(omega_test, omega_truth, 6)
+
+
+def test_vertical_velocity_dry_air():
+    """Test conversion of w to omega assuming dry air."""
+    omega = 1 * units('microbar/second')
+    w_truth = -0.799558327 * units('cm/s')
+    w_test = vertical_velocity(omega, 1000. * units.mbar, 273.15 * units.K)
+    assert_almost_equal(w_test, w_truth, 6)
+
+
+def test_vertical_velocity_pressure_moist_air():
+    """Test conversion of w to omega assuming moist air."""
+    w = -1 * units('cm/s')
+    omega_truth = 1.032100858 * units('microbar/second')
+    omega_test = vertical_velocity_pressure(w, 850. * units.mbar, 280. * units.K,
+                                            8 * units('g/kg'))
+    assert_almost_equal(omega_test, omega_truth, 6)
+
+
+def test_vertical_velocity_moist_air():
+    """Test conversion of w to omega assuming moist air."""
+    omega = -1 * units('microbar/second')
+    w_truth = 0.968897557 * units('cm/s')
+    w_test = vertical_velocity(omega, 850. * units.mbar, 280. * units.K, 8 * units('g/kg'))
+    assert_almost_equal(w_test, w_truth, 6)

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -2155,3 +2155,92 @@ def dewpoint_from_specific_humidity(specific_humidity, temperature, pressure):
     return dewpoint_rh(temperature, relative_humidity_from_specific_humidity(specific_humidity,
                                                                              temperature,
                                                                              pressure))
+
+
+@exporter.export
+@preprocess_xarray
+@check_units('[length]/[time]', '[pressure]', '[temperature]')
+def vertical_velocity_pressure(w, pressure, temperature, mixing=0):
+    r"""Calculate omega from w assuming hydrostatic conditions.
+
+    This function converts vertical velocity with respect to height
+    :math:`\left(w = \frac{Dz}{Dt}\right)` to that
+    with respect to pressure :math:`\left(\omega = \frac{Dp}{Dt}\right)`
+    assuming hydrostatic conditions on the synoptic scale.
+    By Equation 7.33 in [Hobbs2006]_,
+
+    .. math: \omega \simeq -\rho g w
+
+    Density (:math:`\rho`) is calculated using the :func:`density` function,
+    from the given pressure and temperature. If `mixing` is given, the virtual
+    temperature correction is used, otherwise, dry air is assumed.
+
+    Parameters
+    ----------
+    w: `pint.Quantity`
+        Vertical velocity in terms of height
+    pressure: `pint.Quantity`
+        Total atmospheric pressure
+    temperature: `pint.Quantity`
+        Air temperature
+    mixing: `pint.Quantity`, optional
+        Mixing ratio of air
+
+    Returns
+    -------
+    `pint.Quantity`
+        Vertical velocity in terms of pressure (in Pascals / second)
+
+    See Also
+    --------
+    density, vertical_velocity
+
+    """
+    rho = density(pressure, temperature, mixing)
+    return (- g * rho * w).to('Pa/s')
+
+
+@exporter.export
+@preprocess_xarray
+@check_units('[pressure]/[time]', '[pressure]', '[temperature]')
+def vertical_velocity(omega, pressure, temperature, mixing=0):
+    r"""Calculate w from omega assuming hydrostatic conditions.
+
+    This function converts vertical velocity with respect to pressure
+    :math:`\left(\omega = \frac{Dp}{Dt}\right)` to that with respect to height
+    :math:`\left(w = \frac{Dz}{Dt}\right)` assuming hydrostatic conditions on
+    the synoptic scale. By Equation 7.33 in [Hobbs2006]_,
+
+    .. math: \omega \simeq -\rho g w
+
+    so that
+
+    .. math w \simeq \frac{- \omega}{\rho g}
+
+    Density (:math:`\rho`) is calculated using the :func:`density` function,
+    from the given pressure and temperature. If `mixing` is given, the virtual
+    temperature correction is used, otherwise, dry air is assumed.
+
+    Parameters
+    ----------
+    omega: `pint.Quantity`
+        Vertical velocity in terms of pressure
+    pressure: `pint.Quantity`
+        Total atmospheric pressure
+    temperature: `pint.Quantity`
+        Air temperature
+    mixing: `pint.Quantity`, optional
+        Mixing ratio of air
+
+    Returns
+    -------
+    `pint.Quantity`
+        Vertical velocity in terms of height (in meters / second)
+
+    See Also
+    --------
+    density, vertical_velocity_pressure
+
+    """
+    rho = density(pressure, temperature, mixing)
+    return (omega / (- g * rho)).to('m/s')


### PR DESCRIPTION
This PR adds two basic equations that assume hydrostatic balance in order to convert between omega (Dp/Dt) and w (Dz/Dt). I've found that I need this in an example or two for cross section analysis, but it is likely useful more generally as well.

One main question I have with this: what to name the functions? The terms "vertical velocity" and "vertical motion" are used, but inconsistently, to refer to the height- and pressure-based terms. "omega" and "w" are the only consistent terms I've seen used, but if I recall correctly we try to avoid abbreviations like these.