### PR TITLE
Make derivative calculations work with xarray DataArrays

### DIFF
--- a/docs/_templates/overrides/metpy.calc.rst
+++ b/docs/_templates/overrides/metpy.calc.rst
@@ -137,6 +137,7 @@ calc
       cross_section_components
       first_derivative
       gradient
+      grid_deltas_from_dataarray
       laplacian
       lat_lon_grid_deltas
       normal_component

--- a/metpy/calc/cross_sections.py
+++ b/metpy/calc/cross_sections.py
@@ -123,8 +123,8 @@ def unit_vectors_from_cross_section(cross, index='index'):
 
     """
     x, y = distances_from_cross_section(cross)
-    dx_di = first_derivative(x, x=cross[index])
-    dy_di = first_derivative(y, x=cross[index])
+    dx_di = first_derivative(x, axis=index).values
+    dy_di = first_derivative(y, axis=index).values
     tangent_vector_mag = np.hypot(dx_di, dy_di)
     unit_tangent_vector = np.vstack([dx_di / tangent_vector_mag, dy_di / tangent_vector_mag])
     unit_normal_vector = np.vstack([-dy_di / tangent_vector_mag, dx_di / tangent_vector_mag])

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -11,13 +11,12 @@ import xarray as xr
 
 from metpy.calc import (absolute_vorticity, advection, ageostrophic_wind, coriolis_parameter,
                         divergence, frontogenesis, geostrophic_wind, inertial_advective_wind,
-                        lat_lon_grid_deltas, lat_lon_grid_spacing, montgomery_streamfunction,
+                        lat_lon_grid_deltas, montgomery_streamfunction,
                         potential_temperature, potential_vorticity_baroclinic,
                         potential_vorticity_barotropic, q_vector, shearing_deformation,
                         static_stability, storm_relative_helicity, stretching_deformation,
                         total_deformation, vorticity, wind_components)
 from metpy.constants import g, omega, Re
-from metpy.deprecation import MetpyDeprecationWarning
 from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal,
                            get_test_data)
 from metpy.units import concatenate, units
@@ -442,122 +441,6 @@ def test_storm_relative_helicity_agl():
     assert_almost_equal(pos_srh, 400. * units('meter ** 2 / second ** 2 '), 6)
     assert_almost_equal(neg_srh, -100. * units('meter ** 2 / second ** 2 '), 6)
     assert_almost_equal(total_srh, 300. * units('meter ** 2 / second ** 2 '), 6)
-
-
-def test_lat_lon_grid_spacing_1d():
-    """Test for lat_lon_grid_spacing for variable grid."""
-    lat = np.arange(40, 50, 2.5)
-    lon = np.arange(-100, -90, 2.5)
-    with pytest.warns(MetpyDeprecationWarning):
-        dx, dy = lat_lon_grid_spacing(lon, lat)
-    dx_truth = np.array([[212943.5585, 212943.5585, 212943.5585],
-                         [204946.2305, 204946.2305, 204946.2305],
-                         [196558.8269, 196558.8269, 196558.8269],
-                         [187797.3216, 187797.3216, 187797.3216]]) * units.meter
-    dy_truth = np.array([[277987.1857, 277987.1857, 277987.1857, 277987.1857],
-                         [277987.1857, 277987.1857, 277987.1857, 277987.1857],
-                         [277987.1857, 277987.1857, 277987.1857, 277987.1857]]) * units.meter
-    assert_almost_equal(dx, dx_truth, 4)
-    assert_almost_equal(dy, dy_truth, 4)
-
-
-def test_lat_lon_grid_spacing_2d():
-    """Test for lat_lon_grid_spacing for variable grid."""
-    lat = np.arange(40, 50, 2.5)
-    lon = np.arange(-100, -90, 2.5)
-    lon, lat = np.meshgrid(lon, lat)
-    with pytest.warns(MetpyDeprecationWarning):
-        dx, dy = lat_lon_grid_spacing(lon, lat)
-    dx_truth = np.array([[212943.5585, 212943.5585, 212943.5585],
-                         [204946.2305, 204946.2305, 204946.2305],
-                         [196558.8269, 196558.8269, 196558.8269],
-                         [187797.3216, 187797.3216, 187797.3216]]) * units.meter
-    dy_truth = np.array([[277987.1857, 277987.1857, 277987.1857, 277987.1857],
-                         [277987.1857, 277987.1857, 277987.1857, 277987.1857],
-                         [277987.1857, 277987.1857, 277987.1857, 277987.1857]]) * units.meter
-    assert_almost_equal(dx, dx_truth, 4)
-    assert_almost_equal(dy, dy_truth, 4)
-
-
-def test_lat_lon_grid_spacing_mismatched_shape():
-    """Test for lat_lon_grid_spacing for variable grid."""
-    lat = np.arange(40, 50, 2.5)
-    lon = np.array([[-100., -97.5, -95., -92.5],
-                    [-100., -97.5, -95., -92.5],
-                    [-100., -97.5, -95., -92.5],
-                    [-100., -97.5, -95., -92.5]])
-    with pytest.raises(ValueError):
-        with pytest.warns(MetpyDeprecationWarning):
-            dx, dy = lat_lon_grid_spacing(lon, lat)
-
-
-def test_lat_lon_grid_deltas_1d():
-    """Test for lat_lon_grid_deltas for variable grid."""
-    lat = np.arange(40, 50, 2.5)
-    lon = np.arange(-100, -90, 2.5)
-    dx, dy = lat_lon_grid_deltas(lon, lat)
-    dx_truth = np.array([[212943.5585, 212943.5585, 212943.5585],
-                         [204946.2305, 204946.2305, 204946.2305],
-                         [196558.8269, 196558.8269, 196558.8269],
-                         [187797.3216, 187797.3216, 187797.3216]]) * units.meter
-    dy_truth = np.array([[277987.1857, 277987.1857, 277987.1857, 277987.1857],
-                         [277987.1857, 277987.1857, 277987.1857, 277987.1857],
-                         [277987.1857, 277987.1857, 277987.1857, 277987.1857]]) * units.meter
-    assert_almost_equal(dx, dx_truth, 4)
-    assert_almost_equal(dy, dy_truth, 4)
-
-
-@pytest.mark.parametrize('flip_order', [(False, True)])
-def test_lat_lon_grid_deltas_2d(flip_order):
-    """Test for lat_lon_grid_deltas for variable grid with negative delta distances."""
-    lat = np.arange(40, 50, 2.5)
-    lon = np.arange(-100, -90, 2.5)
-    dx_truth = np.array([[212943.5585, 212943.5585, 212943.5585],
-                         [204946.2305, 204946.2305, 204946.2305],
-                         [196558.8269, 196558.8269, 196558.8269],
-                         [187797.3216, 187797.3216, 187797.3216]]) * units.meter
-    dy_truth = np.array([[277987.1857, 277987.1857, 277987.1857, 277987.1857],
-                         [277987.1857, 277987.1857, 277987.1857, 277987.1857],
-                         [277987.1857, 277987.1857, 277987.1857, 277987.1857]]) * units.meter
-    if flip_order:
-        lon = lon[::-1]
-        lat = lat[::-1]
-        dx_truth = -1 * dx_truth[::-1]
-        dy_truth = -1 * dy_truth[::-1]
-
-    lon, lat = np.meshgrid(lon, lat)
-    dx, dy = lat_lon_grid_deltas(lon, lat)
-    assert_almost_equal(dx, dx_truth, 4)
-    assert_almost_equal(dy, dy_truth, 4)
-
-
-def test_lat_lon_grid_deltas_extra_dimensions():
-    """Test for lat_lon_grid_deltas with extra leading dimensions."""
-    lon, lat = np.meshgrid(np.arange(-100, -90, 2.5), np.arange(40, 50, 2.5))
-    lat = lat[None, None]
-    lon = lon[None, None]
-    dx_truth = np.array([[[[212943.5585, 212943.5585, 212943.5585],
-                           [204946.2305, 204946.2305, 204946.2305],
-                           [196558.8269, 196558.8269, 196558.8269],
-                           [187797.3216, 187797.3216, 187797.3216]]]]) * units.meter
-    dy_truth = (np.array([[[[277987.1857, 277987.1857, 277987.1857, 277987.1857],
-                            [277987.1857, 277987.1857, 277987.1857, 277987.1857],
-                            [277987.1857, 277987.1857, 277987.1857, 277987.1857]]]]) *
-                units.meter)
-    dx, dy = lat_lon_grid_deltas(lon, lat)
-    assert_almost_equal(dx, dx_truth, 4)
-    assert_almost_equal(dy, dy_truth, 4)
-
-
-def test_lat_lon_grid_deltas_mismatched_shape():
-    """Test for lat_lon_grid_deltas for variable grid."""
-    lat = np.arange(40, 50, 2.5)
-    lon = np.array([[-100., -97.5, -95., -92.5],
-                    [-100., -97.5, -95., -92.5],
-                    [-100., -97.5, -95., -92.5],
-                    [-100., -97.5, -95., -92.5]])
-    with pytest.raises(ValueError):
-        lat_lon_grid_deltas(lon, lat)
 
 
 def test_absolute_vorticity_asym():

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -17,6 +17,7 @@ except ImportError:  # Only available in numpy >=1.13.0
         return a
 import numpy.ma as ma
 from scipy.spatial import cKDTree
+import xarray as xr
 
 from . import height_to_pressure_std, pressure_to_height_std
 from ..cbook import broadcast_indices
@@ -24,7 +25,7 @@ from ..deprecation import deprecated, metpyDeprecation
 from ..interpolate.one_dimension import interpolate_1d, interpolate_nans_1d, log_interpolate_1d
 from ..package_tools import Exporter
 from ..units import atleast_1d, check_units, concatenate, diff, units
-from ..xarray import preprocess_xarray
+from ..xarray import CFConventionHandler, preprocess_xarray
 
 exporter = Exporter(globals())
 
@@ -772,24 +773,212 @@ def _less_or_close(a, value, **kwargs):
     return (a < value) | np.isclose(a, value, **kwargs)
 
 
+@deprecated('0.8', addendum=' This function has been replaced by the signed delta distance'
+                            'calculation lat_lon_grid_deltas and will be removed in MetPy'
+                            ' 0.11.',
+            pending=False)
 @exporter.export
 @preprocess_xarray
+def lat_lon_grid_spacing(longitude, latitude, **kwargs):
+    r"""Calculate the distance between grid points that are in a latitude/longitude format.
+
+    Calculate the distance between grid points when the grid spacing is defined by
+    delta lat/lon rather than delta x/y
+
+    Parameters
+    ----------
+    longitude : array_like
+        array of longitudes defining the grid
+    latitude : array_like
+        array of latitudes defining the grid
+    kwargs
+        Other keyword arguments to pass to :class:`~pyproj.Geod`
+
+    Returns
+    -------
+     dx, dy: 2D arrays of distances between grid points in the x and y direction
+
+    Notes
+    -----
+    Accepts, 1D or 2D arrays for latitude and longitude
+    Assumes [Y, X] for 2D arrays
+
+    .. deprecated:: 0.8.0
+        Function has been replaced with the signed delta distance calculation
+        `lat_lon_grid_deltas` and will be removed from MetPy in 0.11.0.
+
+    """
+    # Use the absolute value of the signed function replacing this
+    dx, dy = lat_lon_grid_deltas(longitude, latitude, **kwargs)
+
+    return np.abs(dx), np.abs(dy)
+
+
+@exporter.export
+@preprocess_xarray
+def lat_lon_grid_deltas(longitude, latitude, **kwargs):
+    r"""Calculate the delta between grid points that are in a latitude/longitude format.
+
+    Calculate the signed delta distance between grid points when the grid spacing is defined by
+    delta lat/lon rather than delta x/y
+
+    Parameters
+    ----------
+    longitude : array_like
+        array of longitudes defining the grid
+    latitude : array_like
+        array of latitudes defining the grid
+    kwargs
+        Other keyword arguments to pass to :class:`~pyproj.Geod`
+
+    Returns
+    -------
+    dx, dy:
+        at least two dimensional arrays of signed deltas between grid points in the x and y
+        direction
+
+    Notes
+    -----
+    Accepts 1D, 2D, or higher arrays for latitude and longitude
+    Assumes [..., Y, X] for >=2 dimensional arrays
+
+    """
+    from pyproj import Geod
+
+    # Inputs must be the same number of dimensions
+    if latitude.ndim != longitude.ndim:
+        raise ValueError('Latitude and longitude must have the same number of dimensions.')
+
+    # If we were given 1D arrays, make a mesh grid
+    if latitude.ndim < 2:
+        longitude, latitude = np.meshgrid(longitude, latitude)
+
+    geod_args = {'ellps': 'sphere'}
+    if kwargs:
+        geod_args = kwargs
+
+    g = Geod(**geod_args)
+
+    forward_az, _, dy = g.inv(longitude[..., :-1, :], latitude[..., :-1, :],
+                              longitude[..., 1:, :], latitude[..., 1:, :])
+    dy[(forward_az < -90.) | (forward_az > 90.)] *= -1
+
+    forward_az, _, dx = g.inv(longitude[..., :, :-1], latitude[..., :, :-1],
+                              longitude[..., :, 1:], latitude[..., :, 1:])
+    dx[(forward_az < 0.) | (forward_az > 180.)] *= -1
+
+    return dx * units.meter, dy * units.meter
+
+
+@exporter.export
+def grid_deltas_from_dataarray(f):
+    """Calculate the horizontal deltas between grid points of a DataArray.
+
+    Calculate the signed delta distance between grid points of a DataArray in the horizontal
+    directions, whether the grid is lat/lon or x/y.
+
+    Parameters
+    ----------
+    f : `xarray.DataArray`
+        Parsed DataArray on a latitude/longitude grid, in (..., lat, lon) or (..., y, x)
+        dimension order
+
+    Returns
+    -------
+    dx, dy:
+        arrays of signed deltas between grid points in the x and y directions with dimensions
+        matching those of `f`.
+
+    See Also
+    --------
+    lat_lon_grid_deltas
+
+    """
+    if f.metpy.crs['grid_mapping_name'] == 'latitude_longitude':
+        dx, dy = lat_lon_grid_deltas(f.metpy.x.values, f.metpy.y.values,
+                                     initstring=f.metpy.cartopy_crs.proj4_init)
+        slc_x = slc_y = tuple([np.newaxis] * (f.ndim - 2) + [slice(None)] * 2)
+    else:
+        dx = np.diff(f.metpy.x.metpy.unit_array.to('m').magnitude) * units('m')
+        dy = np.diff(f.metpy.y.metpy.unit_array.to('m').magnitude) * units('m')
+        slc = [np.newaxis] * (f.ndim - 2)
+        slc_x = tuple(slc + [np.newaxis, slice(None)])
+        slc_y = tuple(slc + [slice(None), np.newaxis])
+    return dx[slc_x], dy[slc_y]
+
+
+def xarray_derivative_wrap(func):
+    """Decorate the derivative functions to make them work nicely with DataArrays.
+
+    This will automatically determine if the coordinates can be pulled directly from the
+    DataArray, or if a call to lat_lon_grid_deltas is needed.
+    """
+    @functools.wraps(func)
+    def wrapper(f, **kwargs):
+        if 'x' in kwargs or 'delta' in kwargs:
+            # Use the usual DataArray to pint.Quantity preprocessing wrapper
+            return preprocess_xarray(func)(f, **kwargs)
+        elif isinstance(f, xr.DataArray):
+            # Get axis argument, defaulting to first dimension
+            axis = f.metpy.find_axis_name(kwargs.get('axis', 0))
+
+            # Initialize new kwargs with the axis number
+            new_kwargs = {'axis': f.get_axis_num(axis)}
+
+            if f[axis].attrs.get('axis') == 'T':
+                # Time coordinate, need to convert to seconds from datetimes
+                new_kwargs['x'] = f[axis].metpy.as_timestamp().metpy.unit_array
+            elif CFConventionHandler.check_axis(f[axis], 'lon'):
+                # Longitude coordinate, need to get grid deltas
+                new_kwargs['delta'], _ = grid_deltas_from_dataarray(f)
+            elif CFConventionHandler.check_axis(f[axis], 'lat'):
+                # Latitude coordinate, need to get grid deltas
+                _, new_kwargs['delta'] = grid_deltas_from_dataarray(f)
+            else:
+                # General coordinate, use as is
+                new_kwargs['x'] = f[axis].metpy.unit_array
+
+            # Calculate and return result as a DataArray
+            result = func(f.metpy.unit_array, **new_kwargs)
+            return xr.DataArray(result.magnitude,
+                                coords=f.coords,
+                                dims=f.dims,
+                                attrs={'units': str(result.units)})
+        else:
+            # Error
+            raise ValueError('Must specify either "x" or "delta" for value positions when "f" '
+                             'is not a DataArray.')
+    return wrapper
+
+
+@exporter.export
+@xarray_derivative_wrap
 def first_derivative(f, **kwargs):
     """Calculate the first derivative of a grid of values.
 
     Works for both regularly-spaced data and grids with varying spacing.
 
