### PR TITLE
Add cross section function and supporting calculations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
   include:
     - python: 2.7
       env:
-        - VERSIONS="numpy==1.10.0 matplotlib==1.4.0 scipy==0.14.0 pint==0.8 xarray==0.9.6"
+        - VERSIONS="numpy==1.11.0 matplotlib==1.4.0 scipy==0.14.0 pint==0.8 xarray==0.10.7"
         - TASK="coverage"
         - TEST_OUTPUT_CONTROL=""
     - python: 3.5

--- a/docs/_templates/overrides/metpy.calc.rst
+++ b/docs/_templates/overrides/metpy.calc.rst
@@ -91,6 +91,7 @@ calc
    .. autosummary::
       :toctree: ./
 
+      absolute_momentum
       absolute_vorticity
       advection
       ageostrophic_wind
@@ -133,11 +134,15 @@ calc
    .. autosummary::
       :toctree: ./
 
+      cross_section_components
       first_derivative
       gradient
       laplacian
       lat_lon_grid_deltas
+      normal_component
       second_derivative
+      tangential_component
+      unit_vectors_from_cross_section
 
 
    Apparent Temperature

--- a/docs/gempak.rst
+++ b/docs/gempak.rst
@@ -589,11 +589,11 @@ blue is uncertain of parity, and white is unevaluated.
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">MSFC(V)</td>
-        <td class="tg-notimplemented">Pseudo angular momentum (cross-sections)</td>
-        <td class="tg-notimplemented"><a href="https://github.com/Unidata/MetPy/issues/654">Issue #654</a></td>
+        <td class="tg-implemented">MSFC(V)</td>
+        <td class="tg-implemented">Pseudo angular momentum (cross-sections)</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.absolute_momentum.html#metpy.calc.absolute_momentum">metpy.calc.absolute_momentum</a></td>
         <td></td>
-        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>
@@ -605,11 +605,11 @@ blue is uncertain of parity, and white is unevaluated.
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">NORM(V)</td>
-        <td class="tg-notimplemented">Normal component (cross-sections)</td>
-        <td class="tg-notimplemented"><a href="https://github.com/Unidata/MetPy/issues/652">Issue #652</a></td>
+        <td class="tg-implemented">NORM(V)</td>
+        <td class="tg-implemented">Normal component (cross-sections)</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.normal_component.html#metpy.calc.normal_component">metpy.calc.normal_component</a></td>
         <td></td>
-        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>
@@ -792,9 +792,9 @@ blue is uncertain of parity, and white is unevaluated.
       <tr>
         <td>TANG(V)</td>
         <td>Tangential component (cross-sections)</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.tangential_component.html#metpy.calc.tangential_component">metpy.calc.tangential_component</a></td>
         <td></td>
-        <td></td>
-        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>
@@ -1102,11 +1102,11 @@ blue is uncertain of parity, and white is unevaluated.
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">NORMV(V)</td>
-        <td class="tg-notimplemented">Vector normal wind (cross-section)</td>
-        <td class="tg-notimplemented"></td>
+        <td class="tg-implemented">NORMV(V)</td>
+        <td class="tg-implemented">Vector normal wind (cross-section)</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.normal_component.html#metpy.calc.normal_component">metpy.calc.normal_component</a></td>
         <td></td>
-        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>
@@ -1166,11 +1166,11 @@ blue is uncertain of parity, and white is unevaluated.
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">TANGV(V)</td>
-        <td class="tg-notimplemented">Vector tangential wind (cross-section)</td>
-        <td class="tg-notimplemented"></td>
+        <td class="tg-implemented">TANGV(V)</td>
+        <td class="tg-implemented">Vector tangential wind (cross-section)</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.tangential_component.html#metpy.calc.tangential_component">metpy.calc.tangential_component</a></td>
         <td></td>
-        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -110,8 +110,8 @@ References
 
 .. [Schultz1999] Schultz, D. M. and P. N. Schumacher, 1999: The Use and Misuse of Conditional
            Symmetric Instability. Mon. Wea. Rev., 127, 2709–2732,
-           doi:`10.1175/1520-0493(1999)127<2709:TUAMOC>2.0.CO;2
-           <https://doi.org/10.1175/1520-0493(1999)127<2709:TUAMOC>2.0.CO;2>`_.
+           doi:`10.1175/1520-0493(1999)127%3C2709%3ATUAMOC%3E2.0.CO;2
+           <https://doi.org/10.1175/1520-0493(1999)127%3C2709%3ATUAMOC%3E2.0.CO;2>`_.
 
 .. [Steadman1979] Steadman, R.G., 1979: The assessment of sultriness. Part I: A
            temperature-humidity index based on human physiology and clothing

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -108,6 +108,11 @@ References
 .. [Salby1996] Salby, M. L., 1996: *Fundamentals of Atmospheric Physics*.
            Academic Press, 627 pp.
 
+.. [Schultz1999] Schultz, D. M. and P. N. Schumacher, 1999: The Use and Misuse of Conditional
+           Symmetric Instability. Mon. Wea. Rev., 127, 2709–2732,
+           doi:`10.1175/1520-0493(1999)127<2709:TUAMOC>2.0.CO;2
+           <https://doi.org/10.1175/1520-0493(1999)127<2709:TUAMOC>2.0.CO;2>`_.
+
 .. [Steadman1979] Steadman, R.G., 1979: The assessment of sultriness. Part I: A
            temperature-humidity index based on human physiology and clothing
            science. *J. Appl. Meteor.*, **18**, 861-873,

--- a/metpy/calc/__init__.py
+++ b/metpy/calc/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015,2016,2017 MetPy Developers.
+# Copyright (c) 2015,2016,2017,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 r"""This module contains a variety of meteorological calculations."""

--- a/metpy/calc/__init__.py
+++ b/metpy/calc/__init__.py
@@ -4,6 +4,7 @@
 r"""This module contains a variety of meteorological calculations."""
 
 from .basic import *  # noqa: F403
+from .cross_sections import *  # noqa: F403
 from .indices import *  # noqa: F403
 from .kinematics import *  # noqa: F403
 from .thermo import *  # noqa: F403
@@ -11,6 +12,7 @@ from .tools import *  # noqa: F403
 from .turbulence import *  # noqa: F403
 
 __all__ = basic.__all__[:]  # pylint: disable=undefined-variable
+__all__.extend(cross_sections.__all__)  # pylint: disable=undefined-variable
 __all__.extend(indices.__all__)  # pylint: disable=undefined-variable
 __all__.extend(kinematics.__all__)  # pylint: disable=undefined-variable
 __all__.extend(thermo.__all__)  # pylint: disable=undefined-variable

--- a/metpy/calc/cross_sections.py
+++ b/metpy/calc/cross_sections.py
@@ -1,7 +1,7 @@
-# Copyright (c) 2017 MetPy Developers.
+# Copyright (c) 2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
-"""Contains calculation of various derived indices.
+"""Contains calculations related to cross sections and respective vector components.
 
 Compared to the rest of the calculations which are based around pint quantities, this module
 is based around xarray DataArrays.
@@ -47,8 +47,8 @@ def distances_from_cross_section(cross):
                                         lat[0].values * np.ones_like(lat),
                                         lon.values,
                                         lat.values)
-        x = distance * np.cos(np.deg2rad(90. - forward_az))
-        y = distance * np.sin(np.deg2rad(90. - forward_az))
+        x = distance * np.sin(np.deg2rad(forward_az))
+        y = distance * np.cos(np.deg2rad(forward_az))
 
         # Build into DataArrays
         x = xr.DataArray(x, coords=lon.coords, dims=lon.dims, attrs={'units': 'meters'})
@@ -89,7 +89,7 @@ def latitude_from_cross_section(cross):
                                                     cross.metpy.x.values,
                                                     y.values)[..., 1]
         latitude = xr.DataArray(latitude, coords=y.coords, dims=y.dims,
-                                attrs={'units': 'degress_north'})
+                                attrs={'units': 'degrees_north'})
         return latitude
 
 
@@ -298,6 +298,8 @@ def absolute_momentum(u_wind, v_wind, index='index'):
     _, latitude = xr.broadcast(norm_wind, latitude)
     f = coriolis_parameter(np.deg2rad(latitude.values)).magnitude  # in 1/s
     x, y = distances_from_cross_section(norm_wind)
+    x.metpy.convert_units('meters')
+    y.metpy.convert_units('meters')
     _, x, y = xr.broadcast(norm_wind, x, y)
     distance = np.hypot(x, y).values  # in meters
 

