### PR TITLE
Fix non-tuple NumPy indexing in MetPy

### DIFF
--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -1457,6 +1457,7 @@ def isentropic_interpolation(theta_levels, pressure, temperature, *args, **kwarg
 
     slices = [np.newaxis] * ndim
     slices[axis] = slice(None)
+    slices = tuple(slices)
     pres = np.broadcast_to(pres[slices], temperature.shape) * pres.units
 
     # Sort input data

--- a/metpy/calc/turbulence.py
+++ b/metpy/calc/turbulence.py
@@ -42,12 +42,7 @@ def get_perturbation(ts, axis=-1):
     """
     slices = [slice(None)] * ts.ndim
     slices[axis] = None
-    # For numpy<=1.8.0, can't slice on a scalar
-    mean = ts.mean(axis=axis)
-    if ts.ndim == 1:
-        mean = np.atleast_1d(mean)
-    else:
-        mean = mean[slices]
+    mean = ts.mean(axis=axis)[tuple(slices)]
     return ts - mean
 
 

--- a/metpy/cbook.py
+++ b/metpy/cbook.py
@@ -87,8 +87,8 @@ def broadcast_indices(x, minv, ndim, axis):
             broadcast_slice = [np.newaxis] * ndim
             broadcast_slice[dim] = slice(None)
             dim_inds = np.arange(x.shape[dim])
-            ret.append(dim_inds[broadcast_slice])
-    return ret
+            ret.append(dim_inds[tuple(broadcast_slice)])
+    return tuple(ret)
 
 
 __all__ = ('Registry', 'broadcast_indices', 'get_test_data', 'is_string_like', 'iterable')

--- a/metpy/interpolate/one_dimension.py
+++ b/metpy/interpolate/one_dimension.py
@@ -122,7 +122,7 @@ def interpolate_1d(x, xp, *args, **kwargs):
     x_array = x[sort_x]
     expand = [np.newaxis] * ndim
     expand[axis] = slice(None)
-    x_array = x_array[expand]
+    x_array = x_array[tuple(expand)]
 
     # Calculate value above interpolated value
     minv = np.apply_along_axis(np.searchsorted, axis, xp, x[sort_x])


### PR DESCRIPTION
Since NumPy 1.15 came out, we have been getting pages and pages of warnings about our use of non-tuple based indexing. This PR converts all of our previous list-based indexing to tuple-based indexing. This doesn't yet clear out all the warnings (some of them are upstream in Pint and scipy), but it does drop the number down from 600-something to 10-something.

Closes #900.