### PR TITLE
Update for requirements

### DIFF
--- a/examples/cross_section.py
+++ b/examples/cross_section.py
@@ -89,8 +89,8 @@ rh_colorbar = fig.colorbar(rh_contour)
 # Plot potential temperature using contour, with some custom labeling
 theta_contour = ax.contour(cross['lon'], cross['isobaric'], cross['Potential_temperature'],
                            levels=np.arange(250, 450, 5), colors='k', linewidths=2)
-plt.clabel(theta_contour, theta_contour.levels[1::2], fontsize=8, colors='k', inline=1,
-           inline_spacing=8, fmt='%i', rightside_up=True, use_clabeltext=True, alpha=0.6)
+theta_contour.clabel(theta_contour.levels[1::2], fontsize=8, colors='k', inline=1,
+                     inline_spacing=8, fmt='%i', rightside_up=True, use_clabeltext=True)
 
 # Plot winds using the axes interface directly, with some custom indexing to make the barbs
 # less crowded
@@ -104,7 +104,7 @@ ax.barbs(cross['lon'][wind_slc_horz], cross['isobaric'][wind_slc_vert],
 ax.set_yscale('symlog')
 ax.set_yticklabels(np.arange(1000, 50, -100))
 ax.set_ylim(cross['isobaric'].max(), cross['isobaric'].min())
-plt.yticks(np.arange(1000, 50, -100))
+ax.set_yticks(np.arange(1000, 50, -100))
 
 # Define the CRS and inset axes
 data_crs = data['Geopotential_height'].metpy.cartopy_crs

--- a/examples/gridding/Natural_Neighbor_Verification.py
+++ b/examples/gridding/Natural_Neighbor_Verification.py
@@ -76,6 +76,7 @@ zp = (pts[:, 0] * pts[:, 0]) / 1000
 tri = Delaunay(pts)
 
 fig, ax = plt.subplots(1, 1, figsize=(15, 10))
+ax.ishold = lambda: True  # Work-around for Matplotlib 3.0.0 incompatibility
 delaunay_plot_2d(tri, ax=ax)
 
 for i, zval in enumerate(zp):
@@ -114,6 +115,7 @@ def draw_circle(ax, x, y, r, m, label):
 members, tri_info = geometry.find_natural_neighbors(tri, list(zip(sim_gridx, sim_gridy)))
 
 fig, ax = plt.subplots(1, 1, figsize=(15, 10))
+ax.ishold = lambda: True  # Work-around for Matplotlib 3.0.0 incompatibility
 delaunay_plot_2d(tri, ax=ax)
 ax.plot(sim_gridx, sim_gridy, 'ks', markersize=10)
 
@@ -166,6 +168,7 @@ print('radii\n', r)
 vor = Voronoi(list(zip(xp, yp)))
 
 fig, ax = plt.subplots(1, 1, figsize=(15, 10))
+ax.ishold = lambda: True  # Work-around for Matplotlib 3.0.0 incompatibility
 voronoi_plot_2d(vor, ax=ax)
 
 nn_ind = np.array([0, 5, 7, 8])

--- a/examples/gridding/Point_Interpolation.py
+++ b/examples/gridding/Point_Interpolation.py
@@ -26,6 +26,7 @@ def basic_map(proj):
     fig = plt.figure(figsize=(15, 10))
     add_metpy_logo(fig, 0, 80, size='large')
     view = fig.add_axes([0, 0, 1, 1], projection=proj)
+    view._hold = True  # Work-around for CartoPy 0.16/Matplotlib 3.0.0 incompatibility
     view.set_extent([-120, -70, 20, 50])
     view.add_feature(cfeature.STATES.with_scale('50m'))
     view.add_feature(cfeature.OCEAN)

--- a/examples/gridding/Wind_SLP_Interpolation.py
+++ b/examples/gridding/Wind_SLP_Interpolation.py
@@ -89,6 +89,7 @@ norm = BoundaryNorm(levels, ncolors=cmap.N, clip=True)
 fig = plt.figure(figsize=(20, 10))
 add_metpy_logo(fig, 360, 120, size='large')
 view = fig.add_subplot(1, 1, 1, projection=to_proj)
+view._hold = True  # Work-around for CartoPy 0.16/Matplotlib 3.0.0 incompatibility
 
 view.set_extent([-120, -70, 20, 50])
 view.add_feature(cfeature.STATES.with_scale('50m'))

--- a/metpy/plots/tests/test_skewt.py
+++ b/metpy/plots/tests/test_skewt.py
@@ -20,21 +20,25 @@ MPL_VERSION = matplotlib.__version__[:3]
 @pytest.mark.mpl_image_compare(tolerance=0.021, remove_text=True)
 def test_skewt_api():
     """Test the SkewT API."""
-    fig = plt.figure(figsize=(9, 9))
-    skew = SkewT(fig)
+    with matplotlib.rc_context({'axes.autolimit_mode': 'data'}):
+        fig = plt.figure(figsize=(9, 9))
+        skew = SkewT(fig)
 
-    # Plot the data using normal plotting functions, in this case using
-    # log scaling in Y, as dictated by the typical meteorological plot
-    p = np.linspace(1000, 100, 10)
-    t = np.linspace(20, -20, 10)
-    u = np.linspace(-10, 10, 10)
-    skew.plot(p, t, 'r')
-    skew.plot_barbs(p, u, u)
+        # Plot the data using normal plotting functions, in this case using
+        # log scaling in Y, as dictated by the typical meteorological plot
+        p = np.linspace(1000, 100, 10)
+        t = np.linspace(20, -20, 10)
+        u = np.linspace(-10, 10, 10)
+        skew.plot(p, t, 'r')
+        skew.plot_barbs(p, u, u)
 
-    # Add the relevant special lines
-    skew.plot_dry_adiabats()
-    skew.plot_moist_adiabats()
-    skew.plot_mixing_lines()
+        skew.ax.set_xlim(-20, 30)
+        skew.ax.set_ylim(1000, 100)
+
+        # Add the relevant special lines
+        skew.plot_dry_adiabats()
+        skew.plot_moist_adiabats()
+        skew.plot_mixing_lines()
 
     return fig
 
@@ -73,13 +77,16 @@ def test_profile():
 def test_skewt_shade_cape_cin(test_profile):
     """Test shading CAPE and CIN on a SkewT plot."""
     p, t, tp = test_profile
-    fig = plt.figure(figsize=(9, 9))
-    skew = SkewT(fig)
-    skew.plot(p, t, 'r')
-    skew.plot(p, tp, 'k')
-    skew.shade_cape(p, t, tp)
-    skew.shade_cin(p, t, tp)
-    skew.ax.set_xlim(-50, 50)
+
+    with matplotlib.rc_context({'axes.autolimit_mode': 'data'}):
+        fig = plt.figure(figsize=(9, 9))
+        skew = SkewT(fig)
+        skew.plot(p, t, 'r')
+        skew.plot(p, tp, 'k')
+        skew.shade_cape(p, t, tp)
+        skew.shade_cin(p, t, tp)
+        skew.ax.set_xlim(-50, 50)
+
     return fig
 
 
@@ -87,12 +94,15 @@ def test_skewt_shade_cape_cin(test_profile):
 def test_skewt_shade_area(test_profile):
     """Test shading areas on a SkewT plot."""
     p, t, tp = test_profile
-    fig = plt.figure(figsize=(9, 9))
-    skew = SkewT(fig)
-    skew.plot(p, t, 'r')
-    skew.plot(p, tp, 'k')
-    skew.shade_area(p, t, tp)
-    skew.ax.set_xlim(-50, 50)
+
+    with matplotlib.rc_context({'axes.autolimit_mode': 'data'}):
+        fig = plt.figure(figsize=(9, 9))
+        skew = SkewT(fig)
+        skew.plot(p, t, 'r')
+        skew.plot(p, tp, 'k')
+        skew.shade_area(p, t, tp)
+        skew.ax.set_xlim(-50, 50)
+
     return fig
 
 
@@ -111,12 +121,14 @@ def test_skewt_shade_area_invalid(test_profile):
 def test_skewt_shade_area_kwargs(test_profile):
     """Test shading areas on a SkewT plot with kwargs."""
     p, t, tp = test_profile
-    fig = plt.figure(figsize=(9, 9))
-    skew = SkewT(fig)
-    skew.plot(p, t, 'r')
-    skew.plot(p, tp, 'k')
-    skew.shade_area(p, t, tp, facecolor='m')
-    skew.ax.set_xlim(-50, 50)
+
+    with matplotlib.rc_context({'axes.autolimit_mode': 'data'}):
+        fig = plt.figure(figsize=(9, 9))
+        skew = SkewT(fig)
+        skew.plot(p, t, 'r')
+        skew.plot(p, tp, 'k')
+        skew.shade_area(p, t, tp, facecolor='m')
+        skew.ax.set_xlim(-50, 50)
     return fig
 
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     install_requires=['matplotlib>=1.4', 'numpy>=1.11.0', 'scipy>=0.14',
                       'pint>=0.8', 'xarray>=0.10.7', 'enum34;python_version<"3.4"',
-                      'pooch==0.1'],
+                      'pooch==0.1.*'],
     extras_require={
         'cdm': ['pyproj>=1.9.4'],
         'dev': ['ipython[all]>=3.1'],

--- a/tutorials/xarray_tutorial.py
+++ b/tutorials/xarray_tutorial.py
@@ -205,6 +205,7 @@ plt.show()
 
 # Let's add a projection and coastlines to it
 ax = plt.axes(projection=ccrs.LambertConformal())
+ax._hold = True  # Work-around for CartoPy 0.16/Matplotlib 3.0.0 incompatibility
 data['height'].loc[time[0]].loc[{vertical.name: 500.}].plot(ax=ax, transform=data_crs)
 ax.coastlines()
 plt.show()
@@ -232,13 +233,12 @@ ax.barbs(x[wind_slice], y[wind_slice],
 
 # Plot heights and temperature as contours
 h_contour = ax.contour(x, y, data_level['height'], colors='k', levels=range(5400, 6000, 60))
-h_contour_label = plt.clabel(h_contour, fontsize=8, colors='k', inline=1, inline_spacing=8,
-                             fmt='%i', rightside_up=True, use_clabeltext=True)
+h_contour.clabel(fontsize=8, colors='k', inline=1, inline_spacing=8,
+                 fmt='%i', rightside_up=True, use_clabeltext=True)
 t_contour = ax.contour(x, y, data_level['temperature'], colors='xkcd:deep blue',
                        levels=range(248, 276, 2), alpha=0.8, linestyles='--')
-t_contour_label = plt.clabel(t_contour, fontsize=8, colors='xkcd:deep blue', inline=1,
-                             inline_spacing=8, fmt='%i', rightside_up=True,
-                             use_clabeltext=True, alpha=0.8)
+t_contour.clabel(fontsize=8, colors='xkcd:deep blue', inline=1, inline_spacing=8,
+                 fmt='%i', rightside_up=True, use_clabeltext=True)
 
 # Add geographic features
 ax.add_feature(cfeature.LAND.with_scale('50m'), facecolor=cfeature.COLORS['land'])


### PR DESCRIPTION
- Update pinning for pooch 0.1.* I think we can trust bug fix releases. 😁 Also, apparently our `environment.yml` was already doing this (by accident IMO), but now `setup.py` will allow too.
- Tweak tests to pass on matplotlib 3.0. Small bug in a certain path of `MultipleLocator` (matplotlib/matplotlib#12313) broke the tests--but this path is only triggered with non-default matplotlib style (which happens to be used by pytest-mpl). Just adjusting our tests is good enough to avoid the bug.

I *expect* our tests to pass with this PR.