### PR TITLE
WIP: Reorganization of calc docs (with module template override option)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,7 +40,7 @@ test_script:
     - cmd: set TEST_DATA_DIR=%APPVEYOR_BUILD_FOLDER%\\staticdata
     - cmd: python setup.py test --addopts "-s --junitxml=tests.xml --flake8 --mpl --cov=metpy"
     - cmd: cd docs
-    - cmd: make html
+    - cmd: make overridecheck html
     - cmd: cd ..
 
 on_finish:

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ script:
   - if [[ $TASK == "docs" ]]; then
       export TEST_DATA_DIR=${TRAVIS_BUILD_DIR}/staticdata;
       pushd docs;
-      make clean html linkcheck O=-W;
+      make clean overridecheck html linkcheck O=-W;
       export DOC_BUILD_RESULT=$?;
       popd;
       if [[ $TRAVIS_PYTHON_VERSION == 3.6* ]]; then

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,6 +17,10 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/* $(SOURCEDIR)/examples $(SOURCEDIR)/tutorials $(SOURCEDIR)/api/generated
 
+# Check that all functions in modules with template overrides are present in the doc file
+overridecheck:
+	python override_check.py
+
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -1,3 +1,9 @@
+{% if fullname in ['metpy.calc'] %}
+
+{% include 'overrides/' ~ fullname ~ '.rst' with context %}
+
+{% else %}
+
 {{ objname }}
 {{ underline }}
 
@@ -41,3 +47,5 @@
    {%- endfor %}
    {% endif %}
    {% endblock %}
+
+{% endif %}

--- a/docs/_templates/overrides/metpy.calc.rst
+++ b/docs/_templates/overrides/metpy.calc.rst
@@ -1,0 +1,189 @@
+calc
+==========
+
+.. automodule:: metpy.calc
+
+
+   Dry Thermodynamics
+   ------------------
+
+   .. autosummary::
+      :toctree: ./
+
+      add_height_to_pressure
+      add_pressure_to_height
+      density
+      dry_lapse
+      dry_static_energy
+      geopotential_to_height
+      height_to_geopotential
+      height_to_pressure_std
+      mean_pressure_weighted
+      potential_temperature
+      pressure_to_height_std
+      sigma_to_pressure
+      static_stability
+      temperature_from_potential_temperature
+      thickness_hydrostatic
+
+
+   Moist Thermodynamics
+   --------------------
+
+   .. autosummary::
+      :toctree: ./
+
+      dewpoint
+      dewpoint_from_specific_humidity
+      dewpoint_rh
+      equivalent_potential_temperature
+      mixing_ratio
+      mixing_ratio_from_relative_humidity
+      mixing_ratio_from_specific_humidity
+      moist_lapse
+      moist_static_energy
+      precipitable_water
+      psychrometric_vapor_pressure_wet
+      relative_humidity_from_dewpoint
+      relative_humidity_from_mixing_ratio
+      relative_humidity_from_specific_humidity
+      relative_humidity_wet_psychrometric
+      saturation_equivalent_potential_temperature
+      saturation_mixing_ratio
+      saturation_vapor_pressure
+      specific_humidity_from_mixing_ratio
+      thickness_hydrostatic_from_relative_humidity
+      vapor_pressure
+      vertical_velocity
+      vertical_velocity_pressure
+      virtual_potential_temperature
+      virtual_temperature
+      wet_bulb_temperature
+
+
+   Soundings
+   ---------
+
+   .. autosummary::
+      :toctree: ./
+
+      bulk_shear
+      bunkers_storm_motion
+      cape_cin
+      critical_angle
+      el
+      lcl
+      lfc
+      mixed_layer
+      mixed_parcel
+      most_unstable_cape_cin
+      most_unstable_parcel
+      parcel_profile
+      significant_tornado
+      storm_relative_helicity
+      supercell_composite
+      surface_based_cape_cin
+
+
+   Dynamic/Kinematic
+   -----------------
+
+   .. autosummary::
+      :toctree: ./
+
+      absolute_vorticity
+      advection
+      ageostrophic_wind
+      coriolis_parameter
+      divergence
+      exner_function
+      frontogenesis
+      geostrophic_wind
+      inertial_advective_wind
+      kinematic_flux
+      montgomery_streamfunction
+      potential_vorticity_baroclinic
+      potential_vorticity_barotropic
+      q_vector
+      shearing_deformation
+      stretching_deformation
+      total_deformation
+      vorticity
+      wind_components
+      wind_direction
+      wind_speed
+
+
+   Boundary Layer/Turbulence
+   -------------------------
+
+   .. autosummary::
+      :toctree: ./
+
+      brunt_vaisala_frequency
+      brunt_vaisala_frequency_squared
+      brunt_vaisala_period
+      friction_velocity
+      tke
+   
+
+   Mathematical Functions
+   ----------------------
+
+   .. autosummary::
+      :toctree: ./
+
+      first_derivative
+      gradient
+      laplacian
+      lat_lon_grid_deltas
+      second_derivative
+
+
+   Apparent Temperature
+   --------------------
+
+   .. autosummary::
+      :toctree: ./
+
+      apparent_temperature
+      heat_index
+      windchill
+
+   Other
+   -----
+
+   .. autosummary::
+      :toctree: ./
+
+      find_bounding_indices
+      find_intersections
+      get_layer
+      get_layer_heights
+      get_perturbation
+      isentropic_interpolation
+      nearest_intersection_idx
+      parse_angle
+      reduce_point_density
+      resample_nn_1d
+      
+
+   Deprecated
+   ----------
+
+   Do not use these functions in new code, please see their documentation for their replacements.
+
+   .. autosummary::
+      :toctree: ./
+      
+      convergence_vorticity
+      get_wind_components
+      get_wind_dir
+      get_wind_speed
+      h_convergence
+      interp
+      interpolate_nans
+      lat_lon_grid_spacing
+      log_interp
+      shearing_stretching_deformation
+      v_vorticity

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,8 @@ sphinx_gallery_conf = {
         'metpy': None,
         'matplotlib': 'http://matplotlib.org',
         'numpy': 'http://docs.scipy.org/doc/numpy/',
-        'scipy': 'http://docs.scipy.org/doc/scipy/reference'},
+        'scipy': 'http://docs.scipy.org/doc/scipy/reference',
+        'xarray': 'http://xarray.pydata.org/en/stable/'},
     'examples_dirs': [os.path.join('..', 'examples'), os.path.join('..', 'tutorials')],
     'gallery_dirs': ['examples', 'tutorials'],
     'filename_pattern': '\.py',
@@ -72,7 +73,8 @@ intersphinx_mapping = {
                        'matplotlib': ('http://matplotlib.org/', None),
                        'python': ('https://docs.python.org/3/', None),
                        'numpy': ('https://docs.scipy.org/doc/numpy/', None),
-                       'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None)
+                       'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+                       'xarray': ('http://xarray.pydata.org/en/stable/', None)
                        }
 
 # Tweak how docs are formatted

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -22,6 +22,11 @@ if "%1" == "clean" (
 	goto end
 )
 
+if "%1" == "overridecheck" (
+	python override_check.py
+	goto end
+)
+
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
 	echo.

--- a/docs/override_check.py
+++ b/docs/override_check.py
@@ -1,0 +1,43 @@
+#!/usr/lib/env python
+#
+# Module Documentation Override Check
+#
+# Verifies that any modules present in the _templates/overrides directory have all of their
+# their exported functions included in the doc file.
+
+from __future__ import print_function
+
+import glob
+import importlib
+import os
+import sys
+
+
+failed = False
+for full_path in glob.glob('_templates/overrides/metpy.*.rst'):
+
+    filename = os.path.basename(full_path)
+    module = filename.split('.rst')[0]
+
+    # Get all functions in the module
+    i = importlib.import_module(module)
+    functions = set(i.__all__)
+
+    # Get all lines in the file
+    with open(full_path) as f:
+        lines = f.read().splitlines()
+    lines = {line.strip() for line in lines}
+
+    # Check for any missing functions
+    missing_functions = functions - lines
+
+    if len(missing_functions) > 0:
+        failed = True
+        print('ERROR - The following functions are missing from the override file ' +
+              filename + ': ' + ', '.join(missing_functions), file=sys.stderr)
+
+# Report status
+if failed:
+    sys.exit(1)
+else:
+    print('Override check successful.')


### PR DESCRIPTION
This PR reorganizes the `calc` API doc page to be broken down into categories, instead of just one long list (breakdown is currently from [this draft](https://docs.google.com/spreadsheets/d/14g8uyhTVySZ42aJigeaDZSRbspO7a7GsvKDayFyrmY0/) as mentioned in #809). It does so by adding a template override option to the module template, and then implementing a custom `metpy.calc.rst` file in the new `overrides` directory. It also adds a script to verify that all functions in modules that have template overrides are included in their respective doc pages. Closes #809.

Further discussion is likely needed on the best organization of the `calc` page itself, but I wanted to get this PR out there for review on the method, and to see how CI works with it. 

Some initial thoughts on the approach: implementing an override like this within the template itself feels like a hack, but because of how autosummary appears to work (in a fairly all-or-nothing manner), it was the most straight-forward approach that I was able to get to work. Here are other approaches I looked into/tried, but didn't work out:

- remove `metpy.calc` from the top-level autosummary block and add a manual `metpy.calc.rst` in `api` directory (this would mean it has to show up outside of the table)
- make the top-level autosummary just be a table by removing the `:toctree:` option, implement a new hidden `toctree` directive to take care of the table of contents, and create manual pages for all the modules (this would require manual updates of all the modules)
- write our own wrapper around/implementation of autosummary to support this (while I did try making this work, it makes things rather...*overcomplicated*...)