--- a/metpy/calc/cross_sections.py
+++ b/metpy/calc/cross_sections.py
@@ -1,0 +1,307 @@
+# Copyright (c) 2017 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Contains calculation of various derived indices.
+
+Compared to the rest of the calculations which are based around pint quantities, this module
+is based around xarray DataArrays.
+"""
+
+import cartopy.crs as ccrs
+import numpy as np
+import xarray as xr
+
+from .basic import coriolis_parameter
+from .tools import first_derivative
+from ..package_tools import Exporter
+from ..xarray import CFConventionHandler, check_matching_coordinates
+
+exporter = Exporter(globals())
+
+
+def distances_from_cross_section(cross):
+    """Calculate the distances in the x and y directions along a cross-section.
+
+    Parameters
+    ----------
+    cross : `xarray.DataArray`
+        The input DataArray of a cross-section from which to obtain geometeric distances in
+        the x and y directions.
+
+    Returns
+    -------
+    x, y : tuple of `xarray.DataArray`
+        A tuple of the x and y distances as DataArrays
+
+    """
+    if (CFConventionHandler.check_axis(cross.metpy.x, 'lon') and
+            CFConventionHandler.check_axis(cross.metpy.y, 'lat')):
+        # Use pyproj to obtain x and y distances
+        from pyproj import Geod
+
+        g = Geod(cross.metpy.cartopy_crs.proj4_init)
+        lon = cross.metpy.x
+        lat = cross.metpy.y
+
+        forward_az, _, distance = g.inv(lon[0].values * np.ones_like(lon),
+                                        lat[0].values * np.ones_like(lat),
+                                        lon.values,
+                                        lat.values)
+        x = distance * np.cos(np.deg2rad(90. - forward_az))
+        y = distance * np.sin(np.deg2rad(90. - forward_az))
+
+        # Build into DataArrays
+        x = xr.DataArray(x, coords=lon.coords, dims=lon.dims, attrs={'units': 'meters'})
+        y = xr.DataArray(y, coords=lat.coords, dims=lat.dims, attrs={'units': 'meters'})
+
+    elif (CFConventionHandler.check_axis(cross.metpy.x, 'x') and
+            CFConventionHandler.check_axis(cross.metpy.y, 'y')):
+
+        # Simply return what we have
+        x = cross.metpy.x
+        y = cross.metpy.y
+
+    else:
+        raise AttributeError('Sufficient horizontal coordinates not defined.')
+
+    return x, y
+
+
+def latitude_from_cross_section(cross):
+    """Calculate the latitude of points in a cross-section.
+
+    Parameters
+    ----------
+    cross : `xarray.DataArray`
+        The input DataArray of a cross-section from which to obtain latitudes.
+
+    Returns
+    -------
+    latitude : `xarray.DataArray`
+        Latitude of points
+
+    """
+    y = cross.metpy.y
+    if CFConventionHandler.check_axis(y, 'lat'):
+        return y
+    else:
+        latitude = ccrs.Geodetic().transform_points(cross.metpy.cartopy_crs,
+                                                    cross.metpy.x.values,
+                                                    y.values)[..., 1]
+        latitude = xr.DataArray(latitude, coords=y.coords, dims=y.dims,
+                                attrs={'units': 'degress_north'})
+        return latitude
+
+
+@exporter.export
+def unit_vectors_from_cross_section(cross, index='index'):
+    r"""Calculate the unit tanget and unit normal vectors from a cross-section.
+
+    Given a path described parametrically by :math:`\vec{l}(i) = (x(i), y(i))`, we can find
+    the unit tangent vector by the formula
+
+    .. math:: \vec{T}(i) =
+        \frac{1}{\sqrt{\left( \frac{dx}{di} \right)^2 + \left( \frac{dy}{di} \right)^2}}
+        \left( \frac{dx}{di}, \frac{dy}{di} \right)
+
+    From this, because this is a two-dimensional path, the normal vector can be obtained by a
+    simple :math:`\frac{\pi}{2}` rotation.
+
+    Parameters
+    ----------
+    cross : `xarray.DataArray`
+        The input DataArray of a cross-section from which to obtain latitudes.
+    index : `str`, optional
+        A string denoting the index coordinate of the cross section, defaults to 'index' as
+        set by `metpy.interpolate.cross_section`.
+
+    Returns
+    -------
+    unit_tangent_vector, unit_normal_vector : tuple of `numpy.ndarray`
+        Arrays describing the unit tangent and unit normal vectors (in x,y) for all points
+        along the cross section.
+
+    """
+    x, y = distances_from_cross_section(cross)
+    dx_di = first_derivative(x, x=cross[index])
+    dy_di = first_derivative(y, x=cross[index])
+    tangent_vector_mag = np.hypot(dx_di, dy_di)
+    unit_tangent_vector = np.vstack([dx_di / tangent_vector_mag, dy_di / tangent_vector_mag])
+    unit_normal_vector = np.vstack([-dy_di / tangent_vector_mag, dx_di / tangent_vector_mag])
+    return unit_tangent_vector, unit_normal_vector
+
+
+@exporter.export
+@check_matching_coordinates
+def cross_section_components(data_x, data_y, index='index'):
+    r"""Obtain the tangential and normal components of a cross-section of a vector field.
+
+    Parameters
+    ----------
+    data_x : `xarray.DataArray`
+        The input DataArray of the x-component (in terms of data projection) of the vector
+        field.
+    data_y : `xarray.DataArray`
+        The input DataArray of the y-component (in terms of data projection) of the vector
+        field.
+
+    Returns
+    -------
+    component_tangential, component_normal: tuple of `xarray.DataArray`
+        The components of the vector field in the tangential and normal directions,
+        respectively.
+
+    See Also
+    --------
+    tangential_component, normal_component
+
+    Notes
+    -----
+    The coordinates of `data_x` and `data_y` must match.
+
+    """
+    # Get the unit vectors
+    unit_tang, unit_norm = unit_vectors_from_cross_section(data_x, index=index)
+
+    # Take the dot products
+    component_tang = data_x * unit_tang[0] + data_y * unit_tang[1]
+    component_norm = data_x * unit_norm[0] + data_y * unit_norm[1]
+
+    # Reattach units (only reliable attribute after operation)
+    component_tang.attrs = {'units': data_x.attrs['units']}
+    component_norm.attrs = {'units': data_x.attrs['units']}
+
+    return component_tang, component_norm
+
+
+@exporter.export
+@check_matching_coordinates
+def normal_component(data_x, data_y, index='index'):
+    r"""Obtain the normal component of a cross-section of a vector field.
+
+    Parameters
+    ----------
+    data_x : `xarray.DataArray`
+        The input DataArray of the x-component (in terms of data projection) of the vector
+        field.
+    data_y : `xarray.DataArray`
+        The input DataArray of the y-component (in terms of data projection) of the vector
+        field.
+
+    Returns
+    -------
+    component_normal: `xarray.DataArray`
+        The component of the vector field in the normal directions.
+
+    See Also
+    --------
+    cross_section_components, tangential_component
+
+    Notes
+    -----
+    The coordinates of `data_x` and `data_y` must match.
+
+    """
+    # Get the unit vectors
+    _, unit_norm = unit_vectors_from_cross_section(data_x, index=index)
+
+    # Take the dot products
+    component_norm = data_x * unit_norm[0] + data_y * unit_norm[1]
+
+    # Reattach units (only reliable attribute after operation)
+    component_norm.attrs = {'units': data_x.attrs['units']}
+
+    return component_norm
+
+
+@exporter.export
+@check_matching_coordinates
+def tangential_component(data_x, data_y, index='index'):
+    r"""Obtain the tangential component of a cross-section of a vector field.
+
+    Parameters
+    ----------
+    data_x : `xarray.DataArray`
+        The input DataArray of the x-component (in terms of data projection) of the vector
+        field.
+    data_y : `xarray.DataArray`
+        The input DataArray of the y-component (in terms of data projection) of the vector
+        field.
+
+    Returns
+    -------
+    component_tangential: `xarray.DataArray`
+        The component of the vector field in the tangential directions.
+
+    See Also
+    --------
+    cross_section_components, normal_component
+
+    Notes
+    -----
+    The coordinates of `data_x` and `data_y` must match.
+
+    """
+    # Get the unit vectors
+    unit_tang, _ = unit_vectors_from_cross_section(data_x, index=index)
+
+    # Take the dot products
+    component_tang = data_x * unit_tang[0] + data_y * unit_tang[1]
+
+    # Reattach units (only reliable attribute after operation)
+    component_tang.attrs = {'units': data_x.attrs['units']}
+
+    return component_tang
+
+
+@exporter.export
+@check_matching_coordinates
+def absolute_momentum(u_wind, v_wind, index='index'):
+    r"""Calculate cross-sectional absolute momentum (also called pseudoangular momentum).
+
+    As given in [Schultz1999]_, absolute momentum (also called pseudoangular momentum) is
+    given by
+
+    .. math:: M = v + fx
+
+    where :math:`v` is the along-front component of the wind and :math:`x` is the cross-front
+    distance. Applied to a cross-section taken perpendicular to the front, :math:`v` becomes
+    the normal component of the wind and :math:`x` the tangential distance.
+
+    If using this calculation in assessing symmetric instability, geostrophic wind should be
+    used so that geostrophic absolute momentum :math:`\left(M_g\right)` is obtained, as
+    described in [Schultz1999]_.
+
+    Parameters
+    ----------
+    u_wind : `xarray.DataArray`
+        The input DataArray of the x-component (in terms of data projection) of the wind.
+    v_wind : `xarray.DataArray`
+        The input DataArray of the y-component (in terms of data projection) of the wind.
+
+    Returns
+    -------
+    absolute_momentum: `xarray.DataArray`
+        The absolute momentum
+
+    Notes
+    -----
+    The coordinates of `u_wind` and `v_wind` must match.
+
+    """
+    # Get the normal component of the wind
+    norm_wind = normal_component(u_wind, v_wind, index=index)
+    norm_wind.metpy.convert_units('m/s')
+
+    # Get other pieces of calculation (all as ndarrays matching shape of norm_wind)
+    latitude = latitude_from_cross_section(norm_wind)  # in degrees_north
+    _, latitude = xr.broadcast(norm_wind, latitude)
+    f = coriolis_parameter(np.deg2rad(latitude.values)).magnitude  # in 1/s
+    x, y = distances_from_cross_section(norm_wind)
+    _, x, y = xr.broadcast(norm_wind, x, y)
+    distance = np.hypot(x, y).values  # in meters
+
+    m = norm_wind + f * distance
+    m.attrs = {'units': norm_wind.attrs['units']}
+
+    return m

--- a/metpy/calc/tests/test_cross_sections.py
+++ b/metpy/calc/tests/test_cross_sections.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016,2017,2018 MetPy Developers.
+# Copyright (c) 2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Test the `cross_sections` module."""
@@ -12,8 +12,7 @@ from metpy.calc import (absolute_momentum, cross_section_components, normal_comp
 from metpy.calc.cross_sections import (distances_from_cross_section,
                                        latitude_from_cross_section)
 from metpy.interpolate import cross_section
-from metpy.testing import assert_array_almost_equal
-from metpy.units import units
+from metpy.testing import assert_array_almost_equal, assert_xarray_allclose
 
 
 @pytest.fixture()
@@ -139,11 +138,8 @@ def test_distances_from_cross_section_given_lonlat(test_cross_lonlat):
         dims=['index'],
         attrs={'units': 'meters'}
     )
