### PR TITLE
Make handling units like 'degrees_north' a little nicer

### DIFF
--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -895,7 +895,7 @@ def grid_deltas_from_dataarray(f):
 
     """
     if f.metpy.crs['grid_mapping_name'] == 'latitude_longitude':
-        dx, dy = lat_lon_grid_deltas(f.metpy.x.values, f.metpy.y.values,
+        dx, dy = lat_lon_grid_deltas(f.metpy.x, f.metpy.y,
                                      initstring=f.metpy.cartopy_crs.proj4_init)
         slc_x = slc_y = tuple([np.newaxis] * (f.ndim - 2) + [slice(None)] * 2)
     else:

--- a/metpy/tests/test_units.py
+++ b/metpy/tests/test_units.py
@@ -168,3 +168,24 @@ def test_pandas_units_no_units_given():
     df = pd.DataFrame(data=[[1, 4], [2, 5], [3, 6]], columns=['cola', 'colb'])
     with pytest.raises(ValueError):
         pandas_dataframe_to_unit_arrays(df)
+
+
+def test_added_degrees_units():
+    """Test that our added degrees units are present in the registry."""
+    # Test equivalence of abbreviations/aliases to our defined names
+    assert str(units('degrees_N').units) == 'degrees_north'
+    assert str(units('degreesN').units) == 'degrees_north'
+    assert str(units('degree_north').units) == 'degrees_north'
+    assert str(units('degree_N').units) == 'degrees_north'
+    assert str(units('degreeN').units) == 'degrees_north'
+    assert str(units('degrees_E').units) == 'degrees_east'
+    assert str(units('degreesE').units) == 'degrees_east'
+    assert str(units('degree_east').units) == 'degrees_east'
+    assert str(units('degree_E').units) == 'degrees_east'
+    assert str(units('degreeE').units) == 'degrees_east'
+
+    # Test equivalence of our defined units to base units
+    assert units('degrees_north') == units('degrees')
+    assert units('degrees_north').to_base_units().units == units.radian
+    assert units('degrees_east') == units('degrees')
+    assert units('degrees_east').to_base_units().units == units.radian

--- a/metpy/units.py
+++ b/metpy/units.py
@@ -31,6 +31,11 @@ units = pint.UnitRegistry(autoconvert_offset_to_baseunit=True)
 units.define(pint.unit.UnitDefinition('percent', '%', (),
              pint.converters.ScaleConverter(0.01)))
 
+# Define commonly encountered units not defined by pint
+units.define('degrees_north = degree = degrees_N = degreesN = degree_north = degree_N '
+             '= degreeN')
+units.define('degrees_east = degree = degrees_E = degreesE = degree_east = degree_E = degreeE')
+
 
 def pandas_dataframe_to_unit_arrays(df, column_units=None):
     """Attach units to data in pandas dataframes and return united arrays.

--- a/metpy/xarray.py
+++ b/metpy/xarray.py
@@ -11,7 +11,7 @@ import warnings
 import xarray as xr
 from xarray.core.accessors import DatetimeAccessor
 
-from .units import DimensionalityError, UndefinedUnitError, units
+from .units import DimensionalityError, units
 
 __all__ = []
 readable_to_cf_axes = {'time': 'T', 'vertical': 'Z', 'y': 'Y', 'x': 'X'}
@@ -268,20 +268,17 @@ class CFConventionHandler(object):
                         cls.criteria[criterion].get(axis, set())):
                     return True
 
-            # Check for units, allowing for undefined unit failure (CF standard)
-            try:
-                if (axis in cls.criteria['units'] and (
-                        (
-                            cls.criteria['units'][axis]['match'] == 'dimensionality' and
-                            (units.get_dimensionality(var.attrs.get('units')) ==
-                             units.get_dimensionality(cls.criteria['units'][axis]['units']))
-                        ) or (
-                            cls.criteria['units'][axis]['match'] == 'name' and
-                            var.attrs.get('units') in cls.criteria['units'][axis]['units']
-                        ))):
-                    return True
-            except UndefinedUnitError:
-                pass
+            # Check for units, either by dimensionality or name
+            if (axis in cls.criteria['units'] and (
+                    (
+                        cls.criteria['units'][axis]['match'] == 'dimensionality' and
+                        (units.get_dimensionality(var.attrs.get('units')) ==
+                         units.get_dimensionality(cls.criteria['units'][axis]['units']))
+                    ) or (
+                        cls.criteria['units'][axis]['match'] == 'name' and
+                        var.attrs.get('units') in cls.criteria['units'][axis]['units']
+                    ))):
+                return True
 
             # Check if name matches regular expression (non-CF failsafe)
             if re.match(cls.criteria['regular_expression'][axis], var.name.lower()):

