### PR TITLE
fix apparent_temperature when only windchill is calculated

### DIFF
--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -337,7 +337,7 @@ def apparent_temperature(temperature, rh, speed, face_level_winds=False):
                                         mask_undefined=True).to(temperature.units)
 
     # Combine the heat index and wind chill arrays (no point has a value in both)
-    app_temperature = np.ma.where(wind_chill_temperature.mask,
+    app_temperature = np.ma.where(masked_array(wind_chill_temperature).mask,
                                   heat_index_temperature,
                                   wind_chill_temperature)
 

--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -349,7 +349,7 @@ def apparent_temperature(temperature, rh, speed, face_level_winds=False):
     else:
         if app_temperature.mask:
             app_temperature = temperature.m
-        return app_temperature[0] * temperature.units
+        return atleast_1d(app_temperature)[0] * temperature.units
 
 
 @exporter.export

--- a/metpy/calc/tests/test_basic.py
+++ b/metpy/calc/tests/test_basic.py
@@ -417,3 +417,13 @@ def test_apparent_temperature_scalar_no_modification():
     truth = 70 * units.degF
     res = apparent_temperature(temperature, rel_humidity, wind)
     assert_almost_equal(res, truth, 6)
+
+
+def test_apparent_temperature_windchill():
+    """Test that apparent temperature works when a windchill is calculated."""
+    temperature = -5. * units.degC
+    rel_humidity = 50. * units.percent
+    wind = 35. * units('m/s')
+    truth = -18.9357 * units.degC
+    res = apparent_temperature(temperature, rel_humidity, wind)
+    assert_almost_equal(res, truth, 0)


### PR DESCRIPTION
There is a bug when computing `apparent_temperature` when only the windchill calculation is used.

Code assumes that `windchill` returns a masked array, it may not if all values are defined as valid wind chills.  The traceback is like so 
```
metpy/calc/basic.py:340: in apparent_temperature
    app_temperature = np.ma.where(wind_chill_temperature.mask,
...
E           AttributeError: Neither Quantity object nor its magnitude ([-18.93572062]) has attribute 'mask'
```

The change ensures that `wind_chill_temperature` has a mask, when needed