-
-    xr.testing.assert_allclose(true_x, x)
-    assert x.metpy.coordinates_identical(true_x)
-    xr.testing.assert_allclose(true_y, y)
-    assert y.metpy.coordinates_identical(true_y)
+    assert_xarray_allclose(x, true_x)
+    assert_xarray_allclose(y, true_y)
 
 
 def test_distances_from_cross_section_given_xy(test_cross_xy):
@@ -180,10 +176,9 @@ def test_latitude_from_cross_section_given_y(test_cross_xy):
             'index': index,
         },
         dims=['index'],
-        attrs={'units': 'degress_north'}
+        attrs={'units': 'degrees_north'}
     )
-    xr.testing.assert_allclose(true_latitude, latitude)
-    assert latitude.metpy.coordinates_identical(true_latitude)
+    assert_xarray_allclose(latitude, true_latitude)
 
 
 def test_unit_vectors_from_cross_section_given_lonlat(test_cross_lonlat):
@@ -248,10 +243,8 @@ def test_cross_section_components(test_cross_lonlat):
                                   coords=test_cross_lonlat['u_wind'].coords,
                                   dims=test_cross_lonlat['u_wind'].dims,
                                   attrs=test_cross_lonlat['u_wind'].attrs)
-    xr.testing.assert_allclose(true_tang_wind, tang_wind)
-    assert tang_wind.metpy.coordinates_identical(true_tang_wind)
-    xr.testing.assert_allclose(true_norm_wind, norm_wind)
-    assert norm_wind.metpy.coordinates_identical(true_norm_wind)
+    assert_xarray_allclose(tang_wind, true_tang_wind)
+    assert_xarray_allclose(norm_wind, true_norm_wind)
 
 
 def test_tangential_component(test_cross_xy):
@@ -271,8 +264,7 @@ def test_tangential_component(test_cross_xy):
                                   coords=test_cross_xy['u_wind'].coords,
                                   dims=test_cross_xy['u_wind'].dims,
                                   attrs=test_cross_xy['u_wind'].attrs)
-    xr.testing.assert_allclose(true_tang_wind, tang_wind)
-    assert tang_wind.metpy.coordinates_identical(true_tang_wind)
+    assert_xarray_allclose(tang_wind, true_tang_wind)
 
 
 def test_normal_component(test_cross_xy):
@@ -292,8 +284,7 @@ def test_normal_component(test_cross_xy):
                                   coords=test_cross_xy['u_wind'].coords,
                                   dims=test_cross_xy['u_wind'].dims,
                                   attrs=test_cross_xy['u_wind'].attrs)
-    xr.testing.assert_allclose(true_norm_wind, norm_wind)
-    assert norm_wind.metpy.coordinates_identical(true_norm_wind)
+    assert_xarray_allclose(norm_wind, true_norm_wind)
 
 
 def test_absolute_momentum_given_lonlat(test_cross_lonlat):
@@ -313,10 +304,8 @@ def test_absolute_momentum_given_lonlat(test_cross_lonlat):
     true_momentum = xr.DataArray(true_momentum_values,
                                  coords=test_cross_lonlat['u_wind'].coords,
                                  dims=test_cross_lonlat['u_wind'].dims,
-                                 attrs=test_cross_lonlat['u_wind'].attrs)
-    xr.testing.assert_allclose(true_momentum, momentum)
-    assert momentum.metpy.coordinates_identical(true_momentum)
-    assert units(momentum.attrs['units']) == units('m/s')
+                                 attrs={'units': 'meter / second'})
+    assert_xarray_allclose(momentum, true_momentum)
 
 
 def test_absolute_momentum_given_xy(test_cross_xy):
@@ -335,7 +324,5 @@ def test_absolute_momentum_given_xy(test_cross_xy):
     true_momentum = xr.DataArray(true_momentum_values,
                                  coords=test_cross_xy['u_wind'].coords,
                                  dims=test_cross_xy['u_wind'].dims,
-                                 attrs=test_cross_xy['u_wind'].attrs)
-    xr.testing.assert_allclose(true_momentum, momentum)
-    assert momentum.metpy.coordinates_identical(true_momentum)
-    assert units(momentum.attrs['units']) == units('m/s')
+                                 attrs={'units': 'meter / second'})
+    assert_xarray_allclose(momentum, true_momentum)

