### PR TITLE
A Few Documentation Fixes

### DIFF
--- a/docs/gempak.rst
+++ b/docs/gempak.rst
@@ -357,35 +357,35 @@ blue is uncertain of parity, and white is unevaluated.
         <td></td>
       </tr>
       <tr>
-        <td>DDR(S)</td>
-        <td>Partial derivative with respect to R</td>
+        <td class="tg-implemented">DDR(S)</td>
+        <td class="tg-implemented">Partial derivative with respect to R</td>
+        <td class="tg-implemented"><a href="api/generated/generated/metpy.calc.first_derivative.html">metpy.calc.first_derivative</a></td>
         <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>DDT(S)</td>
-        <td>Time derivative</td>
-        <td></td>
-        <td></td>
-        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>
-        <td>DDX(S)</td>
-        <td>Partial derivative with respect to X</td>
+        <td class="tg-implemented">DDT(S)</td>
+        <td class="tg-implemented">Time derivative</td>
+        <td class="tg-implemented"><a href="api/generated/generated/metpy.calc.first_derivative.html">metpy.calc.first_derivative</a></td>
         <td></td>
-        <td></td>
-        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>
-        <td>DDY(S)</td>
-        <td>Partial derivative with respect to Y</td>
+        <td class="tg-implemented">DDX(S)</td>
+        <td class="tg-implemented">Partial derivative with respect to X</td>
+        <td class="tg-implemented"><a href="api/generated/generated/metpy.calc.first_derivative.html">metpy.calc.first_derivative</a></td>
         <td></td>
+        <td class="tg-no">No</td>
         <td></td>
+      </tr>
+      <tr>
+        <td class="tg-implemented">DDY(S)</td>
+        <td class="tg-implemented">Partial derivative with respect to Y</td>
+        <td class="tg-implemented"><a href="api/generated/generated/metpy.calc.first_derivative.html">metpy.calc.first_derivative</a></td>
         <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>
@@ -437,11 +437,11 @@ blue is uncertain of parity, and white is unevaluated.
         <td></td>
       </tr>
       <tr>
-        <td>DTH(S)</td>
-        <td>Partial derivative with respect to theta</td>
+        <td class="tg-implemented">DTH(S)</td>
+        <td class="tg-implemented">Partial derivative with respect to theta</td>
+        <td class="tg-implemented"><a href="api/generated/generated/metpy.calc.first_derivative.html">metpy.calc.first_derivative</a></td>
         <td></td>
-        <td></td>
-        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>
@@ -790,8 +790,8 @@ blue is uncertain of parity, and white is unevaluated.
         <td></td>
       </tr>
       <tr>
-        <td>TANG(V)</td>
-        <td>Tangential component (cross-sections)</td>
+        <td class="tg-implemented">TANG(V)</td>
+        <td class="tg-implemented">Tangential component (cross-sections)</td>
         <td class="tg-implemented"><a href="api/generated/metpy.calc.tangential_component.html#metpy.calc.tangential_component">metpy.calc.tangential_component</a></td>
         <td></td>
         <td class="tg-no">No</td>
@@ -814,11 +814,11 @@ blue is uncertain of parity, and white is unevaluated.
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">THES(PRES, TMPC)</td>
-        <td class="tg-notimplemented">Saturated equivalent potential temperature</td>
-        <td class="tg-notimplemented"><a href="https://github.com/Unidata/MetPy/issues/645">Issue #645</a></td>
+        <td class="tg-implemented">THES(PRES, TMPC)</td>
+        <td class="tg-implemented">Saturated equivalent potential temperature</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.saturation_equivalent_potential_temperature.html#metpy.calc.saturation_equivalent_potential_temperature">metpy.calc.saturation_equivalent_potential_temperature</a></td>
         <td></td>
-        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>
@@ -866,7 +866,7 @@ blue is uncertain of parity, and white is unevaluated.
         <td class="tg-implemented">Web bulb temperature in Kelvin</td>
         <td class="tg-implemented"><a href="api/generated/metpy.calc.wet_bulb_temperature.html">metpy.calc.wet_bulb_temperature</a></td>
         <td></td>
