### PR TITLE
Marginally increase testing coverage

### DIFF
--- a/metpy/deprecation.py
+++ b/metpy/deprecation.py
@@ -263,33 +263,17 @@ def deprecated(since, message='', name='', alternative='', pending=False,
             func = obj.__init__
 
             def finalize(wrapper, new_doc):
-                try:
-                    pass
-                    # obj.__doc = new_doc
-                except (AttributeError, TypeError):
-                    # cls.__doc__ is not writeable on Py2.
-                    # TypeError occurs on PyPy
-                    pass
                 obj.__init__ = wrapper
                 return obj
         else:
             obj_type = 'function'
-            if isinstance(obj, classmethod):
-                func = obj.__func__
-                old_doc = func.__doc__
+            func = obj
+            old_doc = func.__doc__
 
-                def finalize(wrapper, new_doc):
-                    wrapper = functools.wraps(func)(wrapper)
-                    # wrapper.__doc__ = new_doc
-                    return classmethod(wrapper)
-            else:
-                func = obj
-                old_doc = func.__doc__
-
-                def finalize(wrapper, new_doc):
-                    wrapper = functools.wraps(func)(wrapper)
-                    # wrapper.__doc__ = new_doc
-                    return wrapper
+            def finalize(wrapper, new_doc):
+                wrapper = functools.wraps(func)(wrapper)
+                # wrapper.__doc__ = new_doc
+                return wrapper
 
         message = _generate_deprecation_message(since, message, name,
                                                 alternative, pending,

--- a/metpy/interpolate/tests/test_points.py
+++ b/metpy/interpolate/tests/test_points.py
@@ -120,7 +120,7 @@ def test_natural_neighbor_to_points(test_data, test_points):
     assert_array_almost_equal(truth, img)
 
 
-interp_methods = ['cressman', 'barnes']
+interp_methods = ['cressman', 'barnes', 'shouldraise']
 
 
 @pytest.mark.parametrize('method', interp_methods)
@@ -138,6 +138,12 @@ def test_inverse_distance_to_points(method, test_data, test_points):
         extra_kw['r'] = 40
         extra_kw['kappa'] = 100
         test_file = 'barnes_r40_k100.npz'
+    elif method == 'shouldraise':
+        extra_kw['r'] = 40
+        with pytest.raises(ValueError):
+            inverse_distance_to_points(
+                obs_points, z, test_points, kind=method, **extra_kw)
+        return
 
     img = inverse_distance_to_points(obs_points, z, test_points, kind=method, **extra_kw)
 
@@ -148,7 +154,7 @@ def test_inverse_distance_to_points(method, test_data, test_points):
 
 
 interp_methods = ['natural_neighbor', 'cressman', 'barnes',
-                  'linear', 'nearest', 'cubic', 'rbf']
+                  'linear', 'nearest', 'cubic', 'rbf', 'shouldraise']
 
 
 @pytest.mark.parametrize('method', interp_methods)
@@ -156,6 +162,9 @@ def test_interpolate_to_points(method, test_data):
     r"""Test main grid interpolation function."""
     xp, yp, z = test_data
     obs_points = np.vstack([xp, yp]).transpose() * 10
+
+    with get_test_data('interpolation_test_points.npz') as fobj:
+        test_points = np.load(fobj)['points']
 
     extra_kw = {}
     if method == 'cressman':
@@ -165,9 +174,11 @@ def test_interpolate_to_points(method, test_data):
         extra_kw['search_radius'] = 400
         extra_kw['minimum_neighbors'] = 1
         extra_kw['gamma'] = 1
-
-    with get_test_data('interpolation_test_points.npz') as fobj:
-        test_points = np.load(fobj)['points']
+    elif method == 'shouldraise':
+        with pytest.raises(ValueError):
+            interpolate_to_points(
+                obs_points, z, test_points, interp_type=method, **extra_kw)
+        return
 
     img = interpolate_to_points(obs_points, z, test_points, interp_type=method, **extra_kw)
 

--- a/metpy/tests/test_deprecation.py
+++ b/metpy/tests/test_deprecation.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2018 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Test functionality of MetPy's deprecation code."""
+
+import pytest
+
+from metpy import deprecation
+
+
+class FakeyMcFakeface(object):
+    """Our faked object for testing."""
+
+    @classmethod
+    def dontuse(cls):
+        """Don't use."""
+        deprecation.warn_deprecated('0.0.1', pending=True)
+        return False
+
+    @classmethod
+    @deprecation.deprecated('0.0.1')
+    def really_dontuse(cls):
+        """Really, don't use."""
+        return False
+
+
+def test_deprecation():
+    """Test our various warnings."""
+    with pytest.warns(deprecation.MetpyDeprecationWarning):
+        FakeyMcFakeface.dontuse()
+        assert FakeyMcFakeface.dontuse.__doc__ == "Don't use."
+    with pytest.warns(deprecation.MetpyDeprecationWarning):
+        FakeyMcFakeface.really_dontuse()

--- a/metpy/tests/test_units.py
+++ b/metpy/tests/test_units.py
@@ -58,11 +58,18 @@ def test_axvline():
 def test_atleast1d_without_units():
     """Test that atleast_1d wrapper can handle plain arrays."""
     assert_array_equal(atleast_1d(1), np.array([1]))
+    assert_array_equal(atleast_1d([1, ], [2, ]), np.array([[1, ], [2, ]]))
 
 
 def test_atleast2d_without_units():
     """Test that atleast_2d wrapper can handle plain arrays."""
     assert_array_equal(atleast_2d(1), np.array([[1]]))
+
+
+def test_atleast2d_with_units():
+    """Test that atleast_2d wrapper can handle plain array with units."""
+    assert_array_equal(
+        atleast_2d(1 * units.degC), np.array([[1]]) * units.degC)
 
 
 def test_units_diff():


### PR DESCRIPTION
Feel free to take this or send it to the bitbin in the sky...

Perhaps the most questionable change here is my code removal in `metpy/deprecation.py`.  For the life of me, I could not come up with a test case that deprecated a `@classmethod` and was able to trigger that logic block in the code.  The upstream code in `matplotlib` does not have this code block either.  I did add an additional explicit `test_deprecation.py` that covered some more lines.

No worries if all this gets rejected.