-    Either `x` or `delta` must be specified. This uses 3 points to calculate the
-    derivative, using forward or backward at the edges of the grid as appropriate, and
-    centered elsewhere. The irregular spacing is handled explicitly, using the formulation
-    as specified by [Bowen2005]_.
+    Either `x` or `delta` must be specified, or `f` must be given as an `xarray.DataArray` with
+    attached coordinate and projection information. If `f` is an `xarray.DataArray`, and `x` or
+    `delta` are given, `f` will be converted to a `pint.Quantity` and the derivative returned
+    as a `pint.Quantity`, otherwise, if neither `x` nor `delta` are given, the attached
+    coordinate information belonging to `axis` will be used and the derivative will be returned
+    as an `xarray.DataArray`.
+
+    This uses 3 points to calculate the derivative, using forward or backward at the edges of
+    the grid as appropriate, and centered elsewhere. The irregular spacing is handled
+    explicitly, using the formulation as specified by [Bowen2005]_.
 
     Parameters
     ----------
     f : array-like
         Array of values of which to calculate the derivative
-    axis : int, optional
-        The array axis along which to take the derivative. Defaults to 0.
+    axis : int or str, optional
+        The array axis along which to take the derivative. If `f` is ndarray-like, must be an
+        integer. If `f` is a `DataArray`, can be a string (referring to either the coordinate
+        dimension name or the axis type) or integer (referring to axis number), unless using
+        implicit conversion to `pint.Quantity`, in which case it must be an integer. Defaults
+        to 0.
     x : array-like, optional
         The coordinate values corresponding to the grid points in `f`.
     delta : array-like, optional