--- a/metpy/calc/tests/test_cross_sections.py
+++ b/metpy/calc/tests/test_cross_sections.py
@@ -1,0 +1,341 @@
+# Copyright (c) 2016,2017,2018 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Test the `cross_sections` module."""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from metpy.calc import (absolute_momentum, cross_section_components, normal_component,
+                        tangential_component, unit_vectors_from_cross_section)
+from metpy.calc.cross_sections import (distances_from_cross_section,
+                                       latitude_from_cross_section)
+from metpy.interpolate import cross_section
+from metpy.testing import assert_array_almost_equal
+from metpy.units import units
+
+
+@pytest.fixture()
+def test_cross_lonlat():
+    """Return cross section on a lon/lat grid with no time coordinate for use in tests."""
+    data_u = np.linspace(-40, 40, 5 * 6 * 7).reshape((5, 6, 7))
+    data_v = np.linspace(40, -40, 5 * 6 * 7).reshape((5, 6, 7))
+    ds = xr.Dataset(
+        {
+            'u_wind': (['isobaric', 'lat', 'lon'], data_u),
+            'v_wind': (['isobaric', 'lat', 'lon'], data_v)
+        },
+        coords={
+            'isobaric': xr.DataArray(
+                np.linspace(1000, 500, 5),
+                name='isobaric',
+                dims=['isobaric'],
+                attrs={'units': 'hPa'}
+            ),
+            'lat': xr.DataArray(
+                np.linspace(30, 45, 6),
+                name='lat',
+                dims=['lat'],
+                attrs={'units': 'degrees_north'}
+            ),
+            'lon': xr.DataArray(
+                np.linspace(255, 275, 7),
+                name='lon',
+                dims=['lon'],
+                attrs={'units': 'degrees_east'}
+            )
+        }
+    )
+    ds['u_wind'].attrs['units'] = 'knots'
+    ds['v_wind'].attrs['units'] = 'knots'
+
+    start, end = (30.5, 255.5), (44.5, 274.5)
+    return cross_section(ds.metpy.parse_cf(), start, end, steps=7, interp_type='nearest')
+
+
+@pytest.fixture()
+def test_cross_xy():
+    """Return cross section on a x/y grid with a time coordinate for use in tests."""
+    data_u = np.linspace(-25, 25, 5 * 6 * 7).reshape((1, 5, 6, 7))
+    data_v = np.linspace(25, -25, 5 * 6 * 7).reshape((1, 5, 6, 7))
+    ds = xr.Dataset(
+        {
+            'u_wind': (['time', 'isobaric', 'y', 'x'], data_u),
+            'v_wind': (['time', 'isobaric', 'y', 'x'], data_v),
+            'lambert_conformal': ([], '')
+        },
+        coords={
+            'time': xr.DataArray(
+                np.array([np.datetime64('2018-07-01T00:00')]),
+                name='time',
+                dims=['time']
+            ),
+            'isobaric': xr.DataArray(
+                np.linspace(1000, 500, 5),
+                name='isobaric',
+                dims=['isobaric'],
+                attrs={'units': 'hPa'}
+            ),
+            'y': xr.DataArray(
+                np.linspace(-1500, 0, 6),
+                name='y',
+                dims=['y'],
+                attrs={'units': 'km'}
+            ),
+            'x': xr.DataArray(
+                np.linspace(-500, 3000, 7),
+                name='x',
+                dims=['x'],
+                attrs={'units': 'km'}
+            )
+        }
+    )
+    ds['u_wind'].attrs = ds['v_wind'].attrs = {
+        'units': 'm/s',
+        'grid_mapping': 'lambert_conformal'
+    }
+    ds['lambert_conformal'].attrs = {
+        'grid_mapping_name': 'lambert_conformal_conic',
+        'standard_parallel': 50.0,
+        'longitude_of_central_meridian': -107.0,
+        'latitude_of_projection_origin': 50.0,
+        'earth_shape': 'spherical',
+        'earth_radius': 6367470.21484375
+    }
+
+    start, end = ((36.46, -112.45), (42.95, -68.74))
+    return cross_section(ds.metpy.parse_cf(), start, end, steps=7)
+
+
+def test_distances_from_cross_section_given_lonlat(test_cross_lonlat):
+    """Test distances from cross section with lat/lon grid."""
+    x, y = distances_from_cross_section(test_cross_lonlat['u_wind'])
+
+    true_x_values = np.array([-0., 252585.3108187, 505170.6216374, 757755.93245611,
+                              1010341.24327481, 1262926.55409352, 1515511.86491222])
+    true_y_values = np.array([-0., 283412.80349716, 566825.60699432, 850238.41049148,
+                              1133651.21398864, 1417064.0174858, 1700476.82098296])
+    index = xr.DataArray(range(7), name='index', dims=['index'])
+    true_x = xr.DataArray(
+        true_x_values,
+        coords={
+            'crs': test_cross_lonlat['crs'],
+            'lat': test_cross_lonlat['lat'],
+            'lon': test_cross_lonlat['lon'],
+            'index': index,
+        },
+        dims=['index'],
+        attrs={'units': 'meters'}
+    )
+    true_y = xr.DataArray(
+        true_y_values,
+        coords={
+            'crs': test_cross_lonlat['crs'],
+            'lat': test_cross_lonlat['lat'],
+            'lon': test_cross_lonlat['lon'],
+            'index': index,
+        },
+        dims=['index'],
+        attrs={'units': 'meters'}
+    )
+
+    xr.testing.assert_allclose(true_x, x)
+    assert x.metpy.coordinates_identical(true_x)
+    xr.testing.assert_allclose(true_y, y)
+    assert y.metpy.coordinates_identical(true_y)
+
+
+def test_distances_from_cross_section_given_xy(test_cross_xy):
+    """Test distances from cross section with x/y grid."""
+    x, y = distances_from_cross_section(test_cross_xy['u_wind'])
+    xr.testing.assert_identical(test_cross_xy['x'], x)
+    xr.testing.assert_identical(test_cross_xy['y'], y)
+
+
+def test_distances_from_cross_section_given_bad_coords(test_cross_xy):
+    """Ensure an AttributeError is raised when the cross section lacks neeed coordinates."""
+    with pytest.raises(AttributeError):
+        distances_from_cross_section(test_cross_xy['u_wind'].drop('x'))
+
+
+def test_latitude_from_cross_section_given_lat(test_cross_lonlat):
+    """Test latitude from cross section with latitude given."""
+    latitude = latitude_from_cross_section(test_cross_lonlat['v_wind'])
+    xr.testing.assert_identical(test_cross_lonlat['lat'], latitude)
+
+
+def test_latitude_from_cross_section_given_y(test_cross_xy):
+    """Test latitude from cross section with y given."""
+    latitude = latitude_from_cross_section(test_cross_xy['v_wind'])
+    true_latitude_values = np.array([36.46, 38.64829115, 40.44833152, 41.81277354, 42.7011178,
+                                     43.0845549, 42.95])
+    index = xr.DataArray(range(7), name='index', dims=['index'])
+    true_latitude = xr.DataArray(
+        true_latitude_values,
+        coords={
+            'crs': test_cross_xy['crs'],
+            'y': test_cross_xy['y'],
+            'x': test_cross_xy['x'],
+            'index': index,
+        },
+        dims=['index'],
+        attrs={'units': 'degress_north'}
+    )
+    xr.testing.assert_allclose(true_latitude, latitude)
+    assert latitude.metpy.coordinates_identical(true_latitude)
+
+
+def test_unit_vectors_from_cross_section_given_lonlat(test_cross_lonlat):
+    """Test unit vector calculation from cross section with lat/lon grid."""
+    unit_tangent, unit_normal = unit_vectors_from_cross_section(test_cross_lonlat['u_wind'])
+    true_unit_tangent = np.array([[0.66533859, 0.66533859, 0.66533859, 0.66533859, 0.66533859,
+                                   0.66533859, 0.66533859],
+                                  [0.74654173, 0.74654173, 0.74654173, 0.74654173, 0.74654173,
+                                   0.74654173, 0.74654173]])
+    true_unit_normal = np.array([[-0.74654173, -0.74654173, -0.74654173, -0.74654173,
+                                  -0.74654173, -0.74654173, -0.74654173],
+                                 [0.66533859, 0.66533859, 0.66533859, 0.66533859,
+                                  0.66533859, 0.66533859, 0.66533859]])
+    assert_array_almost_equal(true_unit_tangent, unit_tangent, 7)
+    assert_array_almost_equal(true_unit_normal, unit_normal, 7)
+
+
+def test_unit_vectors_from_cross_section_given_xy(test_cross_xy):
+    """Test unit vector calculation from cross section with x/y grid."""
+    unit_tangent, unit_normal = unit_vectors_from_cross_section(test_cross_xy['u_wind'])
+    true_unit_tangent = np.array([[0.93567585, 0.929688, 0.92380315, 0.91844706, 0.91349795,
+                                   0.90875771, 0.90400673],
+                                 [0.35286074, 0.36834796, 0.3828678, 0.39554392, 0.40684333,
+                                  0.41732413, 0.42751822]])
+    true_unit_normal = np.array([[-0.35286074, -0.36834796, -0.3828678, -0.39554392,
+                                  -0.40684333, -0.41732413, -0.42751822],
+                                 [0.93567585, 0.929688, 0.92380315, 0.91844706, 0.91349795,
+                                  0.90875771, 0.90400673]])
+    assert_array_almost_equal(true_unit_tangent, unit_tangent, 7)
+    assert_array_almost_equal(true_unit_normal, unit_normal, 7)
+
+
+def test_cross_section_components(test_cross_lonlat):
+    """Test getting cross section components of a 2D vector field."""
+    tang_wind, norm_wind = cross_section_components(test_cross_lonlat['u_wind'],
+                                                    test_cross_lonlat['v_wind'])
+    true_tang_wind_values = np.array([[3.24812563, 2.9994653, 2.75080496, 2.50214463,
+                                       2.47106208, 2.22240175, 1.97374141],
+                                      [1.94265887, 1.69399854, 1.4453382, 1.19667786,
+                                       1.16559532, 0.91693499, 0.66827465],
+                                      [0.63719211, 0.38853177, 0.13987144, -0.1087889,
+                                       -0.13987144, -0.38853177, -0.63719211],
+                                      [-0.66827465, -0.91693499, -1.16559532, -1.41425566,
+                                       -1.4453382, -1.69399854, -1.94265887],
+                                      [-1.97374141, -2.22240175, -2.47106208, -2.71972242,
+                                       -2.75080496, -2.9994653, -3.24812563]])
+    true_norm_wind_values = np.array([[56.47521297, 52.15175169, 47.82829041, 43.50482913,
+                                       42.96439647, 38.64093519, 34.31747391],
+                                      [33.77704125, 29.45357997, 25.13011869, 20.80665741,
+                                       20.26622475, 15.94276347, 11.61930219],
+                                      [11.07886953, 6.75540825, 2.43194697, -1.89151431,
+                                       -2.43194697, -6.75540825, -11.07886953],
+                                      [-11.61930219, -15.94276347, -20.26622475, -24.58968603,
+                                       -25.13011869, -29.45357997, -33.77704125],
+                                      [-34.31747391, -38.64093519, -42.96439647, -47.28785775,
+                                       -47.82829041, -52.15175169, -56.47521297]])
+    true_tang_wind = xr.DataArray(true_tang_wind_values,
+                                  coords=test_cross_lonlat['u_wind'].coords,
+                                  dims=test_cross_lonlat['u_wind'].dims,
+                                  attrs=test_cross_lonlat['u_wind'].attrs)
+    true_norm_wind = xr.DataArray(true_norm_wind_values,
+                                  coords=test_cross_lonlat['u_wind'].coords,
+                                  dims=test_cross_lonlat['u_wind'].dims,
+                                  attrs=test_cross_lonlat['u_wind'].attrs)
+    xr.testing.assert_allclose(true_tang_wind, tang_wind)
+    assert tang_wind.metpy.coordinates_identical(true_tang_wind)
+    xr.testing.assert_allclose(true_norm_wind, norm_wind)
+    assert norm_wind.metpy.coordinates_identical(true_norm_wind)
+
+
+def test_tangential_component(test_cross_xy):
+    """Test getting cross section tangential component of a 2D vector field."""
+    tang_wind = tangential_component(test_cross_xy['u_wind'], test_cross_xy['v_wind'])
+    true_tang_wind_values = np.array([[[-14.56982141, -13.17102075, -11.83790134,
+                                        -10.59675064, -9.42888813, -8.31533355, -7.2410326],
+                                       [-8.71378435, -7.53076196, -6.40266576, -5.34269988,
+                                        -4.33810002, -3.37748418, -2.45334901],
+                                       [-2.85774728, -1.89050316, -0.96743019, -0.08864912,
+                                        0.7526881, 1.5603652, 2.33433459],
+                                       [2.99828978, 3.74975563, 4.46780539, 5.16540164,
+                                        5.84347621, 6.49821458, 7.12201819],
+                                       [8.85432685, 9.39001443, 9.90304096, 10.41945241,
+                                        10.93426433, 11.43606396, 11.90970179]]])
+    true_tang_wind = xr.DataArray(true_tang_wind_values,
+                                  coords=test_cross_xy['u_wind'].coords,
+                                  dims=test_cross_xy['u_wind'].dims,
+                                  attrs=test_cross_xy['u_wind'].attrs)
+    xr.testing.assert_allclose(true_tang_wind, tang_wind)
+    assert tang_wind.metpy.coordinates_identical(true_tang_wind)
+
+
+def test_normal_component(test_cross_xy):
+    """Test getting cross section normal component of a 2D vector field."""
+    norm_wind = normal_component(test_cross_xy['u_wind'], test_cross_xy['v_wind'])
+    true_norm_wind_values = np.array([[[32.21218429, 30.45650997, 28.59536112, 26.62832466,
+                                        24.57166983, 22.43805311, 20.2347284],
+                                       [19.26516594, 17.41404337, 15.46613157, 13.42554447,
+                                        11.30508283, 9.11378585, 6.85576955],
+                                       [6.3181476, 4.37157677, 2.33690202, 0.22276428,
+                                        -1.96150417, -4.2104814, -6.52318931],
+                                       [-6.62887075, -8.67088982, -10.79232752, -12.98001592,
+                                        -15.22809117, -17.53474865, -19.90214816],
+                                       [-19.5758891, -21.71335642, -23.92155707, -26.18279611,
+                                        -28.49467817, -30.8590159, -33.28110701]]])
+    true_norm_wind = xr.DataArray(true_norm_wind_values,
+                                  coords=test_cross_xy['u_wind'].coords,
+                                  dims=test_cross_xy['u_wind'].dims,
+                                  attrs=test_cross_xy['u_wind'].attrs)
+    xr.testing.assert_allclose(true_norm_wind, norm_wind)
+    assert norm_wind.metpy.coordinates_identical(true_norm_wind)
+
+
+def test_absolute_momentum_given_lonlat(test_cross_lonlat):
+    """Test absolute momentum calculation."""
+    momentum = absolute_momentum(test_cross_lonlat['u_wind'], test_cross_lonlat['v_wind'])
+    true_momentum_values = np.array([[29.05335956, 57.00676169, 88.89733786, 124.37969813,
+                                      165.02883664, 206.55775948, 250.49678829],
+                                     [17.37641122, 45.32981335, 77.22038952, 112.70274979,
+                                      153.3518883, 194.88081114, 238.81983995],
+                                     [5.69946288, 33.65286501, 65.54344118, 101.02580145,
+                                      141.67493996, 183.2038628, 227.14289161],
+                                     [-5.97748546, 21.97591667, 53.86649284, 89.34885311,
+                                      129.99799162, 171.52691446, 215.46594327],
+                                     [-17.6544338, 10.29896833, 42.1895445, 77.67190477,
+                                      118.32104328, 159.84996612, 203.78899492]])
+
+    true_momentum = xr.DataArray(true_momentum_values,
+                                 coords=test_cross_lonlat['u_wind'].coords,
+                                 dims=test_cross_lonlat['u_wind'].dims,
+                                 attrs=test_cross_lonlat['u_wind'].attrs)
+    xr.testing.assert_allclose(true_momentum, momentum)
+    assert momentum.metpy.coordinates_identical(true_momentum)
+    assert units(momentum.attrs['units']) == units('m/s')
+
+
+def test_absolute_momentum_given_xy(test_cross_xy):
+    """Test absolute momentum calculation."""
+    momentum = absolute_momentum(test_cross_xy['u_wind'], test_cross_xy['v_wind'])
+    true_momentum_values = np.array([[[169.22222693, 146.36354006, 145.75559124, 171.8710635,
+                                       215.04876817, 265.73797007, 318.34138347],
+                                      [156.27520858, 133.32107346, 132.62636169, 158.66828331,
+                                       201.78218117, 252.41370282, 304.96242462],
+                                      [143.32819023, 120.27860686, 119.49713214, 145.46550311,
+                                       188.51559418, 239.08943557, 291.58346576],
+                                      [130.38117188, 107.23614026, 106.36790259, 132.26272292,
+                                       175.24900718, 225.76516831, 278.20450691],
+                                      [117.43415353, 94.19367366, 93.23867305, 119.05994273,
+                                       161.98242018, 212.44090106, 264.82554806]]])
+    true_momentum = xr.DataArray(true_momentum_values,
+                                 coords=test_cross_xy['u_wind'].coords,
+                                 dims=test_cross_xy['u_wind'].dims,
+                                 attrs=test_cross_xy['u_wind'].attrs)
+    xr.testing.assert_allclose(true_momentum, momentum)
+    assert momentum.metpy.coordinates_identical(true_momentum)
+    assert units(momentum.attrs['units']) == units('m/s')

