### PR TITLE
Fix logging setup

### DIFF
--- a/metpy/__init__.py
+++ b/metpy/__init__.py
@@ -5,6 +5,7 @@
 
 # What do we want to pull into the top-level namespace?
 
+import logging
 import warnings
 
 # Must occur before below imports
@@ -14,3 +15,10 @@ from ._version import get_versions  # noqa: E402
 from .xarray import *  # noqa: F401, F403
 __version__ = get_versions()['version']
 del get_versions
+
+try:
+    # Added in Python 3.2, will log anything warning or higher to stderr
+    logging.lastResort
+except AttributeError:
+    # Add our own for MetPy on Python 2.7
+    logging.getLogger(__name__).addHandler(logging.StreamHandler())

--- a/metpy/__init__.py
+++ b/metpy/__init__.py
@@ -5,7 +5,12 @@
 
 # What do we want to pull into the top-level namespace?
 
-from ._version import get_versions
+import warnings
+
+# Must occur before below imports
+warnings.filterwarnings('ignore', 'numpy.dtype size changed')
+
+from ._version import get_versions  # noqa: E402
 from .xarray import *  # noqa: F401, F403
 __version__ = get_versions()['version']
 del get_versions

--- a/metpy/interpolate/geometry.py
+++ b/metpy/interpolate/geometry.py
@@ -11,7 +11,6 @@ import math
 import numpy as np
 from scipy.spatial import cKDTree
 
-logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
 
 

--- a/metpy/interpolate/points.py
+++ b/metpy/interpolate/points.py
@@ -17,7 +17,6 @@ from ..package_tools import Exporter
 
 exporter = Exporter(globals())
 
-logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
 
 

--- a/metpy/io/_tools.py
+++ b/metpy/io/_tools.py
@@ -14,7 +14,6 @@ import zlib
 
 from ..units import UndefinedUnitError, units
 
-logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
 
 

--- a/metpy/io/gini.py
+++ b/metpy/io/gini.py
@@ -30,8 +30,6 @@ from ..deprecation import deprecated
 from ..package_tools import Exporter
 
 exporter = Exporter(globals())
-
-logging.basicConfig(level=logging.WARN)
 log = logging.getLogger(__name__)
 
 

--- a/metpy/io/nexrad.py
+++ b/metpy/io/nexrad.py
@@ -25,7 +25,6 @@ from ..package_tools import Exporter
 
 exporter = Exporter(globals())
 
-logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
 
 

--- a/metpy/io/tests/test_nexrad.py
+++ b/metpy/io/tests/test_nexrad.py
@@ -109,6 +109,7 @@ def test_bad_length(caplog):
 
     with caplog.at_level(logging.WARNING, 'metpy.io.nexrad'):
         Level3File(fobj)
+        assert len(caplog.records) == 1
         assert 'This product may not parse correctly' in caplog.records[0].message
 
 

--- a/metpy/plots/ctables.py
+++ b/metpy/plots/ctables.py
@@ -56,7 +56,6 @@ exporter = Exporter(globals())
 
 TABLE_EXT = '.tbl'
 
-logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Fixes #866. No longer use `basicConfig()` because what it does is install a root handler if none is already installed. This breaks applications that also try to use it to set a different level. It's completely unnecessary on Python 3, since by default there is a handler that logs anything WARNING or higher to    stderr, which is really what we want. This isn't the case on Python 2, so what we can do in that case is put a StreamHandler (which defaults to stderr) for all of metpy (all submodules will defer to it by default). WARNING is already the default logging level anyway.

This also fixes up a logging test and installs a warning filter for all of those "numpy dtype size has changed" messages that are spewing *everywhere*.