--- a/tutorials/xarray_tutorial.py
+++ b/tutorials/xarray_tutorial.py
@@ -22,7 +22,6 @@ import xarray as xr
 # Any import of metpy will activate the accessors
 import metpy.calc as mpcalc
 from metpy.testing import get_test_data
-from metpy.units import units
 
 #########################################################################
 # Getting Data
@@ -51,8 +50,9 @@ print(data)
 # Additionally, we take a few optional steps to clean up our dataset for later use:
 #
 # - Rename our data variables for easier reference.
-# - Modify the units on geopotential height to meters, which pint (the unit library in use by
-#   MetPy) can understand (compared to the current gpm units).
+# - Modify the units on geopotential height to meters, since the unit used here ('gpm') is
+#   currently not handled by MetPy's unit registry (see `GitHub Issue #907
+#   <https://github.com/Unidata/MetPy/issues/907>`_).
 
 # To parse the full dataset, we can call parse_cf without an argument
 data = data.metpy.parse_cf()
@@ -150,14 +150,11 @@ print(data_globe)
 # - Broadcasting must be taken care of outside of the calculation, as it would only recognize
 #   dimensions by order, not name
 #
-# Also, some of the units used in CF conventions (such as 'degrees_north') are not recognized
-# by pint, so we must implement a workaround.
-#
 # As an example, we calculate geostropic wind at 500 hPa below:
 
 lat, lon = xr.broadcast(y, x)
-f = mpcalc.coriolis_parameter(lat.values * units.degrees)
-dx, dy = mpcalc.lat_lon_grid_deltas(lon.values, lat.values, initstring=data_crs.proj4_init)
+f = mpcalc.coriolis_parameter(lat)
+dx, dy = mpcalc.lat_lon_grid_deltas(lon, lat, initstring=data_crs.proj4_init)
 heights = data['height'].loc[time[0]].loc[{vertical.name: 500.}]
 u_geo, v_geo = mpcalc.geostrophic_wind(heights, f, dx, dy)
 print(u_geo)
@@ -187,7 +184,7 @@ print(v_geo)
 
 heights = data['height'].loc[time[0]].loc[{vertical.name: 500.}]
 lat, lon = xr.broadcast(y, x)
-f = mpcalc.coriolis_parameter(lat.values * units.degrees)
+f = mpcalc.coriolis_parameter(lat)
 dx, dy = mpcalc.grid_deltas_from_dataarray(heights)
 u_geo, v_geo = mpcalc.geostrophic_wind(heights, f, dx, dy)
 print(u_geo)


### PR DESCRIPTION
As brought up (and discussed at length) in #907, units like 'gpm' and 'degrees_north' are not handled by pint, which can necessitate workarounds in order to do calculations with geopotential height, or relating to latitude/longitude (see the [xarray tutorial](https://unidata.github.io/MetPy/dev/tutorials/xarray_tutorial.html) for examples).

This PR currently takes the approach of adding a few new units to the unit registry (~~`geopotential_meter`~~, `degrees_north`, and `degrees_east`) with appropriate abbreviations/aliases to handle these cases.

Discussion in #907 was not quite settled on this approach (the other option seemed to be changing the units in `parse_cf()`), but I wanted to put this out there as a PR since I was able to get this approach implemented. This seems like the best approach for `degrees_*`, since that is CF-standard, but `gpm` is weird, so I don't know about that one... [EDIT: see comment below]

~~(Also, #899 has a couple lines that could be cleaned up by this.)~~