### PR TITLE
"Improve this page" links for examples and tutorials

### DIFF
--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -6,10 +6,20 @@
 {% block breadcrumbs_aside %}
     <li class="source-link">
         {% if hasdoc(pagename) %}
-            {% if pagename.startswith("api/") or pagename.startswith("tutorials/") or pagename.startswith("examples/")%}
+            {% if pagename.startswith(api_dir) %}
                 {% set title = "Suggested improvement for " + pagename %}
                 {% set body = "Please describe what could be improved about this page or the typo/mistake that you found:" %}
                 <a href="https://github.com/{{ github_repo }}/issues/new?title={{ title|urlencode }}&body={{ body|urlencode }}"
+                   class="fa fa-github"> Improve this page</a>
+            {% elif pagename.split("/")[0] in galleries %}
+                {% set gallery_path = gallery_dir[pagename.split("/")[0]] %}
+                {% set example_script = pagename|replace(pagename.split("/")[0], gallery_dir[pagename.split("/")[0]]) %}
+                {% if pagename.split("/")[-1] == "index" %}
+                    {% set example_script = example_script|replace("index", "README.txt") %}
+                {% else %}
+                    {% set example_script = example_script + ".py" %}
+                {% endif %}
+                <a href="https://github.com/{{ github_repo }}/edit/{{ github_version }}/{{ doc_path }}/{{ example_script }}"
                    class="fa fa-github"> Improve this page</a>
             {% else %}
                 <a href="https://github.com/{{ github_repo }}/edit/{{ github_version }}/{{ doc_path }}/{{ pagename }}{{ suffix }}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,6 +175,10 @@ if 'sphinx_rtd_theme' in vars() and sphinx_rtd_theme.__version__ == '0.2.5b1.pos
 # links to the Github repository sources and issues
 html_context = {
     'doc_path': 'docs',
+    'galleries': sphinx_gallery_conf['gallery_dirs'],
+    'gallery_dir': dict(zip(sphinx_gallery_conf['gallery_dirs'],
+                            sphinx_gallery_conf['examples_dirs'])),
+    'api_dir': 'api/generated',
     'github_repo': 'Unidata/MetPy',
     'github_version': 'master',  # Make changes to the master branch
 }


### PR DESCRIPTION
Adds the sphinx-gallery configuration to the template so we can link to the Github edit page for the gallery .py files. The template also identifies the index.html files and directs them to the README.txt files.

Copied this from the [Verde repo](https://github.com/fatiando/verde). For a working example, see https://www.fatiando.org/verde/latest/gallery/block_reduce.html