@@ -858,23 +1047,33 @@ def first_derivative(f, **kwargs):
 
 
 @exporter.export
-@preprocess_xarray
+@xarray_derivative_wrap
 def second_derivative(f, **kwargs):
     """Calculate the second derivative of a grid of values.
 
     Works for both regularly-spaced data and grids with varying spacing.
 
-    Either `x` or `delta` must be specified. This uses 3 points to calculate the
-    derivative, using forward or backward at the edges of the grid as appropriate, and
-    centered elsewhere. The irregular spacing is handled explicitly, using the formulation
-    as specified by [Bowen2005]_.
+    Either `x` or `delta` must be specified, or `f` must be given as an `xarray.DataArray` with
+    attached coordinate and projection information. If `f` is an `xarray.DataArray`, and `x` or
+    `delta` are given, `f` will be converted to a `pint.Quantity` and the derivative returned
+    as a `pint.Quantity`, otherwise, if neither `x` nor `delta` are given, the attached
+    coordinate information belonging to `axis` will be used and the derivative will be returned
+    as an `xarray.DataArray`.
+
+    This uses 3 points to calculate the derivative, using forward or backward at the edges of
+    the grid as appropriate, and centered elsewhere. The irregular spacing is handled
+    explicitly, using the formulation as specified by [Bowen2005]_.
 
     Parameters
     ----------
     f : array-like
         Array of values of which to calculate the derivative
-    axis : int, optional
-        The array axis along which to take the derivative. Defaults to 0.
+    axis : int or str, optional
+        The array axis along which to take the derivative. If `f` is ndarray-like, must be an
+        integer. If `f` is a `DataArray`, can be a string (referring to either the coordinate
+        dimension name or the axis type) or integer (referring to axis number), unless using
+        implicit conversion to `pint.Quantity`, in which case it must be an integer. Defaults
+        to 0.
     x : array-like, optional
         The coordinate values corresponding to the grid points in `f`.
     delta : array-like, optional
@@ -940,13 +1139,17 @@ def second_derivative(f, **kwargs):
 
 
 @exporter.export
-@preprocess_xarray
 def gradient(f, **kwargs):
     """Calculate the gradient of a grid of values.
 
     Works for both regularly-spaced data, and grids with varying spacing.
 
