### PR TITLE
Respell doc page names for clarity

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,8 +1,8 @@
 .. _api-index:
 
-#############
-The MetPy API
-#############
+###############
+Reference Guide
+###############
 
 .. currentmodule:: metpy
 

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -1,7 +1,7 @@
 .. _examples-index:
 
-MetPy Examples
-==============
+Examples
+========
 
 
 .. _general-examples:

--- a/tutorials/README.txt
+++ b/tutorials/README.txt
@@ -1,7 +1,7 @@
 .. _tutorials-index:
 
-MetPy Tutorials
-===============
+Tutorials
+=========
 
 This collection of tutorials (under development) demonstrates the use of MetPy to perform
 common meteorological tasks.


### PR DESCRIPTION
Closes #904 by clarifying the docs for readability/find-ability 