### PR TITLE
Add gpm unit as an alias to meters

### DIFF
--- a/metpy/tests/test_units.py
+++ b/metpy/tests/test_units.py
@@ -189,3 +189,9 @@ def test_added_degrees_units():
     assert units('degrees_north').to_base_units().units == units.radian
     assert units('degrees_east') == units('degrees')
     assert units('degrees_east').to_base_units().units == units.radian
+
+
+def test_gpm_unit():
+    """Test that the gpm unit does alias to meters."""
+    x = 1 * units('gpm')
+    assert str(x.units) == 'meter'

--- a/metpy/units.py
+++ b/metpy/units.py
@@ -17,10 +17,13 @@ units : :class:`pint.UnitRegistry`
 from __future__ import division
 
 import functools
+import logging
 
 import numpy as np
 import pint
 import pint.unit
+
+log = logging.getLogger(__name__)
 
 UndefinedUnitError = pint.UndefinedUnitError
 DimensionalityError = pint.DimensionalityError
@@ -35,6 +38,13 @@ units.define(pint.unit.UnitDefinition('percent', '%', (),
 units.define('degrees_north = degree = degrees_N = degreesN = degree_north = degree_N '
              '= degreeN')
 units.define('degrees_east = degree = degrees_E = degreesE = degree_east = degree_E = degreeE')
+
+# Alias geopotential meters (gpm) to just meters
+try:
+    units._units['meter']._aliases = ('metre', 'gpm')
+    units._units['gpm'] = units._units['meter']
+except AttributeError:
+    log.warning('Failed to add gpm alias to meters.')
 
 
 def pandas_dataframe_to_unit_arrays(df, column_units=None):


### PR DESCRIPTION
Closes #907 by defining gpm as a meter alias so any units assigned gpm will quietly be changed to plain meters.