-    Either `coordinates` or `deltas` must be specified.
+    Either `coordinates` or `deltas` must be specified, or `f` must be given as an
+    `xarray.DataArray` with  attached coordinate and projection information. If `f` is an
+    `xarray.DataArray`, and `coordinates` or `deltas` are given, `f` will be converted to a
+    `pint.Quantity` and the gradient returned as a tuple of `pint.Quantity`, otherwise, if
+    neither `coordinates` nor `deltas` are given, the attached coordinate information belonging
+    to `axis` will be used and the gradient will be returned as a tuple of `xarray.DataArray`.
 
     Parameters
     ----------
@@ -960,18 +1163,20 @@ def gradient(f, **kwargs):
         in axis order. There should be one item less than the size of `f` along the applicable
         axis.
     axes : sequence, optional
-        Sequence of integers that specify the array axes along which to take the derivatives.
-        Defaults to all axes of f in order. If given, its length must be less than or equal to
-        that of the `coordinates` or `deltas` given.
+        Sequence of strings (if `f` is a `xarray.DataArray` and implicit conversion to
+        `pint.Quantity` is not used) or integers that specify the array axes along which to
+        take the derivatives. Defaults to all axes of `f`. If given, and used with
+        `coordinates` or `deltas`, its length must be less than or equal to that of the
+        `coordinates` or `deltas` given.
 
     Returns
     -------
