### PR TITLE
Remove removed functions from doc page override

### DIFF
--- a/docs/_templates/overrides/metpy.calc.rst
+++ b/docs/_templates/overrides/metpy.calc.rst
@@ -176,14 +176,10 @@ calc
    .. autosummary::
       :toctree: ./
       
-      convergence_vorticity
       get_wind_components
       get_wind_dir
       get_wind_speed
-      h_convergence
       interp
       interpolate_nans
       lat_lon_grid_spacing
       log_interp
-      shearing_stretching_deformation
-      v_vorticity

--- a/docs/installguide.rst
+++ b/docs/installguide.rst
@@ -14,7 +14,7 @@ This includes:
 * Core Python developers will
   `stop support for Python 2.7 January 1, 2020 <https://pythonclock.org/>`_
 * NumPy feature releases will be
-  `Python 3 only starting January 1, 2019 <https://docs.scipy.org/doc/numpy/neps/dropping-python2.7-proposal.html>`_,
+  `Python 3 only starting January 1, 2019 <https://www.numpy.org/neps/nep-0014-dropping-python2.7-proposal.html>`_,
   and support for the last release supporting Python 2 will end January 1, 2020.
 * XArray will drop
   `2.7 January 1, 2019 as well <https://github.com/pydata/xarray/issues/1830>`_

--- a/docs/override_check.py
+++ b/docs/override_check.py
@@ -31,7 +31,7 @@ for full_path in glob.glob('_templates/overrides/metpy.*.rst'):
     # Check for any missing functions
     missing_functions = functions - lines
 
-    if len(missing_functions) > 0:
+    if missing_functions:
         failed = True
         print('ERROR - The following functions are missing from the override file ' +
               filename + ': ' + ', '.join(missing_functions), file=sys.stderr)


### PR DESCRIPTION
After #889 and #882 were merged, there was a conflict where the override
doc page created in #889 had functions that were removed in #882. This
PR removes those functions and should restore the doc builds to working order.

Also cleans up a line from code review in #889.

Closes #897.