--- a/metpy/interpolate/__init__.py
+++ b/metpy/interpolate/__init__.py
@@ -6,9 +6,11 @@ r"""Provides tools for interpolating data."""
 from .grid import *  # noqa: F403
 from .one_dimension import *  # noqa: F403
 from .points import *  # noqa: F403
+from .slices import *  # noqa: F403
 from .tools import *  # noqa: F403
 
 __all__ = grid.__all__[:]  # pylint: disable=undefined-variable
 __all__.extend(one_dimension.__all__)  # pylint: disable=undefined-variable
 __all__.extend(points.__all__)  # pylint: disable=undefined-variable
+__all__.extend(slices.__all__)  # pylint: disable=undefined-variable
 __all__.extend(tools.__all__)  # pylint: disable=undefined-variable

--- a/metpy/interpolate/slices.py
+++ b/metpy/interpolate/slices.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2018 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Tools for interpolating to a vertical slice/cross section through data."""
+
+import cartopy.crs as ccrs
+import numpy as np
+import xarray as xr
+
+from ..package_tools import Exporter
+from ..xarray import CFConventionHandler
+
+exporter = Exporter(globals())
+
+
+@exporter.export
+def cross_section(data, start, end, steps=100, interp_type='linear'):
+    r"""Obtain an interpolated cross-sectional slice through gridded data.
+
+    Utilizing the interpolation functionality in `metpy.interpolate`, this function takes a
+    vertical cross-sectional slice along a geodesic through the given data on a regular grid,
+    which is given as an `xarray.DataArray` so that we can utilize its coordinate and
+    projection metadata.
+
+    Parameters
+    ----------
+    data: `xarray.DataArray` or `xarray.Dataset`
+        Three- (or higher) dimensional field(s) to interpolate (must have attached projection
+        information).
+    start: (2, ) array_like
+        A latitude-longitude pair designating the start point of the cross section (units are
+        degrees north and degrees east).
+    end: (2, ) array_like
+        A latitude-longitude pair designating the end point of the cross section (units are
+        degrees north and degrees east).
+    steps: int, optional
+        The number of points along the geodesic between the start and the end point
+        (including the end points) to use in the cross section. Defaults to 100.
+    interp_type: str, optional
+        The interpolation method, either 'linear' or 'nearest' (see
+        `xarray.DataArray.interp()` for details). Defaults to 'linear'.
+
+    Returns
+    -------
+    `xarray.DataArray` or `xarray.Dataset`
+        The interpolated cross section, with new index dimension along the cross-section.
+
+    See Also
+    --------
+    interpolate_points
+
+    """
+    if isinstance(data, xr.Dataset):
+        # Recursively apply to dataset
+        return data.apply(cross_section, True, (start, end), steps=steps,
+                          interp_type=interp_type)
+    elif data.ndim == 0:
+        # This has no dimensions, so it is likely a projection variable. In any case, there
+        # are no data here to take the cross section with. Therefore, do nothing.
+        return data
+    else:
+        from pyproj import Geod
+        # Apply to this DataArray
+
+        # Get the projection and coordinates
+        crs_data = data.metpy.cartopy_crs
+        x, y = data.metpy.coordinates('x', 'y')
+
+        # Get the geodesic along which to take the cross section
+        # Geod.npts only gives points *in between* the start and end, and we want to include
+        # the endpoints.
+        g = Geod(crs_data.proj4_init)
+        geodesic = np.concatenate([
+            np.array(start[::-1])[None],
+            np.array(g.npts(start[1], start[0], end[1], end[0], steps - 2)),
+            np.array(end[::-1])[None]
+        ]).transpose()
+        points_cross = crs_data.transform_points(ccrs.Geodetic(), *geodesic)[:, :2]
+
+        # Patch points_cross to match given longitude range, whether [0, 360) or (-180,  180]
+        if CFConventionHandler.check_axis(x, 'lon') and (x > 180).any():
+            points_cross[points_cross[:, 0] < 0, 0] += 360.
+
+        # Interpolate to geodesic slice, while adding new dimension coordinate 'index'
+        data_cross = data.interp({
+            x.name: xr.DataArray(points_cross[:, 0], dims='index', attrs=x.attrs),
+            y.name: xr.DataArray(points_cross[:, 1], dims='index', attrs=y.attrs)
+        }, method=interp_type)
+        data_cross.coords['index'] = range(steps)
+
+        return data_cross

--- a/metpy/interpolate/slices.py
+++ b/metpy/interpolate/slices.py
@@ -14,6 +14,89 @@ exporter = Exporter(globals())
 
 
 @exporter.export
+def interpolate_to_slice(data, points, interp_type='linear'):
+    r"""Obtain an interpolated slice through data using xarray.
+
+    Utilizing the interpolation functionality in `metpy.interpolate`, this function takes a
+    slice the given data (currently only regular grids are supported), which is given as an
+    `xarray.DataArray` so that we can utilize its coordinate metadata.
+
+    Parameters
+    ----------
+    data: `xarray.DataArray` or `xarray.Dataset`
+        Three- (or higher) dimensional field(s) to interpolate.
+    points: (N, 2) array_like
+        A list of x, y points in the data projection at which to interpolate the data
+    interp_type: str, optional
+        The interpolation method, either 'linear' or 'nearest' (see
+        `xarray.DataArray.interp()` for details). Defaults to 'linear'.
+
+    Returns
+    -------
+    `xarray.DataArray` or `xarray.Dataset`
+        The interpolated slice of data, with new index dimension of size N.
+
+    See Also
+    --------
+    cross_section
+
+    """
+    x, y = data.metpy.coordinates('x', 'y')
+    data_sliced = data.interp({
+        x.name: xr.DataArray(points[:, 0], dims='index', attrs=x.attrs),
+        y.name: xr.DataArray(points[:, 1], dims='index', attrs=y.attrs)
+    }, method=interp_type)
+    data_sliced.coords['index'] = range(len(points))
+
+    return data_sliced
+
+
+@exporter.export
+def geodesic(crs, start, end, steps):
+    r"""Construct a geodesic path between two points.
+
+    This function acts as a wrapper for the geodesic construction available in `pyproj`.
+
+    Parameters
+    ----------
+    crs: `cartopy.crs`
+        Cartopy Coordinate Reference System to use for the output
+    start: (2, ) array_like
+        A latitude-longitude pair designating the start point of the geodesic (units are
+        degrees north and degrees east).
+    end: (2, ) array_like
+        A latitude-longitude pair designating the end point of the geodesic (units are degrees
+        north and degrees east).
+    steps: int, optional
+        The number of points along the geodesic between the start and the end point
+        (including the end points).
+
+    Returns
+    -------
+    `numpy.ndarray`
+        The list of x, y points in the given CRS of length `steps` along the geodesic.
+
+    See Also
+    --------
+    cross_section
+
+    """
+    from pyproj import Geod
+
+    # Geod.npts only gives points *in between* the start and end, and we want to include
+    # the endpoints.
+    g = Geod(crs.proj4_init)
+    geodesic = np.concatenate([
+        np.array(start[::-1])[None],
+        np.array(g.npts(start[1], start[0], end[1], end[0], steps - 2)),
+        np.array(end[::-1])[None]
+    ]).transpose()
+    points = crs.transform_points(ccrs.Geodetic(), *geodesic)[:, :2]
+
+    return points
+
+
+@exporter.export
 def cross_section(data, start, end, steps=100, interp_type='linear'):
     r"""Obtain an interpolated cross-sectional slice through gridded data.
 