-    array-like
+    tuple of array-like
         The first derivative calculated along each specified axis of the original array
 
     See Also
     --------
-    laplacian
+    laplacian, first_derivative
 
     Notes
     -----
@@ -979,7 +1184,7 @@ def gradient(f, **kwargs):
     deprecated in 0.9 in favor of `coordinates`.
 
     If this function is used without the `axes` parameter, the length of `coordinates` or
-    `deltas` (as applicable) must match the number of dimensions of `f`.
+    `deltas` (as applicable) should match the number of dimensions of `f`.
 
     """
     pos_kwarg, positions, axes = _process_gradient_args(f, kwargs)
@@ -988,13 +1193,17 @@ def gradient(f, **kwargs):
 
 
 @exporter.export
-@preprocess_xarray
 def laplacian(f, **kwargs):
     """Calculate the laplacian of a grid of values.
 
     Works for both regularly-spaced data, and grids with varying spacing.
 
-    Either `coordinates` or `deltas` must be specified.
+    Either `coordinates` or `deltas` must be specified, or `f` must be given as an
+    `xarray.DataArray` with  attached coordinate and projection information. If `f` is an
+    `xarray.DataArray`, and `coordinates` or `deltas` are given, `f` will be converted to a
+    `pint.Quantity` and the gradient returned as a tuple of `pint.Quantity`, otherwise, if
+    neither `coordinates` nor `deltas` are given, the attached coordinate information belonging
+    to `axis` will be used and the gradient will be returned as a tuple of `xarray.DataArray`.
 
     Parameters
     ----------