-        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>
@@ -3218,35 +3218,35 @@ blue is uncertain of parity, and white is unevaluated.
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">RELH</td>
-        <td class="tg-notimplemented">Relative humidity</td>
-        <td class="tg-notimplemented"><a href="https://github.com/Unidata/MetPy/issues/648">Issue #648</a></td>
+        <td class="tg-implemented">RELH</td>
+        <td class="tg-implemented">Relative humidity</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.relative_humidity_from_dewpoint.html#metpy.calc.relative_humidity_from_dewpoint">metpy.calc.relative_humidity_from_dewpoint</a></td>
         <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td class="tg-notimplemented">TMWK</td>
-        <td class="tg-notimplemented">Wet bulb temperature in Kelvin</td>
-        <td class="tg-notimplemented"><a href="https://github.com/Unidata/MetPy/issues/409">Issue #409</a></td>
-        <td></td>
-        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">TMWC</td>
-        <td class="tg-notimplemented">Wet bulb temperature in Celsius</td>
-        <td class="tg-notimplemented"<a href="https://github.com/Unidata/MetPy/issues/409">Issue #409</a></td>
+        <td class="tg-implemented">TMWK</td>
+        <td class="tg-implemented">Wet bulb temperature in Kelvin</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.wet_bulb_temperature.html#metpy.calc.wet_bulb_temperature">metpy.calc.wet_bulb_temperature(pressures, temperatures, dewpoints).to('K')</a></td>
         <td></td>
-        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">TMWF</td>
-        <td class="tg-notimplemented">Wet bulb temperature in Fahrenheit</td>
-        <td class="tg-notimplemented"><a href="https://github.com/Unidata/MetPy/issues/409">Issue #409</a></td>
+        <td class="tg-implemented">TMWC</td>
+        <td class="tg-implemented">Wet bulb temperature in Celsius</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.wet_bulb_temperature.html#metpy.calc.wet_bulb_temperature">metpy.calc.wet_bulb_temperature(pressures, temperatures, dewpoints).to('degC')</a></td>
         <td></td>
+        <td class="tg-no">No</td>
         <td></td>
+      </tr>
+      <tr>
+        <td class="tg-implemented">TMWF</td>
+        <td class="tg-implemented">Wet bulb temperature in Fahrenheit</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.wet_bulb_temperature.html#metpy.calc.wet_bulb_temperature">metpy.calc.wet_bulb_temperature(pressures, temperatures, dewpoints).to('degF')</a></td>
+        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>

--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -97,11 +97,11 @@ def vorticity(u, v, dx, dy):
     v : (M, N) ndarray
         y component of the wind
     dx : float or ndarray
-        The grid spacing(s) in the x-direction. If an array, there should be one
-        item less than the size of `u` along the applicable axis.
+        The grid spacing(s) in the x-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
     dy : float or ndarray
-        The grid spacing(s) in the y-direction. If an array, there should be one
-        item less than the size of `u` along the applicable axis.
+        The grid spacing(s) in the y-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
 
     Returns
     -------
@@ -111,6 +111,11 @@ def vorticity(u, v, dx, dy):
     See Also
     --------
     divergence
+
+    Notes
+    -----
+    If inputs have more than two dimensions, they are assumed to have either leading dimensions
+    of (x, y) or trailing dimensions of (y, x), depending on the value of ``dim_order``.
 
     """
     dudy = first_derivative(u, delta=dy, axis=-2)
@@ -130,10 +135,12 @@ def divergence(u, v, dx, dy):
         x component of the wind
     v : (M, N) ndarray
         y component of the wind
-    dx : float
-        The grid spacing in the x-direction
-    dy : float
-        The grid spacing in the y-direction
+    dx : float or ndarray
+        The grid spacing(s) in the x-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
+    dy : float or ndarray
+        The grid spacing(s) in the y-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
 
     Returns
     -------
@@ -143,6 +150,11 @@ def divergence(u, v, dx, dy):
     See Also
     --------
     vorticity
+
+    Notes
+    -----
+    If inputs have more than two dimensions, they are assumed to have either leading dimensions
+    of (x, y) or trailing dimensions of (y, x), depending on the value of ``dim_order``.
 
     """
     dudx = first_derivative(u, delta=dx, axis=-1)