@@ -47,7 +130,7 @@ def cross_section(data, start, end, steps=100, interp_type='linear'):
 
     See Also
     --------
-    interpolate_points
+    interpolate_to_slice, geodesic
 
     """
     if isinstance(data, xr.Dataset):
@@ -59,33 +142,17 @@ def cross_section(data, start, end, steps=100, interp_type='linear'):
         # are no data here to take the cross section with. Therefore, do nothing.
         return data
     else:
-        from pyproj import Geod
-        # Apply to this DataArray
 
         # Get the projection and coordinates
         crs_data = data.metpy.cartopy_crs
-        x, y = data.metpy.coordinates('x', 'y')
+        x = data.metpy.x
 
-        # Get the geodesic along which to take the cross section
-        # Geod.npts only gives points *in between* the start and end, and we want to include
-        # the endpoints.
-        g = Geod(crs_data.proj4_init)
-        geodesic = np.concatenate([
-            np.array(start[::-1])[None],
-            np.array(g.npts(start[1], start[0], end[1], end[0], steps - 2)),
-            np.array(end[::-1])[None]
-        ]).transpose()
-        points_cross = crs_data.transform_points(ccrs.Geodetic(), *geodesic)[:, :2]
+        # Get the geodesic
+        points_cross = geodesic(crs_data, start, end, steps)
 
         # Patch points_cross to match given longitude range, whether [0, 360) or (-180,  180]
         if CFConventionHandler.check_axis(x, 'lon') and (x > 180).any():
             points_cross[points_cross[:, 0] < 0, 0] += 360.
 
-        # Interpolate to geodesic slice, while adding new dimension coordinate 'index'
-        data_cross = data.interp({
-            x.name: xr.DataArray(points_cross[:, 0], dims='index', attrs=x.attrs),
-            y.name: xr.DataArray(points_cross[:, 1], dims='index', attrs=y.attrs)
-        }, method=interp_type)
-        data_cross.coords['index'] = range(steps)
-
-        return data_cross
+        # Return the interpolated data
+        return interpolate_to_slice(data, points_cross, interp_type=interp_type)

--- a/metpy/interpolate/tests/test_slices.py
+++ b/metpy/interpolate/tests/test_slices.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2018 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Test the `slices` module."""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from metpy.interpolate import cross_section
+
+
+@pytest.fixture()
+def test_ds_lonlat():
+    """Return dataset on a lon/lat grid with no time coordinate for use in tests."""
+    data_temp = np.linspace(250, 300, 5 * 6 * 7).reshape((5, 6, 7))
+    data_rh = np.linspace(0, 1, 5 * 6 * 7).reshape((5, 6, 7))
+    ds = xr.Dataset(
+        {
+            'temperature': (['isobaric', 'lat', 'lon'], data_temp),
+            'relative_humidity': (['isobaric', 'lat', 'lon'], data_rh)
+        },
+        coords={
+            'isobaric': xr.DataArray(
+                np.linspace(1000, 500, 5),
+                name='isobaric',
+                dims=['isobaric'],
+                attrs={'units': 'hPa'}
+            ),
+            'lat': xr.DataArray(
+                np.linspace(30, 45, 6),
+                name='lat',
+                dims=['lat'],
+                attrs={'units': 'degrees_north'}
+            ),
+            'lon': xr.DataArray(
+                np.linspace(255, 275, 7),
+                name='lon',
+                dims=['lon'],
+                attrs={'units': 'degrees_east'}
+            )
+        }
+    )
+    ds['temperature'].attrs['units'] = 'kelvin'
+    ds['relative_humidity'].attrs['units'] = 'dimensionless'
+    return ds.metpy.parse_cf()
+
+
+@pytest.fixture()
+def test_ds_xy():
+    """Return dataset on a x/y grid with a time coordinate for use in tests."""
+    data = np.linspace(250, 300, 5 * 6 * 7).reshape((1, 5, 6, 7))
+    ds = xr.Dataset(
+        {
+            'temperature': (['time', 'isobaric', 'y', 'x'], data),
+            'lambert_conformal': ([], '')
+        },
+        coords={
+            'time': xr.DataArray(
+                np.array([np.datetime64('2018-07-01T00:00')]),
+                name='time',
+                dims=['time']
+            ),
+            'isobaric': xr.DataArray(
+                np.linspace(1000, 500, 5),
+                name='isobaric',
+                dims=['isobaric'],
+                attrs={'units': 'hPa'}
+            ),
+            'y': xr.DataArray(
+                np.linspace(-1500, 0, 6),
+                name='y',
+                dims=['y'],
+                attrs={'units': 'km'}
+            ),
+            'x': xr.DataArray(
+                np.linspace(-500, 3000, 7),
+                name='x',
+                dims=['x'],
+                attrs={'units': 'km'}
+            )
+        }
+    )
+    ds['temperature'].attrs = {
+        'units': 'kelvin',
+        'grid_mapping': 'lambert_conformal'
+    }
+    ds['lambert_conformal'].attrs = {
+        'grid_mapping_name': 'lambert_conformal_conic',
+        'standard_parallel': 50.0,
+        'longitude_of_central_meridian': -107.0,
+        'latitude_of_projection_origin': 50.0,
+        'earth_shape': 'spherical',
+        'earth_radius': 6367470.21484375
+    }
+    return ds.metpy.parse_cf()
+
+
+def test_cross_section_dataarray_and_linear_interp(test_ds_xy):
+    """Test the cross_section function with a data array and linear interpolation."""
+    data = test_ds_xy['temperature']
+    start, end = ((36.46, -112.45), (42.95, -68.74))
+    data_cross = cross_section(data, start, end, steps=7)
+    truth_values = np.array([[[250.00095489, 251.53646673, 253.11586664, 254.73477364,
+                               256.38991013, 258.0794356, 259.80334269],
+                              [260.04880178, 261.58431362, 263.16371353, 264.78262053,
+                               266.43775702, 268.12728249, 269.85118958],
+                              [270.09664867, 271.63216051, 273.21156042, 274.83046742,
+                               276.48560391, 278.17512938, 279.89903647],
+                              [280.14449556, 281.6800074, 283.25940731, 284.87831431,
+                               286.5334508, 288.22297627, 289.94688336],
+                              [290.19234245, 291.72785429, 293.3072542, 294.9261612,
+                               296.58129769, 298.27082316, 299.99473025]]])
+    truth_values_x = np.array([-499495.71907062, 98404.43537514, 688589.09865512,
+                               1272690.44926197, 1852009.73516881, 2427525.45740665,
+                               2999932.89862589])
+    truth_values_y = np.array([-1499865.98780602, -1268717.36799267, -1029139.66048478,
+                               -782037.60343652, -528093.95678826, -267710.32566917,
+                               -939.10769171])
+    index = xr.DataArray(range(7), name='index', dims=['index'])
+
+    data_truth_x = xr.DataArray(
+        truth_values_x,
+        name='x',
+        coords={
+            'crs': data['crs'],
+            'y': (['index'], truth_values_y),
+            'x': (['index'], truth_values_x),
+            'index': index,
+        },
+        dims=['index']
+    )
+    data_truth_y = xr.DataArray(
+        truth_values_y,
+        name='y',
+        coords={
+            'crs': data['crs'],
+            'y': (['index'], truth_values_y),
+            'x': (['index'], truth_values_x),
+            'index': index,
+        },
+        dims=['index']
+    )
+    data_truth = xr.DataArray(
+        truth_values,
+        name='temperature',
+        coords={
+            'time': data['time'],
+            'isobaric': data['isobaric'],
+            'index': index,
+            'crs': data['crs'],
+            'y': data_truth_y,
+            'x': data_truth_x
+        },
+        dims=['time', 'isobaric', 'index'],
+        attrs={'units': 'kelvin'}
+    )
+
+    xr.testing.assert_allclose(data_truth, data_cross)
+
+
+def test_cross_section_dataarray_projection_noop(test_ds_xy):
+    """Test the cross_section function with a projection dataarray."""
+    data = test_ds_xy['lambert_conformal']
+    start, end = ((36.46, -112.45), (42.95, -68.74))
+    data_cross = cross_section(data, start, end, steps=7)
+    xr.testing.assert_identical(data, data_cross)
+
+
+def test_cross_section_dataset_and_nearest_interp(test_ds_lonlat):
+    """Test the cross_section function with a dataset and nearest interpolation."""
+    start, end = (30.5, 255.5), (44.5, 274.5)
+    data_cross = cross_section(test_ds_lonlat, start, end, steps=7, interp_type='nearest')
+    nearest_values = test_ds_lonlat.isel(lat=xr.DataArray([0, 1, 2, 3, 3, 4, 5], dims='index'),
+                                         lon=xr.DataArray(range(7), dims='index'))
+    truth_temp = nearest_values['temperature'].values
+    truth_rh = nearest_values['relative_humidity'].values
+    truth_values_lon = np.array([255.5, 258.20305939, 261.06299342, 264.10041516,
+                                 267.3372208, 270.7961498, 274.5])
+    truth_values_lat = np.array([30.5, 33.02800969, 35.49306226, 37.88512911, 40.19271688,
+                                 42.40267088, 44.5])
+    index = xr.DataArray(range(7), name='index', dims=['index'])
+
+    data_truth = xr.Dataset(
+        {
+            'temperature': (['isobaric', 'index'], truth_temp),
+            'relative_humidity': (['isobaric', 'index'], truth_rh)
+        },
+        coords={
+            'isobaric': test_ds_lonlat['isobaric'],
+            'index': index,
+            'crs': test_ds_lonlat['crs'],
+            'lat': (['index'], truth_values_lat),
+            'lon': (['index'], truth_values_lon)
+        },
+    )
+
+    xr.testing.assert_allclose(data_truth, data_cross)