@@ -1006,9 +1215,11 @@ def laplacian(f, **kwargs):
         Spacing between the grid points in `f`. There should be one item less than the size
         of `f` along the applicable axis.
     axes : sequence, optional
-        Sequence of integers that specify the array axes along which to take the derivatives.
-        Defaults to all axes of f. If given, its length must be less than or equal to that of
-        the `coordinates` or `deltas` given.
+        Sequence of strings (if `f` is a `xarray.DataArray` and implicit conversion to
+        `pint.Quantity` is not used) or integers that specify the array axes along which to
+        take the derivatives. Defaults to all axes of `f`. If given, and used with
+        `coordinates` or `deltas`, its length must be less than or equal to that of the
+        `coordinates` or `deltas` given.
 
     Returns
     -------
@@ -1017,7 +1228,7 @@ def laplacian(f, **kwargs):
 
     See Also
     --------
-    gradient
+    gradient, second_derivative
 
     Notes
     -----
@@ -1025,12 +1236,17 @@ def laplacian(f, **kwargs):
     deprecated in 0.9 in favor of `coordinates`.
 
     If this function is used without the `axes` parameter, the length of `coordinates` or
-    `deltas` (as applicable) must match the number of dimensions of `f`.
+    `deltas` (as applicable) should match the number of dimensions of `f`.
 
     """
     pos_kwarg, positions, axes = _process_gradient_args(f, kwargs)
-    return sum(second_derivative(f, axis=axis, **{pos_kwarg: positions[ind]})
-               for ind, axis in enumerate(axes))
+    derivs = [second_derivative(f, axis=axis, **{pos_kwarg: positions[ind]})
+              for ind, axis in enumerate(axes)]
+    laplac = sum(derivs)
+    if isinstance(derivs[0], xr.DataArray):
+        # Patch in the units that are dropped
+        laplac.attrs['units'] = derivs[0].attrs['units']
+    return laplac
 
 
 def _broadcast_to_axis(arr, axis, ndim):
@@ -1070,8 +1286,11 @@ def _process_gradient_args(f, kwargs):
                       'deprecated. Use "coordinates" instead.', metpyDeprecation)
         _check_length(kwargs['x'])
         return 'x', kwargs['x'], axes
+    elif isinstance(f, xr.DataArray):
+        return 'pass', axes, axes  # only the axis argument matters
     else:
-        raise ValueError('Must specify either "coordinates" or "deltas" for value positions.')
+        raise ValueError('Must specify either "coordinates" or "deltas" for value positions '
+                         'when "f" is not a DataArray.')
 
 
 def _process_deriv_args(f, kwargs):

--- a/metpy/tests/test_xarray.py
+++ b/metpy/tests/test_xarray.py
@@ -73,11 +73,16 @@ def test_globe(test_var):
     assert isinstance(globe, ccrs.Globe)
 
 
-def test_units(test_var):
+def test_unit_array(test_var):
     """Test unit handling through the accessor."""
     arr = test_var.metpy.unit_array
     assert isinstance(arr, units.Quantity)
     assert arr.units == units.kelvin
+
+
+def test_units(test_var):
+    """Test the units property on the accessor."""
+    assert test_var.metpy.units == units('kelvin')
 
 
 def test_convert_units(test_var):
@@ -431,3 +436,37 @@ def test_check_matching_coordinates(test_ds_generic):
                                 test_ds_generic['test'] * 2)
     with pytest.raises(ValueError):
         add(test_ds_generic['test'], other)
+
+
+def test_as_timestamp(test_var):
+    """Test the as_timestamp method for a time DataArray."""
+    time = test_var.metpy.time
+    truth = xr.DataArray(np.array([544557600]),
+                         name='time',
+                         coords=time.coords,
+                         dims='time',
+                         attrs={'long_name': 'forecast time', 'axis': 'T',
+                                'units': 'seconds'})
+    assert truth.identical(time.metpy.as_timestamp())
+
+
+def test_find_axis_name_integer(test_var):
+    """Test getting axis name using the axis number identifier."""
+    assert test_var.metpy.find_axis_name(2) == 'y'
+
+
+def test_find_axis_name_axis_type(test_var):
+    """Test getting axis name using the axis type identifier."""
+    assert test_var.metpy.find_axis_name('vertical') == 'isobaric'
+
+
+def test_find_axis_name_dim_coord_name(test_var):
+    """Test getting axis name using the dimension coordinate name identifier."""
+    assert test_var.metpy.find_axis_name('isobaric') == 'isobaric'
+
+
+def test_find_axis_name_bad_identifier(test_var):
+    """Test getting axis name using the axis type identifier."""
+    with pytest.raises(ValueError) as exc:
+        test_var.metpy.find_axis_name('latitude')
+    assert 'axis is not valid' in str(exc.value)

--- a/tutorials/xarray_tutorial.py
+++ b/tutorials/xarray_tutorial.py
@@ -97,7 +97,7 @@ data['isobaric3'].metpy.convert_units('hPa')
 #
 # 1. Use the ``data_var.metpy.coordinates`` method
 # 2. Use the ``data_var.metpy.x``, ``data_var.metpy.y``, ``data_var.metpy.vertical``,
-#    `data_var.metpy.time` properties
+#    ``data_var.metpy.time`` properties
 #
 # The valid coordinate types are:
 #
@@ -142,7 +142,7 @@ print(data_globe)
 # Calculations
 # ------------
 #
-# Nearly all of the calculations in `metpy.calc` will accept DataArrays by converting them
+# Most of the calculations in `metpy.calc` will accept DataArrays by converting them
 # into their corresponding unit arrays. While this may often work without any issues, we must
 # keep in mind that because the calculations are working with unit arrays and not DataArrays:
 #
@@ -157,9 +157,39 @@ print(data_globe)
 
 lat, lon = xr.broadcast(y, x)
 f = mpcalc.coriolis_parameter(lat.values * units.degrees)
-dx, dy = mpcalc.lat_lon_grid_deltas(lon.values, lat.values)
+dx, dy = mpcalc.lat_lon_grid_deltas(lon.values, lat.values, initstring=data_crs.proj4_init)
 heights = data['height'].loc[time[0]].loc[{vertical.name: 500.}]
-u_geo, v_geo = mpcalc.geostrophic_wind(heights, f, dx, dy, dim_order='yx')
+u_geo, v_geo = mpcalc.geostrophic_wind(heights, f, dx, dy)
+print(u_geo)
+print(v_geo)
+
+#########################################################################
+# Also, a limited number of calculations directly support xarray DataArrays or Datasets (they
+# can accept *and* return xarray objects). Right now, this includes
+#
+# - Derivative functions
+#     - ``first_derivative``
+#     - ``second_derivative``
+#     - ``gradient``
+#     - ``laplacian``
+# - Cross-section functions
+#     - ``cross_section_components``
+#     - ``normal_component``
+#     - ``tangential_component``
+#     - ``absolute_momentum``
+#
+# More details can be found by looking at the documentation for the specific function.
+
+#########################################################################
+# There is also the special case of the helper function, ``grid_deltas_from_dataarray``, which
+# takes a DataArray input, but returns unit arrays for use in other calculations. We could
+# rewrite the above geostrophic wind example using this helper function as follows:
+
+heights = data['height'].loc[time[0]].loc[{vertical.name: 500.}]
+lat, lon = xr.broadcast(y, x)
+f = mpcalc.coriolis_parameter(lat.values * units.degrees)
+dx, dy = mpcalc.grid_deltas_from_dataarray(heights)
+u_geo, v_geo = mpcalc.geostrophic_wind(heights, f, dx, dy)
 print(u_geo)
 print(v_geo)
 
@@ -259,8 +289,8 @@ plt.show()
 #
 # Fix:
 #
-# Specify the `coordinates` argument to the `parse_cf` method to map the `T` (time), `Z`
-# (vertical), `Y`, and `X` axes (as applicable to your dataset) to the corresponding
+# Specify the ``coordinates`` argument to the ``parse_cf`` method to map the ``T`` (time),
+# ``Z`` (vertical), ``Y``, and ``X`` axes (as applicable to your dataset) to the corresponding
 # coordinates.
 #
 # ::


### PR DESCRIPTION
While this was originally devised while working on isallobaric wind and thermal wind, I've also found that it would be needed for some of the cross-section examples I'm putting together (a couple forms of PV that our current implementations don't handle), so here it is now on its own.

This PR modifies the current derivative calculations to work with DataArrays themselves, rather than by conversion to (and output as) pint quantities. This includes automatic coordinate handling. With that, in order to support lat/lon non-uniform coordinates, the `lat_lon_grid_deltas` function also needed to be moved from kinematics.py to tools.py to make the imports work right.

Three implementation questions I'd like to ask right away:
- what should the default be for `first_derivative` and `second_derivative` if `axis` is not given, or should it be required (what I have right now)?
- would it be useful to add a "with respect to" option (`wrt`, following CF?) to automatically pick out the desired axis? For example, if we wanted the rate of change of temperature with respect to time, we could just have
  ```
  first_derivative(temperature, wrt='time')
  ```
  vs. needing to know the name of the time axis,
  ```
  first_derivative(temperature, axis='time1')
  ```
  or
  ```
  first_derivative(temperature, axis=temperature.metpy.time.name)
  ```
- should the old v0.8 preprocessing approach still be made to work here, but be deprecated?