@@ -162,10 +174,12 @@ def shearing_deformation(u, v, dx, dy):
         x component of the wind
     v : (M, N) ndarray
         y component of the wind
-    dx : float
-        The grid spacing in the x-direction
-    dy : float
-        The grid spacing in the y-direction
+    dx : float or ndarray
+        The grid spacing(s) in the x-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
+    dy : float or ndarray
+        The grid spacing(s) in the y-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
 
     Returns
     -------
@@ -175,6 +189,11 @@ def shearing_deformation(u, v, dx, dy):
     See Also
     --------
     stretching_deformation, total_deformation
+
+    Notes
+    -----
+    If inputs have more than two dimensions, they are assumed to have either leading dimensions
+    of (x, y) or trailing dimensions of (y, x), depending on the value of ``dim_order``.
 
     """
     dudy = first_derivative(u, delta=dy, axis=-2)
@@ -194,10 +213,12 @@ def stretching_deformation(u, v, dx, dy):
         x component of the wind
     v : (M, N) ndarray
         y component of the wind
-    dx : float
-        The grid spacing in the x-direction
-    dy : float
-        The grid spacing in the y-direction
+    dx : float or ndarray
+        The grid spacing(s) in the x-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
+    dy : float or ndarray
+        The grid spacing(s) in the y-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
 
     Returns
     -------
@@ -207,6 +228,11 @@ def stretching_deformation(u, v, dx, dy):
     See Also
     --------
     shearing_deformation, total_deformation
+
+    Notes
+    -----
+    If inputs have more than two dimensions, they are assumed to have either leading dimensions
+    of (x, y) or trailing dimensions of (y, x), depending on the value of ``dim_order``.
 
     """
     dudx = first_derivative(u, delta=dx, axis=-1)
@@ -226,10 +252,12 @@ def total_deformation(u, v, dx, dy):
         x component of the wind
     v : (M, N) ndarray
         y component of the wind
-    dx : float
-        The grid spacing in the x-direction
-    dy : float
-        The grid spacing in the y-direction
+    dx : float or ndarray
+        The grid spacing(s) in the x-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
+    dy : float or ndarray
+        The grid spacing(s) in the y-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
 
     Returns
     -------
@@ -239,6 +267,11 @@ def total_deformation(u, v, dx, dy):
     See Also
     --------
     shearing_deformation, stretching_deformation
+
+    Notes
+    -----
+    If inputs have more than two dimensions, they are assumed to have either leading dimensions
+    of (x, y) or trailing dimensions of (y, x), depending on the value of ``dim_order``.
 
     """
     dudy, dudx = gradient(u, deltas=(dy, dx), axes=(-2, -1))
@@ -266,8 +299,10 @@ def advection(scalar, wind, deltas):
         with a component of the wind in each dimension.  For example, for
         horizontal advection, this could be a list: [u, v], where u and v
         are each a 2-dimensional array.
-    deltas : sequence
-        A (length M) sequence containing the grid spacing in each dimension.
+    deltas : sequence of float or ndarray
+        A (length M) sequence containing the grid spacing(s) in each dimension. If using
+        arrays, in each array there should be one item less than the size of `scalar` along the
+        applicable axis.
 
     Returns
     -------
@@ -321,10 +356,12 @@ def frontogenesis(thta, u, v, dx, dy, dim_order='yx'):
         x component of the wind
     v : (M, N) ndarray
         y component of the wind
-    dx : float
-        The grid spacing in the x-direction
-    dy : float
-        The grid spacing in the y-direction
+    dx : float or ndarray
+        The grid spacing(s) in the x-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
+    dy : float or ndarray
+        The grid spacing(s) in the y-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
 
     Returns
     -------
@@ -333,7 +370,8 @@ def frontogenesis(thta, u, v, dx, dy, dim_order='yx'):
 
     Notes
     -----
-    Assumes dim_order='yx', unless otherwise specified.
+    If inputs have more than two dimensions, they are assumed to have either leading dimensions
+    of (x, y) or trailing dimensions of (y, x), depending on the value of ``dim_order``.
 
     Conversion factor to go from [temperature units]/m/s to [temperature units/100km/3h]
     :math:`1.08e4*1.e5`
@@ -375,15 +413,22 @@ def geostrophic_wind(heights, f, dx, dy):
     f : array_like
         The coriolis parameter.  This can be a scalar to be applied
         everywhere or an array of values.
-    dx : scalar
-        The grid spacing in the x-direction
-    dy : scalar
-        The grid spacing in the y-direction
+    dx : float or ndarray
+        The grid spacing(s) in the x-direction. If an array, there should be one item less than
+        the size of `heights` along the applicable axis.
+    dy : float or ndarray
+        The grid spacing(s) in the y-direction. If an array, there should be one item less than
+        the size of `heights` along the applicable axis.
 
     Returns
     -------
     A 2-item tuple of arrays
         A tuple of the u-component and v-component of the geostrophic wind.
+
+    Notes
+    -----
+    If inputs have more than two dimensions, they are assumed to have either leading dimensions
+    of (x, y) or trailing dimensions of (y, x), depending on the value of ``dim_order``.
 
     """
     if heights.dimensionality['[length]'] == 2.0:
@@ -405,26 +450,30 @@ def ageostrophic_wind(heights, f, dx, dy, u, v, dim_order='yx'):
     Parameters
     ----------
     heights : (M, N) ndarray
-        The height field, with either leading dimensions of (x, y) or trailing dimensions
-        of (y, x), depending on the value of ``dim_order``.
+        The height field.
     f : array_like
         The coriolis parameter.  This can be a scalar to be applied
         everywhere or an array of values.
-    dx : scalar
-        The grid spacing in the x-direction
-    dy : scalar
-        The grid spacing in the y-direction
+    dx : float or ndarray
+        The grid spacing(s) in the x-direction. If an array, there should be one item less than
+        the size of `heights` along the applicable axis.
+    dy : float or ndarray
+        The grid spacing(s) in the y-direction. If an array, there should be one item less than
+        the size of `heights` along the applicable axis.
     u : (M, N) ndarray
-        The u wind field, with either leading dimensions of (x, y) or trailing dimensions
-        of (y, x), depending on the value of ``dim_order``.
+        The u wind field.
     v : (M, N) ndarray
-        The u wind field, with either leading dimensions of (x, y) or trailing dimensions
-        of (y, x), depending on the value of ``dim_order``.
+        The u wind field.
 
     Returns
     -------
     A 2-item tuple of arrays
         A tuple of the u-component and v-component of the ageostrophic wind.
+
+    Notes
+    -----
+    If inputs have more than two dimensions, they are assumed to have either leading dimensions
+    of (x, y) or trailing dimensions of (y, x), depending on the value of ``dim_order``.
 
     """
     u_geostrophic, v_geostrophic = geostrophic_wind(heights, f, dx, dy, dim_order=dim_order)
@@ -542,10 +591,12 @@ def absolute_vorticity(u, v, dx, dy, lats, dim_order='yx'):
         x component of the wind
     v : (M, N) ndarray
         y component of the wind
-    dx : float
-        The grid spacing in the x-direction
-    dy : float
-        The grid spacing in the y-direction
+    dx : float or ndarray
+        The grid spacing(s) in the x-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
+    dy : float or ndarray
+        The grid spacing(s) in the y-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
     lats : (M, N) ndarray
         latitudes of the wind data
 
@@ -553,6 +604,11 @@ def absolute_vorticity(u, v, dx, dy, lats, dim_order='yx'):
     -------
     (M, N) ndarray
         absolute vorticity
+
+    Notes
+    -----
+    If inputs have more than two dimensions, they are assumed to have either leading dimensions
+    of (x, y) or trailing dimensions of (y, x), depending on the value of ``dim_order``.
 
     """
     f = coriolis_parameter(lats)