--- a/metpy/testing.py
+++ b/metpy/testing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015,2016 MetPy Developers.
+# Copyright (c) 2015,2016,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 r"""Collection of utilities for testing.
@@ -8,10 +8,13 @@ This includes:
 * code for testing matplotlib figures
 """
 
+from __future__ import absolute_import
+
 import numpy as np
 import numpy.testing
 from pint import DimensionalityError
 import pytest
+import xarray as xr
 
 from metpy.calc import wind_components
 from metpy.cbook import get_test_data
@@ -161,6 +164,13 @@ def assert_array_equal(actual, desired):
     """
     actual, desired = check_and_drop_units(actual, desired)
     numpy.testing.assert_array_equal(actual, desired)
+
+
+def assert_xarray_allclose(actual, desired):
+    """Check that the xarrays are almost equal, including coordinates and attributes."""
+    xr.testing.assert_allclose(actual, desired)
+    assert desired.metpy.coordinates_identical(actual)
+    assert desired.attrs == actual.attrs
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/metpy/tests/test_xarray.py
+++ b/metpy/tests/test_xarray.py
@@ -386,3 +386,16 @@ def test_check_axis_regular_expression_match(test_ds_generic, test_tuple):
     """Test the variety of possibilities for check_axis in the regular expression match."""
     data = test_ds_generic.rename({'e': test_tuple[0]})
     assert data.metpy.check_axis(data[test_tuple[0]], test_tuple[1])
+
+
+def test_narr_example_variable_without_grid_mapping(test_ds):
+    """Test that NARR example is parsed correctly, with x/y coordinates scaled the same."""
+    data = test_ds.metpy.parse_cf()
+    # Make sure that x and y coordinates are parsed correctly, rather than having unequal
+    # scaling based on whether that variable has the grid_mapping attribute. This would
+    # otherwise double the coordinates's shapes since xarray tries to combine the coordinates
+    # with different scaling from differing units.
+    assert test_ds['x'].shape == data['lon'].metpy.x.shape
+    assert test_ds['y'].shape == data['lon'].metpy.y.shape
+    assert data['lon'].metpy.x.identical(data['Temperature'].metpy.x)
+    assert data['lon'].metpy.y.identical(data['Temperature'].metpy.y)

