### PR TITLE
Expose cartopy globe in CFProjection and xarray accessor

### DIFF
--- a/metpy/plots/mapping.py
+++ b/metpy/plots/mapping.py
@@ -41,7 +41,8 @@ class CFProjection(object):
         return {cartopy_name: source[cf_name] for cartopy_name, cf_name in mapping
                 if cf_name in source}
 
-    def _make_cartopy_globe(self):
+    @property
+    def cartopy_globe(self):
         """Initialize a `cartopy.crs.Globe` from the metadata."""
         if 'earth_radius' in self._attrs:
             kwargs = {'ellipse': 'sphere', 'semimajor_axis': self._attrs['earth_radius'],
@@ -60,7 +61,7 @@ class CFProjection(object):
 
     def to_cartopy(self):
         """Convert to a CartoPy projection."""
-        globe = self._make_cartopy_globe()
+        globe = self.cartopy_globe
         proj_name = self._attrs['grid_mapping_name']
         try:
             proj_handler = self.projection_registry[proj_name]

--- a/metpy/tests/test_xarray.py
+++ b/metpy/tests/test_xarray.py
@@ -4,6 +4,8 @@
 """Test the operation of MetPy's XArray accessors."""
 from __future__ import absolute_import
 
+from collections import OrderedDict
+
 import cartopy.crs as ccrs
 import numpy as np
 import pytest
@@ -59,6 +61,16 @@ def test_no_projection(test_ds):
         var.metpy.crs
 
     assert 'not available' in str(exc.value)
+
+
+def test_globe(test_var):
+    """Test getting the globe belonging to the projection."""
+    globe = test_var.metpy.cartopy_globe
+
+    assert globe.to_proj4_params() == OrderedDict([('ellps', 'sphere'),
+                                                   ('a', 6367470.21484375),
+                                                   ('b', 6367470.21484375)])
+    assert isinstance(globe, ccrs.Globe)
 
 
 def test_units(test_var):

--- a/metpy/xarray.py
+++ b/metpy/xarray.py
@@ -54,6 +54,11 @@ class MetPyAccessor(object):
         """Return the coordinate reference system (CRS) as a cartopy object."""
         return self.crs.to_cartopy()
 
+    @property
+    def cartopy_globe(self):
+        """Return the globe belonging to the coordinate reference system (CRS)."""
+        return self.crs.cartopy_globe
+
     def _axis(self, axis):
         """Return the coordinate variable corresponding to the given individual axis."""
         if axis in readable_to_cf_axes:

--- a/tutorials/xarray_tutorial.py
+++ b/tutorials/xarray_tutorial.py
@@ -132,6 +132,13 @@ data_crs = data['temperature'].metpy.cartopy_crs
 print(data_crs)
 
 #########################################################################
+# The cartopy ``Globe`` can similarly be accessed via the ``data_var.metpy.cartopy_globe``
+# property:
+
+data_globe = data['temperature'].metpy.cartopy_globe
+print(data_globe)
+
+#########################################################################
 # Calculations
 # ------------
 #


### PR DESCRIPTION
This PR changes the protected method `_make_cartopy_globe` in
CFProjection into a property, and exposes that property in our xarray
DataArray accessor as well.

Closes #859.