@@ -582,10 +638,12 @@ def potential_vorticity_baroclinic(potential_temperature, pressure, u, v, dx, dy
         x component of the wind
     v : (M, N) ndarray
         y component of the wind
-    dx : float
-        The grid spacing in the x-direction
-    dy : float
-        The grid spacing in the y-direction
+    dx : float or ndarray
+        The grid spacing(s) in the x-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
+    dy : float or ndarray
+        The grid spacing(s) in the y-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
     lats : (M, N) ndarray
         latitudes of the wind data
     axis : int, optional
@@ -638,10 +696,12 @@ def potential_vorticity_barotropic(heights, u, v, dx, dy, lats, dim_order='yx'):
         x component of the wind
     v : (M, N) ndarray
         y component of the wind
-    dx : float
-        The grid spacing in the x-direction
-    dy : float
-        The grid spacing in the y-direction
+    dx : float or ndarray
+        The grid spacing(s) in the x-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
+    dy : float or ndarray
+        The grid spacing(s) in the y-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
     lats : (M, N) ndarray
         latitudes of the wind data
 
@@ -649,6 +709,11 @@ def potential_vorticity_barotropic(heights, u, v, dx, dy, lats, dim_order='yx'):
     -------
     (M, N) ndarray
         barotropic potential vorticity
+
+    Notes
+    -----
+    If inputs have more than two dimensions, they are assumed to have either leading dimensions
+    of (x, y) or trailing dimensions of (y, x), depending on the value of ``dim_order``.
 
     """
     avor = absolute_vorticity(u, v, dx, dy, lats, dim_order=dim_order)
@@ -683,10 +748,12 @@ def inertial_advective_wind(u, v, u_geostrophic, v_geostrophic, dx, dy, lats):
         x component of the geostrophic (advected) wind
     v_geostrophic : (M, N) ndarray
         y component of the geostrophic (advected) wind
-    dx : float
-        The grid spacing in the x-direction
-    dy : float
-        The grid spacing in the y-direction
+    dx : float or ndarray
+        The grid spacing(s) in the x-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
+    dy : float or ndarray
+        The grid spacing(s) in the y-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
     lats : (M, N) ndarray
         latitudes of the wind data
 
@@ -702,6 +769,9 @@ def inertial_advective_wind(u, v, u_geostrophic, v_geostrophic, dx, dy, lats):
     Many forms of the inertial advective wind assume the advecting and advected
     wind to both be the geostrophic wind. To do so, pass the x and y components
     of the geostrophic with for u and u_geostrophic/v and v_geostrophic.
+
+    If inputs have more than two dimensions, they are assumed to have either leading dimensions
+    of (x, y) or trailing dimensions of (y, x), depending on the value of ``dim_order``.
 
     """
     f = coriolis_parameter(lats)
@@ -746,10 +816,12 @@ def q_vector(u, v, temperature, pressure, dx, dy, static_stability=1):
         Array of temperature at pressure level
     pressure : `pint.Quantity`
         Pressure at level
-    dx : float
-        The grid spacing in the x-direction
-    dy : float
-        The grid spacing in the y-direction
+    dx : float or ndarray
+        The grid spacing(s) in the x-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
+    dy : float or ndarray
+        The grid spacing(s) in the y-direction. If an array, there should be one item less than
+        the size of `u` along the applicable axis.
     static_stability : `pint.Quantity`, optional
         The static stability at the pressure level. Defaults to 1 if not given to calculate
         the Q-vector without factoring in static stability.
@@ -762,6 +834,11 @@ def q_vector(u, v, temperature, pressure, dx, dy, static_stability=1):
     See Also
     --------
     static_stability
+
+    Notes
+    -----
+    If inputs have more than two dimensions, they are assumed to have either leading dimensions
+    of (x, y) or trailing dimensions of (y, x), depending on the value of ``dim_order``.
 
     """
     dudy, dudx = gradient(u, deltas=(dy, dx), axes=(-2, -1))

--- a/metpy/interpolate/slices.py
+++ b/metpy/interpolate/slices.py
@@ -17,8 +17,8 @@ exporter = Exporter(globals())
 def interpolate_to_slice(data, points, interp_type='linear'):
     r"""Obtain an interpolated slice through data using xarray.
 
-    Utilizing the interpolation functionality in `metpy.interpolate`, this function takes a
-    slice the given data (currently only regular grids are supported), which is given as an
+    Utilizing the interpolation functionality in `xarray`, this function takes a slice the
+    given data (currently only regular grids are supported), which is given as an
     `xarray.DataArray` so that we can utilize its coordinate metadata.
 
     Parameters
@@ -100,10 +100,10 @@ def geodesic(crs, start, end, steps):
 def cross_section(data, start, end, steps=100, interp_type='linear'):
     r"""Obtain an interpolated cross-sectional slice through gridded data.
 
-    Utilizing the interpolation functionality in `metpy.interpolate`, this function takes a
-    vertical cross-sectional slice along a geodesic through the given data on a regular grid,
-    which is given as an `xarray.DataArray` so that we can utilize its coordinate and
-    projection metadata.
+    Utilizing the interpolation functionality in `xarray`, this function takes a vertical
+    cross-sectional slice along a geodesic through the given data on a regular grid, which is
+    given as an `xarray.DataArray` so that we can utilize its coordinate and projection
+    metadata.
 
     Parameters
     ----------

--- a/tutorials/xarray_tutorial.py
+++ b/tutorials/xarray_tutorial.py
@@ -45,20 +45,17 @@ print(data)
 #
 # To make use of the data within MetPy, we need to parse the dataset for projection and
 # coordinate information following the CF conventions. For this, we use the
-# ``data.metpy.parse_cf()`` method.
+# ``data.metpy.parse_cf()`` method, which will return a new, parsed ``DataArray`` or
+# ``Dataset``.
 #
-# Additionally, we take a few optional steps to clean up our dataset for later use:
-#
-# - Rename our data variables for easier reference.
-# - Modify the units on geopotential height to meters, since the unit used here ('gpm') is
-#   currently not handled by MetPy's unit registry (see `GitHub Issue #907
-#   <https://github.com/Unidata/MetPy/issues/907>`_).
+# Additionally, we rename our data variables for easier reference.
 
-# To parse the full dataset, we can call parse_cf without an argument
+# To parse the full dataset, we can call parse_cf without an argument, and assign the returned
+# Dataset.
 data = data.metpy.parse_cf()
 
 # If we instead want just a single variable, we can pass that variable name to parse_cf and
-# it will return just that data variable
+# it will return just that data variable as a DataArray.
 data_var = data.metpy.parse_cf('Temperature_isobaric')
 
 # To rename variables, supply a dictionary between old and new names to the rename method
@@ -70,9 +67,6 @@ data.rename({
     'v-component_of_wind_isobaric': 'v',
     'Geopotential_height_isobaric': 'height'
 }, inplace=True)
-
-# To change an attribute on a variable, do the following
-data['height'].attrs['units'] = 'm'
 
 #########################################################################
 # Units
@@ -175,11 +169,12 @@ print(v_geo)
 #     - ``tangential_component``
 #     - ``absolute_momentum``
 #
-# More details can be found by looking at the documentation for the specific function.
+# More details can be found by looking at the documentation for the specific function of
+# interest.
 
 #########################################################################
 # There is also the special case of the helper function, ``grid_deltas_from_dataarray``, which
-# takes a DataArray input, but returns unit arrays for use in other calculations. We could
+# takes a ``DataArray`` input, but returns unit arrays for use in other calculations. We could
 # rewrite the above geostrophic wind example using this helper function as follows:
 
 heights = data['height'].loc[time[0]].loc[{vertical.name: 500.}]
@@ -195,8 +190,9 @@ print(v_geo)
 # --------
 #
 # Like most meteorological data, we want to be able to plot these data. DataArrays can be used
-# like normal numpy arrays in plotting code, or we can use some of xarray's plotting
-# functionality.
+# like normal numpy arrays in plotting code, which is the recommended process at the current
+# point in time, or we can use some of xarray's plotting functionality for quick inspection of
+# the data.
 #
 # (More detail beyond the following can be found at `xarray's plotting reference
 # <http://xarray.pydata.org/en/stable/plotting.html>`_.)


### PR DESCRIPTION
This PR contains a few documentation fixes:

- Fix the description of the `cross_section` and `interpolate_to_slice` functions to reference xarray's interpolation, not metpy's
- Clear up some usage details with Dataset.metpy.parse_cf() (see #909)
- Update `dx`/`dy` parameter descriptions (as in #901) for all applicable functions in kinematics
- Add notes to kinematics functions about handling of >2 dimensions (similar what `ageostrophic_wind` had in parameter descriptions)
- Update the GEMPAK table for closed issues
  - ~~This includes #645, which isn't closed yet, even though it is implemented.~~