--- a/metpy/tests/test_xarray.py
+++ b/metpy/tests/test_xarray.py
@@ -316,9 +316,9 @@ criterion_matches = [
 
 @pytest.mark.parametrize('test_tuple', criterion_matches)
 def test_check_axis_criterion_match(test_ds_generic, test_tuple):
-    """Test the variety of possibilities for _check_axis in the criterion match."""
+    """Test the variety of possibilities for check_axis in the criterion match."""
     test_ds_generic['e'].attrs[test_tuple[0]] = test_tuple[1]
-    assert test_ds_generic.metpy._check_axis(test_ds_generic['e'], test_tuple[2])
+    assert test_ds_generic.metpy.check_axis(test_ds_generic['e'], test_tuple[2])
 
 
 unit_matches = [
@@ -342,9 +342,9 @@ unit_matches = [
 
 @pytest.mark.parametrize('test_tuple', unit_matches)
 def test_check_axis_unit_match(test_ds_generic, test_tuple):
-    """Test the variety of possibilities for _check_axis in the unit match."""
+    """Test the variety of possibilities for check_axis in the unit match."""
     test_ds_generic['e'].attrs['units'] = test_tuple[0]
-    assert test_ds_generic.metpy._check_axis(test_ds_generic['e'], test_tuple[1])
+    assert test_ds_generic.metpy.check_axis(test_ds_generic['e'], test_tuple[1])
 
 
 regex_matches = [
@@ -383,6 +383,6 @@ regex_matches = [
 
 @pytest.mark.parametrize('test_tuple', regex_matches)
 def test_check_axis_regular_expression_match(test_ds_generic, test_tuple):
-    """Test the variety of possibilities for _check_axis in the regular expression match."""
+    """Test the variety of possibilities for check_axis in the regular expression match."""
     data = test_ds_generic.rename({'e': test_tuple[0]})
-    assert data.metpy._check_axis(data[test_tuple[0]], test_tuple[1])
+    assert data.metpy.check_axis(data[test_tuple[0]], test_tuple[1])

--- a/metpy/xarray.py
+++ b/metpy/xarray.py
@@ -90,6 +90,20 @@ class MetPyAccessor(object):
     def x(self):
         return self._axis('x')
 
+    def coordinates_identical(self, other):
+        """Return whether or not the coordinates of other match this DataArray's."""
+        # If the number of coordinates do not match, we know they can't match.
+        if len(self._data_array.coords) != len(other.coords):
+            return False
+
+        # If same length, iterate over all of them and check
+        for coord_name, coord_var in self._data_array.coords.items():
+            if not other[coord_name].identical(coord_var):
+                return False
+
+        # Otherwise, they match.
+        return True
+
 
 @xr.register_dataset_accessor('metpy')
 class CFConventionHandler(object):
@@ -124,12 +138,12 @@ class CFConventionHandler(object):
 
         # Trying to guess whether we should be adding a crs to this variable's coordinates
         # First make sure it's missing CRS but isn't lat/lon itself
-        if not self._check_axis(var, 'lat', 'lon') and 'crs' not in var.coords:
+        if not self.check_axis(var, 'lat', 'lon') and 'crs' not in var.coords:
             # Look for both lat/lon in the coordinates
             has_lat = has_lon = False
             for coord_var in var.coords.values():
-                has_lat = has_lat or self._check_axis(coord_var, 'lat')
-                has_lon = has_lon or self._check_axis(coord_var, 'lon')
+                has_lat = has_lat or self.check_axis(coord_var, 'lat')
+                has_lon = has_lon or self.check_axis(coord_var, 'lon')
 
             # If we found them, create a lat/lon projection as the crs coord
             if has_lat and has_lon:
@@ -204,7 +218,7 @@ class CFConventionHandler(object):
     }
 
     @classmethod
-    def _check_axis(cls, var, *axes):
+    def check_axis(cls, var, *axes):
         """Check if var satisfies the criteria for any of the given axes."""
         for axis in axes:
             # Check for
@@ -239,7 +253,7 @@ class CFConventionHandler(object):
     def _fixup_coords(self, var):
         """Clean up the units on the coordinate variables."""
         for coord_name, data_array in var.coords.items():
-            if self._check_axis(data_array, 'x', 'y'):
+            if self.check_axis(data_array, 'x', 'y'):
                 try:
                     var.coords[coord_name].metpy.convert_units('meters')
                 except DimensionalityError:  # Radians!
@@ -255,7 +269,7 @@ class CFConventionHandler(object):
         coord_lists = {'T': [], 'Z': [], 'Y': [], 'X': []}
         for coord_var in coords:
 
-            # Identify the coordinate type using _check_axis helper
+            # Identify the coordinate type using check_axis helper
             axes_to_check = {
                 'T': ('time',),
                 'Z': ('vertical',),
@@ -263,7 +277,7 @@ class CFConventionHandler(object):
                 'X': ('x', 'lon')
             }
             for axis_cf, axes_readable in axes_to_check.items():
-                if self._check_axis(coord_var, *axes_readable):
+                if self.check_axis(coord_var, *axes_readable):
                     coord_lists[axis_cf].append(coord_var)
 
         # Resolve any coordinate conflicts
@@ -299,7 +313,7 @@ class CFConventionHandler(object):
             # existence of unique projection x/y (preferred over lon/lat) and use that if
             # it exists uniquely
             projection_coords = [coord_var for coord_var in coord_lists[axis] if
-                                 self._check_axis(coord_var, 'x', 'y')]
+                                 self.check_axis(coord_var, 'x', 'y')]
             if len(projection_coords) == 1:
                 coord_lists[axis] = projection_coords
                 return
@@ -328,6 +342,19 @@ def preprocess_xarray(func):
         args = tuple(a.metpy.unit_array if isinstance(a, xr.DataArray) else a for a in args)
         kwargs = {name: (v.metpy.unit_array if isinstance(v, xr.DataArray) else v)
                   for name, v in kwargs.items()}
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def check_matching_coordinates(func):
+    """Decorate a function to make sure all given DataArrays have matching coordinates."""
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        data_arrays = ([a for a in args if isinstance(a, xr.DataArray)] +
+                       [a for a in kwargs.values() if isinstance(a, xr.DataArray)])
+        for i in range(1, len(data_arrays)):
+            if not data_arrays[0].metpy.coordinates_identical(data_arrays[i]):
+                raise IndexError('Input DataArray arguments must be on same coordinates.')
         return func(*args, **kwargs)
     return wrapper
 

--- a/metpy/xarray.py
+++ b/metpy/xarray.py
@@ -98,7 +98,7 @@ class MetPyAccessor(object):
 
         # If same length, iterate over all of them and check
         for coord_name, coord_var in self._data_array.coords.items():
-            if not other[coord_name].identical(coord_var):
+            if coord_name not in other.coords or not other[coord_name].identical(coord_var):
                 return False
 
         # Otherwise, they match.
@@ -355,9 +355,11 @@ def check_matching_coordinates(func):
     def wrapper(*args, **kwargs):
         data_arrays = ([a for a in args if isinstance(a, xr.DataArray)] +
                        [a for a in kwargs.values() if isinstance(a, xr.DataArray)])
-        for i in range(1, len(data_arrays)):
-            if not data_arrays[0].metpy.coordinates_identical(data_arrays[i]):
-                raise IndexError('Input DataArray arguments must be on same coordinates.')
+        if len(data_arrays) > 1:
+            first = data_arrays[0]
+            for other in data_arrays[1:]:
+                if not first.metpy.coordinates_identical(other):
+                    raise ValueError('Input DataArray arguments must be on same coordinates.')
         return func(*args, **kwargs)
     return wrapper
 

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,8 @@ setup(
                                   '_static/unidata_150x150.png']},
 
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
-    install_requires=['matplotlib>=1.4', 'numpy>=1.10.0', 'scipy>=0.14',
-                      'pint>=0.8', 'xarray>=0.9.6', 'enum34;python_version<"3.4"'],
+    install_requires=['matplotlib>=1.4', 'numpy>=1.11.0', 'scipy>=0.14',
+                      'pint>=0.8', 'xarray>=0.10.7', 'enum34;python_version<"3.4"'],
     extras_require={
         'cdm': ['pyproj>=1.9.4'],
         'dev': ['ipython[all]>=3.1'],


### PR DESCRIPTION
This adds a `cross_section` function to `interpolate`. It allows interpolation to a cross-sectional slice through gridded data along a geodesic path between two lat/lon points. It takes data as either an `xarray.Dataset` or `xarray.DataArray`, and utlizes xarray's own `.interp()` method.

Additionally, this adds in a number of supporting calculations:

- normal and tangential unit vectors along the cross section path
- normal and tangential components of vector field (closes #652)
- cross-sectional absolute/pseduoangular momentum (closes #654)

~~This PR is currently a work-in-progress, since I wanted to get the code of the implementation itself out for initial review, and ask about tests. I currently have some examples in notebooks that I plan on using for the unit tests, but, I'm unsure of best way to test the correctness of an entire `Dataset` or `DataArray` in this case. Would a good approach be to save the correct output as netCDF files in `staticdata` after removing the non-serializable `crs` object coordinate, open them back up while adding back the `crs`, and then test for equality using the [`.identical()`](http://xarray.pydata.org/en/stable/combining.html#equals-and-identical) method? (tests implemented like @dopplershift's comment below)~~

~~EDIT: I just discovered the capabilities of the xarray `.interp()` method added in v0.10.7, which not only makes this code significantly more concise, but also gave a 3 order-of-magnitude speed-up from 74 seconds to 64.9 milliseconds on a linear interpolation example I just ran. The limitations to this approach are it requires gridded data (what I was assuming anyway for this initial implementation) and only allows linear and nearest interpolation. Would it be okay to move to using xarray's interpolation?~~

~~Also, calculations will be coming soon...~~