### PR TITLE
Test cleanup

### DIFF
--- a/examples/isentropic_example.py
+++ b/examples/isentropic_example.py
@@ -186,9 +186,8 @@ ax.barbs(lon.values, lat.values, isentu[level, :, :].m, isentv[level, :, :].m, l
          regrid_shape=20, transform=ccrs.PlateCarree())
 
 # Make some titles
-ax.set_title('{:.0f} K Montgomery Streamfunction '.format(isentlevs[level].m) +
-             r'($10^{-2} m^2 s^{-2}$), ' +
-             'Wind (kt), Relative Humidity (percent)', loc='left')
+ax.set_title('{:.0f} K Montgomery Streamfunction '.format(isentlevs[level].m)
+             + r'($10^{-2} m^2 s^{-2}$), Wind (kt), Relative Humidity (percent)', loc='left')
 add_timestamp(ax, times[0].dt, y=0.02, pretext='Valid: ', high_contrast=True)
 
 fig.tight_layout()

--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -139,9 +139,9 @@ def get_wind_speed(u, v):
     return wind_speed(u, v)
 
 
-get_wind_speed.__doc__ = (wind_speed.__doc__ +
-                          '\n    .. deprecated:: 0.9.0\n        Function has been renamed to '
-                          '`wind_speed` and will be removed from MetPy in 0.12.0.')
+get_wind_speed.__doc__ = (wind_speed.__doc__
+                          + '\n    .. deprecated:: 0.9.0\n        Function has been renamed to'
+                            ' `wind_speed` and will be removed from MetPy in 0.12.0.')
 
 
 @exporter.export
@@ -153,9 +153,9 @@ def get_wind_dir(u, v):
     return wind_direction(u, v)
 
 
-get_wind_dir.__doc__ = (wind_direction.__doc__ +
-                        '\n    .. deprecated:: 0.9.0\n        Function has been renamed to '
-                        '`wind_direction` and will be removed from MetPy in 0.12.0.')
+get_wind_dir.__doc__ = (wind_direction.__doc__
+                        + '\n    .. deprecated:: 0.9.0\n        Function has been renamed to '
+                          '`wind_direction` and will be removed from MetPy in 0.12.0.')
 
 
 @exporter.export
@@ -167,10 +167,10 @@ def get_wind_components(u, v):
     return wind_components(u, v)
 
 
-get_wind_components.__doc__ = (wind_components.__doc__ +
-                               '\n    .. deprecated:: 0.9.0\n        Function has been '
-                               'renamed to `wind_components` and will be removed from MetPy '
-                               'in 0.12.0.')
+get_wind_components.__doc__ = (wind_components.__doc__
+                               + '\n    .. deprecated:: 0.9.0\n        Function has been '
+                                 'renamed to `wind_components` and will be removed from MetPy '
+                                 'in 0.12.0.')
 
 
 @exporter.export
@@ -223,8 +223,8 @@ def windchill(temperature, speed, face_level_winds=False, mask_undefined=True):
 
     temp_limit, speed_limit = 10. * units.degC, 3 * units.mph
     speed_factor = speed.to('km/hr').magnitude ** 0.16
-    wcti = units.Quantity((0.6215 + 0.3965 * speed_factor) * temperature.to('degC').magnitude -
-                          11.37 * speed_factor + 13.12, units.degC).to(temperature.units)
+    wcti = units.Quantity((0.6215 + 0.3965 * speed_factor) * temperature.to('degC').magnitude
+                          - 11.37 * speed_factor + 13.12, units.degC).to(temperature.units)
 
     # See if we need to mask any undefined values
     if mask_undefined:
@@ -275,11 +275,15 @@ def heat_index(temperature, rh, mask_undefined=True):
     delta2 = delta * delta
 
     # Calculate the Heat Index -- constants converted for RH in [0, 1]
-    hi = (-42.379 * units.degF + 2.04901523 * delta +
-          1014.333127 * units.delta_degF * rh - 22.475541 * delta * rh -
-          6.83783e-3 / units.delta_degF * delta2 - 5.481717e2 * units.delta_degF * rh2 +
-          1.22874e-1 / units.delta_degF * delta2 * rh + 8.5282 * delta * rh2 -
-          1.99e-2 / units.delta_degF * delta2 * rh2)
+    hi = (-42.379 * units.degF
+          + 2.04901523 * delta
+          + 1014.333127 * units.delta_degF * rh
+          - 22.475541 * delta * rh
+          - 6.83783e-3 / units.delta_degF * delta2
+          - 5.481717e2 * units.delta_degF * rh2
+          + 1.22874e-1 / units.delta_degF * delta2 * rh
+          + 8.5282 * delta * rh2
+          - 1.99e-2 / units.delta_degF * delta2 * rh2)
 
     # See if we need to mask any undefined values
     if mask_undefined:

--- a/metpy/calc/cross_sections.py
+++ b/metpy/calc/cross_sections.py
@@ -33,8 +33,8 @@ def distances_from_cross_section(cross):
         A tuple of the x and y distances as DataArrays
 
     """
-    if (CFConventionHandler.check_axis(cross.metpy.x, 'lon') and
-            CFConventionHandler.check_axis(cross.metpy.y, 'lat')):
+    if (CFConventionHandler.check_axis(cross.metpy.x, 'lon')
+            and CFConventionHandler.check_axis(cross.metpy.y, 'lat')):
         # Use pyproj to obtain x and y distances
         from pyproj import Geod
 
@@ -53,8 +53,8 @@ def distances_from_cross_section(cross):
         x = xr.DataArray(x, coords=lon.coords, dims=lon.dims, attrs={'units': 'meters'})
         y = xr.DataArray(y, coords=lat.coords, dims=lat.dims, attrs={'units': 'meters'})
 
-    elif (CFConventionHandler.check_axis(cross.metpy.x, 'x') and
-            CFConventionHandler.check_axis(cross.metpy.y, 'y')):
+    elif (CFConventionHandler.check_axis(cross.metpy.x, 'x')
+            and CFConventionHandler.check_axis(cross.metpy.y, 'y')):
 
         # Simply return what we have
         x = cross.metpy.x

--- a/metpy/calc/indices.py
+++ b/metpy/calc/indices.py
@@ -59,8 +59,8 @@ def precipitable_water(dewpt, pressure, bottom=None, top=None):
     w = mixing_ratio(saturation_vapor_pressure(dewpt_layer), pres_layer)
 
     # Since pressure is in decreasing order, pw will be the opposite sign of that expected.
-    pw = -1. * (np.trapz(w.magnitude, pres_layer.magnitude) * (w.units * pres_layer.units) /
-                (mpconsts.g * mpconsts.rho_l))
+    pw = -1. * (np.trapz(w.magnitude, pres_layer.magnitude) * (w.units * pres_layer.units)
+                / (mpconsts.g * mpconsts.rho_l))
     return pw.to('millimeters')
 
 
@@ -155,8 +155,7 @@ def bunkers_storm_motion(pressure, u, v, heights):
     # mean wind from 5.5-6km
     wind_5500m = concatenate(mean_pressure_weighted(pressure, u, v, heights=heights,
                                                     depth=500 * units('meter'),
-                                                    bottom=heights[0] +
-                                                    5500 * units('meter')))
+                                                    bottom=heights[0] + 5500 * units('meter')))
 
     # Calculate the shear vector from sfc-500m to 5.5-6km
     shear = wind_5500m - wind_500m
@@ -255,9 +254,9 @@ def supercell_composite(mucape, effective_storm_helicity, effective_shear):
     effective_shear[effective_shear < 10 * units('m/s')] = 0 * units('m/s')
     effective_shear = effective_shear / (20 * units('m/s'))
 
-    return ((mucape / (1000 * units('J/kg'))) *
-            (effective_storm_helicity / (50 * units('m^2/s^2'))) *
-            effective_shear).to('dimensionless')
+    return ((mucape / (1000 * units('J/kg')))
+            * (effective_storm_helicity / (50 * units('m^2/s^2')))
+            * effective_shear).to('dimensionless')
 
 
 @exporter.export
@@ -300,18 +299,18 @@ def significant_tornado(sbcape, surface_based_lcl_height, storm_helicity_1km, sh
 
     """
     surface_based_lcl_height = np.clip(atleast_1d(surface_based_lcl_height),
-                                       1000 * units('meter'), 2000 * units('meter'))
-    surface_based_lcl_height[surface_based_lcl_height >
-                             2000 * units('meter')] = 0 * units('meter')
-    surface_based_lcl_height = ((2000. * units('meter') - surface_based_lcl_height) /
-                                (1000. * units('meter')))
+                                       1000 * units.m, 2000 * units.m)
+    surface_based_lcl_height[surface_based_lcl_height > 2000 * units.m] = 0 * units.m
+    surface_based_lcl_height = ((2000. * units.m - surface_based_lcl_height)
+                                / (1000. * units.m))
     shear_6km = np.clip(atleast_1d(shear_6km), None, 30 * units('m/s'))
     shear_6km[shear_6km < 12.5 * units('m/s')] = 0 * units('m/s')
     shear_6km /= 20 * units('m/s')
 
-    return ((sbcape / (1500. * units('J/kg'))) *
-            surface_based_lcl_height *
-            (storm_helicity_1km / (150. * units('m^2/s^2'))) * shear_6km)
+    return ((sbcape / (1500. * units('J/kg')))
+            * surface_based_lcl_height
+            * (storm_helicity_1km / (150. * units('m^2/s^2')))
+            * shear_6km)
 
 
 @exporter.export

--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -568,8 +568,8 @@ def storm_relative_helicity(u, v, heights, depth, bottom=0 * units.m,
     storm_relative_u = u - storm_u
     storm_relative_v = v - storm_v
 
-    int_layers = (storm_relative_u[1:] * storm_relative_v[:-1] -
-                  storm_relative_u[:-1] * storm_relative_v[1:])
+    int_layers = (storm_relative_u[1:] * storm_relative_v[:-1]
+                  - storm_relative_u[:-1] * storm_relative_v[1:])
 
     # Need to manually check for masked value because sum() on masked array with non-default
     # mask will return a masked value rather than 0. See numpy/numpy#11736
@@ -680,8 +680,8 @@ def potential_vorticity_baroclinic(potential_temperature, pressure, u, v, dx, dy
     # Get the middle layer stability derivative (index 1)
     slices = [slice(None)] * stability.ndim
     slices[axis] = 1
-    return (-1 * avor * mpconsts.g * stability[slices]).to(units.kelvin * units.meter**2 /
-                                                           (units.second * units.kilogram))
+    return (-1 * avor * mpconsts.g * stability[slices]).to(units.kelvin * units.meter**2
+                                                           / (units.second * units.kilogram))
 
 
 @exporter.export

--- a/metpy/calc/tests/test_calc_tools.py
+++ b/metpy/calc/tests/test_calc_tools.py
@@ -510,8 +510,8 @@ def test_lat_lon_grid_deltas_extra_dimensions():
                            [187797.3216, 187797.3216, 187797.3216]]]]) * units.meter
     dy_truth = (np.array([[[[277987.1857, 277987.1857, 277987.1857, 277987.1857],
                             [277987.1857, 277987.1857, 277987.1857, 277987.1857],
-                            [277987.1857, 277987.1857, 277987.1857, 277987.1857]]]]) *
-                units.meter)
+                            [277987.1857, 277987.1857, 277987.1857, 277987.1857]]]])
+                * units.meter)
     dx, dy = lat_lon_grid_deltas(lon, lat)
     assert_almost_equal(dx, dx_truth, 4)
     assert_almost_equal(dy, dy_truth, 4)

--- a/metpy/calc/tests/test_indices.py
+++ b/metpy/calc/tests/test_indices.py
@@ -4,18 +4,14 @@
 """Test the `indices` module."""
 
 from datetime import datetime
-import warnings
 
 import numpy as np
 
 from metpy.calc import (bulk_shear, bunkers_storm_motion, critical_angle,
                         mean_pressure_weighted, precipitable_water,
                         significant_tornado, supercell_composite)
-from metpy.deprecation import MetpyDeprecationWarning
 from metpy.testing import assert_almost_equal, assert_array_equal, get_upper_air_data
 from metpy.units import concatenate, units
-
-warnings.simplefilter('ignore', MetpyDeprecationWarning)
 
 
 def test_precipitable_water():

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -522,8 +522,8 @@ def test_potential_vorticity_baroclinic_unity_axis0(pv_data):
 
     vort_difference = pvor - (abs_vorticity * g * (-1 * (units.kelvin / units.hPa)))
 
-    true_vort = np.zeros_like(u) * (units.kelvin * units.meter**2 /
-                                    (units.second * units.kilogram))
+    true_vort = np.zeros_like(u) * (units.kelvin * units.meter**2
+                                    / (units.second * units.kilogram))
 
     assert_almost_equal(vort_difference, true_vort, 10)
 
@@ -556,8 +556,8 @@ def test_potential_vorticity_baroclinic_unity_axis2(pv_data):
 
     vort_difference = pvor - (abs_vorticity * g * (-1 * (units.kelvin / units.hPa)))
 
-    true_vort = np.zeros_like(u) * (units.kelvin * units.meter ** 2 /
-                                    (units.second * units.kilogram))
+    true_vort = np.zeros_like(u) * (units.kelvin * units.meter ** 2
+                                    / (units.second * units.kilogram))
 
     assert_almost_equal(vort_difference, true_vort, 10)
 
@@ -589,8 +589,8 @@ def test_potential_vorticity_baroclinic_non_unity_derivative(pv_data):
 
     vort_difference = pvor - (abs_vorticity * g * (-100 * (units.kelvin / units.hPa)))
 
-    true_vort = np.zeros_like(u) * (units.kelvin * units.meter ** 2 /
-                                    (units.second * units.kilogram))
+    true_vort = np.zeros_like(u) * (units.kelvin * units.meter ** 2
+                                    / (units.second * units.kilogram))
 
     assert_almost_equal(vort_difference, true_vort, 10)
 
@@ -915,13 +915,13 @@ def test_q_vector_without_static_stability(q_vector_data):
     q1_truth = (np.array([[-2.7454089e-14, -3.0194267e-13, -3.0194267e-13, -2.7454089e-14],
                           [-1.8952185e-13, -2.2269905e-14, -2.2269905e-14, -1.8952185e-13],
                           [-1.9918390e-13, -2.3370829e-14, -2.3370829e-14, -1.9918390e-13],
-                          [-5.6160772e-14, -3.5145951e-13, -3.5145951e-13, -5.6160772e-14]]) *
-                units('m^2 kg^-1 s^-1'))
+                          [-5.6160772e-14, -3.5145951e-13, -3.5145951e-13, -5.6160772e-14]])
+                * units('m^2 kg^-1 s^-1'))
     q2_truth = (np.array([[-4.4976059e-14, -4.3582378e-13, 4.3582378e-13, 4.4976059e-14],
                           [-3.0124244e-13, -3.5724617e-14, 3.5724617e-14, 3.0124244e-13],
                           [3.1216232e-13, 3.6662900e-14, -3.6662900e-14, -3.1216232e-13],
-                          [8.6038280e-14, 4.6968342e-13, -4.6968342e-13, -8.6038280e-14]]) *
-                units('m^2 kg^-1 s^-1'))
+                          [8.6038280e-14, 4.6968342e-13, -4.6968342e-13, -8.6038280e-14]])
+                * units('m^2 kg^-1 s^-1'))
 
     assert_almost_equal(q1, q1_truth, 20)
     assert_almost_equal(q2, q2_truth, 20)
@@ -939,13 +939,13 @@ def test_q_vector_with_static_stability(q_vector_data):
     q1_truth = (np.array([[-1.4158140e-08, -1.6197987e-07, -1.6875014e-07, -1.6010616e-08],
                           [-9.3971386e-08, -1.1252476e-08, -1.1252476e-08, -9.7617234e-08],
                           [-1.0785670e-07, -1.2403513e-08, -1.2403513e-08, -1.0364793e-07],
-                          [-2.9186946e-08, -1.7577703e-07, -1.6937879e-07, -2.6112047e-08]]) *
-                units('kg m^-2 s^-3'))
+                          [-2.9186946e-08, -1.7577703e-07, -1.6937879e-07, -2.6112047e-08]])
+                * units('kg m^-2 s^-3'))
     q2_truth = (np.array([[-2.3194263e-08, -2.3380160e-07, 2.4357380e-07, 2.6229040e-08],
                           [-1.4936626e-07, -1.8050836e-08, 1.8050836e-08, 1.5516129e-07],
                           [1.6903373e-07, 1.9457964e-08, -1.9457964e-08, -1.6243771e-07],
-                          [4.4714390e-08, 2.3490489e-07, -2.2635441e-07, -4.0003646e-08]]) *
-                units('kg m^-2 s^-3'))
+                          [4.4714390e-08, 2.3490489e-07, -2.2635441e-07, -4.0003646e-08]])
+                * units('kg m^-2 s^-3'))
 
     assert_almost_equal(q1, q1_truth, 14)
     assert_almost_equal(q2, q2_truth, 14)

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -958,8 +958,8 @@ def test_mixing_ratio_from_rh_dimensions():
     p = 1000. * units.mbar
     temperature = 0. * units.degC
     rh = 100. * units.percent
-    assert (str(mixing_ratio_from_relative_humidity(rh, temperature, p).units) ==
-            'dimensionless')
+    assert (str(mixing_ratio_from_relative_humidity(rh, temperature, p).units)
+            == 'dimensionless')
 
 
 @pytest.fixture

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -253,9 +253,9 @@ def moist_lapse(pressure, temperature):
         t = units.Quantity(t, temperature.units)
         p = units.Quantity(p, pressure.units)
         rs = saturation_mixing_ratio(p, t)
-        frac = ((mpconsts.Rd * t + mpconsts.Lv * rs) /
-                (mpconsts.Cp_d + (mpconsts.Lv * mpconsts.Lv * rs * mpconsts.epsilon /
-                                  (mpconsts.Rd * t * t)))).to('kelvin')
+        frac = ((mpconsts.Rd * t + mpconsts.Lv * rs)
+                / (mpconsts.Cp_d + (mpconsts.Lv * mpconsts.Lv * rs * mpconsts.epsilon
+                                    / (mpconsts.Rd * t * t)))).to('kelvin')
         return frac / p
     return units.Quantity(si.odeint(dt, atleast_1d(temperature).squeeze(),
                                     pressure.squeeze()).T.squeeze(), temperature.units)
@@ -627,8 +627,8 @@ def saturation_vapor_pressure(temperature):
     """
     # Converted from original in terms of C to use kelvin. Using raw absolute values of C in
     # a formula plays havoc with units support.
-    return sat_pressure_0c * np.exp(17.67 * (temperature - 273.15 * units.kelvin) /
-                                    (temperature - 29.65 * units.kelvin))
+    return sat_pressure_0c * np.exp(17.67 * (temperature - 273.15 * units.kelvin)
+                                    / (temperature - 29.65 * units.kelvin))
 
 
 @exporter.export
@@ -730,8 +730,8 @@ def mixing_ratio(part_press, tot_press, molecular_weight_ratio=mpconsts.epsilon)
     saturation_mixing_ratio, vapor_pressure
 
     """
-    return (molecular_weight_ratio *
-            part_press / (tot_press - part_press)).to('dimensionless')
+    return (molecular_weight_ratio * part_press
+            / (tot_press - part_press)).to('dimensionless')
 
 
 @exporter.export
@@ -913,8 +913,8 @@ def virtual_temperature(temperature, mixing, molecular_weight_ratio=mpconsts.eps
     .. math:: T_v = T \frac{\text{w} + \epsilon}{\epsilon\,(1 + \text{w})}
 
     """
-    return temperature * ((mixing + molecular_weight_ratio) /
-                          (molecular_weight_ratio * (1 + mixing)))
+    return temperature * ((mixing + molecular_weight_ratio)
+                          / (molecular_weight_ratio * (1 + mixing)))
 
 
 @exporter.export
@@ -1028,8 +1028,8 @@ def relative_humidity_wet_psychrometric(dry_bulb_temperature, web_bulb_temperatu
 
     """
     return (psychrometric_vapor_pressure_wet(dry_bulb_temperature, web_bulb_temperature,
-                                             pressure, **kwargs) /
-            saturation_vapor_pressure(dry_bulb_temperature))
+                                             pressure, **kwargs)
+            / saturation_vapor_pressure(dry_bulb_temperature))
 
 
 @exporter.export
@@ -1078,8 +1078,8 @@ def psychrometric_vapor_pressure_wet(dry_bulb_temperature, wet_bulb_temperature,
     saturation_vapor_pressure
 
     """
-    return (saturation_vapor_pressure(wet_bulb_temperature) - psychrometer_coefficient *
-            pressure * (dry_bulb_temperature - wet_bulb_temperature).to('kelvin'))
+    return (saturation_vapor_pressure(wet_bulb_temperature) - psychrometer_coefficient
+            * pressure * (dry_bulb_temperature - wet_bulb_temperature).to('kelvin'))
 
 
 @exporter.export
@@ -1118,8 +1118,8 @@ def mixing_ratio_from_relative_humidity(relative_humidity, temperature, pressure
     relative_humidity_from_mixing_ratio, saturation_mixing_ratio
 
     """
-    return (relative_humidity *
-            saturation_mixing_ratio(pressure, temperature)).to('dimensionless')
+    return (relative_humidity
+            * saturation_mixing_ratio(pressure, temperature)).to('dimensionless')
 
 
 @exporter.export
@@ -1269,8 +1269,8 @@ def relative_humidity_from_specific_humidity(specific_humidity, temperature, pre
     relative_humidity_from_mixing_ratio
 
     """
-    return (mixing_ratio_from_specific_humidity(specific_humidity) /
-            saturation_mixing_ratio(pressure, temperature))
+    return (mixing_ratio_from_specific_humidity(specific_humidity)
+            / saturation_mixing_ratio(pressure, temperature))
 
 
 @exporter.export
@@ -1359,16 +1359,16 @@ def cape_cin(pressure, temperature, dewpt, parcel_profile):
     p_mask = _less_or_close(x, lfc_pressure) & _greater_or_close(x, el_pressure)
     x_clipped = x[p_mask]
     y_clipped = y[p_mask]
-    cape = (mpconsts.Rd *
-            (np.trapz(y_clipped, np.log(x_clipped)) * units.degK)).to(units('J/kg'))
+    cape = (mpconsts.Rd
+            * (np.trapz(y_clipped, np.log(x_clipped)) * units.degK)).to(units('J/kg'))
 
     # CIN
     # Only use data between the surface and LFC for calculation
     p_mask = _greater_or_close(x, lfc_pressure)
     x_clipped = x[p_mask]
     y_clipped = y[p_mask]
-    cin = (mpconsts.Rd *
-           (np.trapz(y_clipped, np.log(x_clipped)) * units.degK)).to(units('J/kg'))
+    cin = (mpconsts.Rd
+           * (np.trapz(y_clipped, np.log(x_clipped)) * units.degK)).to(units('J/kg'))
 
     return cape, cin
 
@@ -1806,8 +1806,8 @@ def mixed_layer(p, *args, **kwargs):
     ret = []
     for datavar_layer in datavars_layer:
         actual_depth = abs(p_layer[0] - p_layer[-1])
-        ret.append((-1. / actual_depth.m) * np.trapz(datavar_layer, p_layer) *
-                   datavar_layer.units)
+        ret.append((-1. / actual_depth.m) * np.trapz(datavar_layer, p_layer)
+                   * datavar_layer.units)
     return ret
 
 
@@ -1874,8 +1874,8 @@ def moist_static_energy(heights, temperature, specific_humidity):
         The moist static energy
 
     """
-    return (dry_static_energy(heights, temperature) +
-            mpconsts.Lv * specific_humidity.to('dimensionless')).to('kJ/kg')
+    return (dry_static_energy(heights, temperature)
+            + mpconsts.Lv * specific_humidity.to('dimensionless')).to('kJ/kg')
 
 
 @exporter.export

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -182,10 +182,10 @@ def interpolate_nans(x, y, kind='linear'):
     return interpolate_nans_1d(x, y, kind=kind)
 
 
-interpolate_nans.__doc__ = (interpolate_nans_1d.__doc__ +
-                            '\n    .. deprecated:: 0.9.0\n        Function has been renamed '
-                            '`interpolate_nans_1d` and moved to `metpy.interpolate`, and '
-                            'will be removed from MetPy in 0.12.0.')
+interpolate_nans.__doc__ = (interpolate_nans_1d.__doc__
+                            + '\n    .. deprecated:: 0.9.0\n        Function has been renamed '
+                              '`interpolate_nans_1d` and moved to `metpy.interpolate`, and '
+                              'will be removed from MetPy in 0.12.0.')
 
 
 def _next_non_masked_element(a, idx):
@@ -400,12 +400,12 @@ def _get_bound_pressure_height(pressure, bound, heights=None, interpolate=True):
         raise ValueError('Bound must be specified in units of length or pressure.')
 
     # If the bound is out of the range of the data, we shouldn't extrapolate
-    if not (_greater_or_close(bound_pressure, np.nanmin(pressure) * pressure.units) and
-            _less_or_close(bound_pressure, np.nanmax(pressure) * pressure.units)):
+    if not (_greater_or_close(bound_pressure, np.nanmin(pressure) * pressure.units)
+            and _less_or_close(bound_pressure, np.nanmax(pressure) * pressure.units)):
         raise ValueError('Specified bound is outside pressure range.')
     if heights is not None:
-        if not (_less_or_close(bound_height, np.nanmax(heights) * heights.units) and
-                _greater_or_close(bound_height, np.nanmin(heights) * heights.units)):
+        if not (_less_or_close(bound_height, np.nanmax(heights) * heights.units)
+                and _greater_or_close(bound_height, np.nanmin(heights) * heights.units)):
             raise ValueError('Specified bound is outside height range.')
 
     return bound_pressure, bound_height
@@ -581,8 +581,8 @@ def get_layer(pressure, *args, **kwargs):
     pressure = pressure[sort_inds]
 
     # Mask based on top and bottom pressure
-    inds = (_less_or_close(pressure, bottom_pressure) &
-            _greater_or_close(pressure, top_pressure))
+    inds = (_less_or_close(pressure, bottom_pressure)
+            & _greater_or_close(pressure, top_pressure))
     p_interp = pressure[inds]
 
     # Interpolate pressures at bounds if necessary and sort
@@ -619,10 +619,10 @@ def interp(x, xp, *args, **kwargs):
     return interpolate_1d(x, xp, *args, **kwargs)
 
 
-interp.__doc__ = (interpolate_1d.__doc__ +
-                  '\n    .. deprecated:: 0.9.0\n        Function has been renamed '
-                  '`interpolate_1d` and moved to `metpy.interpolate`, and '
-                  'will be removed from MetPy in 0.12.0.')
+interp.__doc__ = (interpolate_1d.__doc__
+                  + '\n    .. deprecated:: 0.9.0\n        Function has been renamed '
+                    '`interpolate_1d` and moved to `metpy.interpolate`, and '
+                    'will be removed from MetPy in 0.12.0.')
 
 
 @exporter.export
@@ -723,10 +723,10 @@ def log_interp(x, xp, *args, **kwargs):
     return log_interpolate_1d(x, xp, *args, **kwargs)
 
 
-log_interp.__doc__ = (log_interpolate_1d.__doc__ +
-                      '\n    .. deprecated:: 0.9.0\n        Function has been renamed '
-                      '`log_interpolate_1d` and moved to `metpy.interpolate`, and '
-                      'will be removed from MetPy in 0.12.0.')
+log_interp.__doc__ = (log_interpolate_1d.__doc__
+                      + '\n    .. deprecated:: 0.9.0\n        Function has been renamed '
+                        '`log_interpolate_1d` and moved to `metpy.interpolate`, and '
+                        'will be removed from MetPy in 0.12.0.')
 
 
 def _greater_or_close(a, value, **kwargs):
@@ -1013,12 +1013,12 @@ def first_derivative(f, **kwargs):
 
     combined_delta = delta[tuple(delta_slice0)] + delta[tuple(delta_slice1)]
     delta_diff = delta[tuple(delta_slice1)] - delta[tuple(delta_slice0)]
-    center = (- delta[tuple(delta_slice1)] / (combined_delta * delta[tuple(delta_slice0)]) *
-              f[tuple(slice0)] +
-              delta_diff / (delta[tuple(delta_slice0)] * delta[tuple(delta_slice1)]) *
-              f[tuple(slice1)] +
-              delta[tuple(delta_slice0)] / (combined_delta * delta[tuple(delta_slice1)]) *
-              f[tuple(slice2)])
+    center = (- delta[tuple(delta_slice1)] / (combined_delta * delta[tuple(delta_slice0)])
+              * f[tuple(slice0)]
+              + delta_diff / (delta[tuple(delta_slice0)] * delta[tuple(delta_slice1)])
+              * f[tuple(slice1)]
+              + delta[tuple(delta_slice0)] / (combined_delta * delta[tuple(delta_slice1)])
+              * f[tuple(slice2)])
 
     # Fill in "left" edge with forward difference
     slice0[axis] = slice(None, 1)
@@ -1029,11 +1029,12 @@ def first_derivative(f, **kwargs):
 
     combined_delta = delta[tuple(delta_slice0)] + delta[tuple(delta_slice1)]
     big_delta = combined_delta + delta[tuple(delta_slice0)]
-    left = (- big_delta / (combined_delta * delta[tuple(delta_slice0)]) * f[tuple(slice0)] +
-            combined_delta / (delta[tuple(delta_slice0)] * delta[tuple(delta_slice1)]) *
-            f[tuple(slice1)] -
-            delta[tuple(delta_slice0)] / (combined_delta * delta[tuple(delta_slice1)]) *
-            f[tuple(slice2)])
+    left = (- big_delta / (combined_delta * delta[tuple(delta_slice0)])
+            * f[tuple(slice0)]
+            + combined_delta / (delta[tuple(delta_slice0)] * delta[tuple(delta_slice1)])
+            * f[tuple(slice1)]
+            - delta[tuple(delta_slice0)] / (combined_delta * delta[tuple(delta_slice1)])
+            * f[tuple(slice2)])
 
     # Now the "right" edge with backward difference
     slice0[axis] = slice(-3, -2)
@@ -1044,11 +1045,12 @@ def first_derivative(f, **kwargs):
 
     combined_delta = delta[tuple(delta_slice0)] + delta[tuple(delta_slice1)]
     big_delta = combined_delta + delta[tuple(delta_slice1)]
-    right = (delta[tuple(delta_slice1)] / (combined_delta * delta[tuple(delta_slice0)]) *
-             f[tuple(slice0)] -
-             combined_delta / (delta[tuple(delta_slice0)] * delta[tuple(delta_slice1)]) *
-             f[tuple(slice1)] +
-             big_delta / (combined_delta * delta[tuple(delta_slice1)]) * f[tuple(slice2)])
+    right = (delta[tuple(delta_slice1)] / (combined_delta * delta[tuple(delta_slice0)])
+             * f[tuple(slice0)]
+             - combined_delta / (delta[tuple(delta_slice0)] * delta[tuple(delta_slice1)])
+             * f[tuple(slice1)]
+             + big_delta / (combined_delta * delta[tuple(delta_slice1)])
+             * f[tuple(slice2)])
 
     return concatenate((left, center, right), axis=axis)
 
@@ -1114,10 +1116,10 @@ def second_derivative(f, **kwargs):
     delta_slice1[axis] = slice(1, None)
 
     combined_delta = delta[tuple(delta_slice0)] + delta[tuple(delta_slice1)]
-    center = 2 * (f[tuple(slice0)] / (combined_delta * delta[tuple(delta_slice0)]) -
-                  f[tuple(slice1)] / (delta[tuple(delta_slice0)] *
-                  delta[tuple(delta_slice1)]) +
-                  f[tuple(slice2)] / (combined_delta * delta[tuple(delta_slice1)]))
+    center = 2 * (f[tuple(slice0)] / (combined_delta * delta[tuple(delta_slice0)])
+                  - f[tuple(slice1)] / (delta[tuple(delta_slice0)]
+                                        * delta[tuple(delta_slice1)])
+                  + f[tuple(slice2)] / (combined_delta * delta[tuple(delta_slice1)]))
 
     # Fill in "left" edge
     slice0[axis] = slice(None, 1)
@@ -1127,9 +1129,9 @@ def second_derivative(f, **kwargs):
     delta_slice1[axis] = slice(1, 2)
 
     combined_delta = delta[tuple(delta_slice0)] + delta[tuple(delta_slice1)]
-    left = 2 * (f[tuple(slice0)] / (combined_delta * delta[tuple(delta_slice0)]) -
-                f[tuple(slice1)] / (delta[tuple(delta_slice0)] * delta[tuple(delta_slice1)]) +
-                f[tuple(slice2)] / (combined_delta * delta[tuple(delta_slice1)]))
+    left = 2 * (f[tuple(slice0)] / (combined_delta * delta[tuple(delta_slice0)])
+                - f[tuple(slice1)] / (delta[tuple(delta_slice0)] * delta[tuple(delta_slice1)])
+                + f[tuple(slice2)] / (combined_delta * delta[tuple(delta_slice1)]))
 
     # Now the "right" edge
     slice0[axis] = slice(-3, -2)
@@ -1139,9 +1141,9 @@ def second_derivative(f, **kwargs):
     delta_slice1[axis] = slice(-1, None)
 
     combined_delta = delta[tuple(delta_slice0)] + delta[tuple(delta_slice1)]
-    right = 2 * (f[tuple(slice0)] / (combined_delta * delta[tuple(delta_slice0)]) -
-                 f[tuple(slice1)] / (delta[tuple(delta_slice0)] * delta[tuple(delta_slice1)]) +
-                 f[tuple(slice2)] / (combined_delta * delta[tuple(delta_slice1)]))
+    right = 2 * (f[tuple(slice0)] / (combined_delta * delta[tuple(delta_slice0)])
+                 - f[tuple(slice1)] / (delta[tuple(delta_slice0)] * delta[tuple(delta_slice1)])
+                 + f[tuple(slice2)] / (combined_delta * delta[tuple(delta_slice1)]))
 
     return concatenate((left, center, right), axis=axis)
 

--- a/metpy/constants.py
+++ b/metpy/constants.py
@@ -107,8 +107,8 @@ with exporter:
     dry_air_spec_heat_ratio = 1.4
     Cp_d = dry_air_spec_heat_press = units.Quantity(1005, 'm^2 / s^2 / K')  # Bolton 1980
     Cv_d = dry_air_spec_heat_vol = Cp_d / dry_air_spec_heat_ratio
-    rho_d = dry_air_density_stp = ((1000. * units.mbar) /
-                                   (Rd * 273.15 * units.K)).to('kg / m^3')
+    rho_d = dry_air_density_stp = ((1000. * units.mbar)
+                                   / (Rd * 273.15 * units.K)).to('kg / m^3')
 
     # General meteorology constants
     P0 = pot_temp_ref_press = 1000. * units.mbar

--- a/metpy/interpolate/grid.py
+++ b/metpy/interpolate/grid.py
@@ -177,10 +177,10 @@ def natural_neighbor(xp, yp, variable, grid_x, grid_y):
     return natural_neighbor_to_grid(xp, yp, variable, grid_x, grid_y)
 
 
-natural_neighbor.__doc__ = (natural_neighbor_to_grid.__doc__ +
-                            '\n    .. deprecated:: 0.9.0\n        Function has been renamed '
-                            'to `natural_neighbor_to_grid` and will be removed from MetPy in '
-                            '0.12.0.')
+natural_neighbor.__doc__ = (natural_neighbor_to_grid.__doc__
+                            + '\n    .. deprecated:: 0.9.0\n        Function has been renamed '
+                              'to `natural_neighbor_to_grid` and will be removed from MetPy in'
+                              ' 0.12.0.')
 
 
 @exporter.export
@@ -246,10 +246,10 @@ def inverse_distance(xp, yp, variable, grid_x, grid_y, r, gamma=None, kappa=None
                                     kappa=kappa, min_neighbors=min_neighbors, kind=kind)
 
 
-inverse_distance.__doc__ = (inverse_distance_to_grid.__doc__ +
-                            '\n    .. deprecated:: 0.9.0\n        Function has been renamed '
-                            'to `inverse_distance_to_grid` and will be removed from MetPy in '
-                            '0.12.0.')
+inverse_distance.__doc__ = (inverse_distance_to_grid.__doc__
+                            + '\n    .. deprecated:: 0.9.0\n        Function has been renamed '
+                              'to `inverse_distance_to_grid` and will be removed from MetPy in'
+                              ' 0.12.0.')
 
 
 @exporter.export
@@ -348,6 +348,6 @@ def interpolate(x, y, z, interp_type='linear', hres=50000,
                                boundary_coords=boundary_coords)
 
 
-interpolate.__doc__ = (interpolate_to_grid.__doc__ +
-                       '\n    .. deprecated:: 0.9.0\n        Function has been renamed to '
-                       '`interpolate_to_grid` and will be removed from MetPy in 0.12.0.')
+interpolate.__doc__ = (interpolate_to_grid.__doc__
+                       + '\n    .. deprecated:: 0.9.0\n        Function has been renamed to '
+                         '`interpolate_to_grid` and will be removed from MetPy in 0.12.0.')

--- a/metpy/interpolate/one_dimension.py
+++ b/metpy/interpolate/one_dimension.py
@@ -155,8 +155,8 @@ def interpolate_1d(x, xp, *args, **kwargs):
         # Var needs to be on the *left* of the multiply to ensure that if it's a pint
         # Quantity, it gets to control the operation--at least until we make sure
         # masked arrays and pint play together better. See https://github.com/hgrecco/pint#633
-        var_interp = var[below] + (var[above] - var[below]) * ((x_array - xp[below]) /
-                                                               (xp[above] - xp[below]))
+        var_interp = var[below] + (var[above] - var[below]) * ((x_array - xp[below])
+                                                               / (xp[above] - xp[below]))
 
         # Set points out of bounds to fill value.
         var_interp[minv == xp.shape[axis]] = fill_value

--- a/metpy/io/cdm.py
+++ b/metpy/io/cdm.py
@@ -329,8 +329,8 @@ class Variable(AttributeContainer):
 
     def __str__(self):
         """Return a string representation of the Variable."""
-        groups = [str(type(self)) +
-                  ': {0.datatype} {0.name}({1})'.format(self, ', '.join(self.dimensions))]
+        groups = [str(type(self))
+                  + ': {0.datatype} {0.name}({1})'.format(self, ', '.join(self.dimensions))]
         for att in self.ncattrs():
             groups.append('\t{0}: {1}'.format(att, getattr(self, att)))
         if self.ndim:

--- a/metpy/io/nexrad.py
+++ b/metpy/io/nexrad.py
@@ -83,8 +83,7 @@ def bzip_blocks_decompress_all(data):
 def nexrad_to_datetime(julian_date, ms_midnight):
     """Convert NEXRAD date time format to python `datetime.datetime`."""
     # Subtracting one from julian_date is because epoch date is 1
-    return datetime.datetime.utcfromtimestamp((julian_date - 1) * day +
-                                              ms_midnight * milli)
+    return datetime.datetime.utcfromtimestamp((julian_date - 1) * day + ms_midnight * milli)
 
 
 def remap_status(val):
@@ -241,8 +240,8 @@ class Level2File(object):
                 # As of 2620002P, this is a special value used to indicate that the segment
                 # number/count bytes are used to indicate total size in bytes.
                 if msg_hdr.size_hw == 65535:
-                    msg_bytes = (msg_hdr.num_segments << 16 | msg_hdr.segment_num +
-                                 self.CTM_HEADER_SIZE)
+                    msg_bytes = (msg_hdr.num_segments << 16 | msg_hdr.segment_num
+                                 + self.CTM_HEADER_SIZE)
                 elif msg_hdr.msg_type in (29, 31):
                     msg_bytes = self.CTM_HEADER_SIZE + 2 * msg_hdr.size_hw
 
@@ -617,8 +616,8 @@ class Level2File(object):
     def _buffer_segment(self, msg_hdr):
         # Add to the buffer
         bufs = self._msg_buf.setdefault(msg_hdr.msg_type, {})
-        bufs[msg_hdr.segment_num] = self._buffer.read(2 * msg_hdr.size_hw -
-                                                      self.msg_hdr_fmt.size)
+        bufs[msg_hdr.segment_num] = self._buffer.read(2 * msg_hdr.size_hw
+                                                      - self.msg_hdr_fmt.size)
 
         # Warn for badly formatted data
         if len(bufs) != msg_hdr.segment_num:

--- a/metpy/plots/skewt.py
+++ b/metpy/plots/skewt.py
@@ -48,21 +48,18 @@ class SkewXTick(maxis.XTick):
         return self.get_loc() is None
 
     def _need_lower(self):
-        return (self._has_default_loc() or
-                transforms.interval_contains(self.axes.lower_xlim,
-                                             self.get_loc()))
+        return (self._has_default_loc()
+                or transforms.interval_contains(self.axes.lower_xlim, self.get_loc()))
 
     def _need_upper(self):
-        return (self._has_default_loc() or
-                transforms.interval_contains(self.axes.upper_xlim,
-                                             self.get_loc()))
+        return (self._has_default_loc()
+                or transforms.interval_contains(self.axes.upper_xlim, self.get_loc()))
 
     @property
     def gridOn(self):  # noqa: N802
         """Control whether the gridline is drawn for this tick."""
-        return (self._gridOn and (self._has_default_loc() or
-                transforms.interval_contains(self.get_view_interval(),
-                                             self.get_loc())))
+        return (self._gridOn and (self._has_default_loc()
+                or transforms.interval_contains(self.get_view_interval(), self.get_loc())))
 
     @gridOn.setter
     def gridOn(self, value):  # noqa: N802
@@ -205,19 +202,19 @@ class SkewXAxes(Axes):
         # coordinates thus performing the transform around the proper origin
         # We keep the pre-transAxes transform around for other users, like the
         # spines for finding bounds
-        self.transDataToAxes = (self.transScale +
-                                (self.transLimits +
-                                 transforms.Affine2D().skew_deg(self.rot, 0)))
+        self.transDataToAxes = (self.transScale
+                                + (self.transLimits
+                                   + transforms.Affine2D().skew_deg(self.rot, 0)))
 
         # Create the full transform from Data to Pixels
         self.transData = self.transDataToAxes + self.transAxes
 
         # Blended transforms like this need to have the skewing applied using
         # both axes, in axes coords like before.
-        self._xaxis_transform = (transforms.blended_transform_factory(
-            self.transScale + self.transLimits,
-            transforms.IdentityTransform()) +
-            transforms.Affine2D().skew_deg(self.rot, 0)) + self.transAxes
+        self._xaxis_transform = (
+            transforms.blended_transform_factory(self.transScale + self.transLimits,
+                                                 transforms.IdentityTransform())
+            + transforms.Affine2D().skew_deg(self.rot, 0)) + self.transAxes
 
     @property
     def lower_xlim(self):
@@ -864,8 +861,8 @@ class Hodograph(object):
                 # Find any bounds not in the data and interpolate them
                 interpolation_heights = [bound.m for bound in bounds if bound not in c]
                 interpolation_heights = np.array(interpolation_heights) * bounds.units
-                interpolation_heights = (np.sort(interpolation_heights) *
-                                         interpolation_heights.units)
+                interpolation_heights = (np.sort(interpolation_heights)
+                                         * interpolation_heights.units)
                 (interpolated_heights, interpolated_u,
                  interpolated_v) = interpolate_1d(interpolation_heights, c, c, u, v)
 

--- a/metpy/plots/station_plot.py
+++ b/metpy/plots/station_plot.py
@@ -569,10 +569,10 @@ class StationPlotLayout(dict):
 
     def __repr__(self):
         """Return string representation of layout."""
-        return ('{' +
-                ', '.join('{0}: ({1[0].name}, {1[1]}, ...)'.format(loc, info)
-                          for loc, info in sorted(self.items())) +
-                '}')
+        return ('{'
+                + ', '.join('{0}: ({1[0].name}, {1[1]}, ...)'.format(loc, info)
+                            for loc, info in sorted(self.items()))
+                + '}')
 
 
 with exporter:

--- a/metpy/tests/test_units.py
+++ b/metpy/tests/test_units.py
@@ -4,7 +4,6 @@
 r"""Tests the operation of MetPy's unit support code."""
 
 import sys
-import warnings
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -15,9 +14,6 @@ from metpy.testing import assert_array_almost_equal, assert_array_equal
 from metpy.testing import set_agg_backend  # noqa: F401
 from metpy.units import (atleast_1d, atleast_2d, check_units, concatenate, diff,
                          pandas_dataframe_to_unit_arrays, units)
-
-
-warnings.filterwarnings('ignore', 'Pandas doesn\'t allow columns to be created', UserWarning)
 
 
 def test_concatenate():
@@ -141,6 +137,7 @@ def test_pandas_units_simple():
     assert_array_equal(res['colb'], colb_truth)
 
 
+@pytest.mark.filterwarnings('ignore:Pandas doesn\'t allow columns to be created')
 def test_pandas_units_on_dataframe():
     """Unit attachment based on a units attribute to a dataframe."""
     df = pd.DataFrame(data=[[1, 4], [2, 5], [3, 6]], columns=['cola', 'colb'])
@@ -152,6 +149,7 @@ def test_pandas_units_on_dataframe():
     assert_array_equal(res['colb'], colb_truth)
 
 
+@pytest.mark.filterwarnings('ignore:Pandas doesn\'t allow columns to be created')
 def test_pandas_units_on_dataframe_not_all_united():
     """Unit attachment with units attribute with a column with no units."""
     df = pd.DataFrame(data=[[1, 4], [2, 5], [3, 6]], columns=['cola', 'colb'])

--- a/metpy/xarray.py
+++ b/metpy/xarray.py
@@ -271,12 +271,12 @@ class CFConventionHandler(object):
             # Check for units, either by dimensionality or name
             if (axis in cls.criteria['units'] and (
                     (
-                        cls.criteria['units'][axis]['match'] == 'dimensionality' and
-                        (units.get_dimensionality(var.attrs.get('units')) ==
-                         units.get_dimensionality(cls.criteria['units'][axis]['units']))
+                        cls.criteria['units'][axis]['match'] == 'dimensionality'
+                        and (units.get_dimensionality(var.attrs.get('units'))
+                             == units.get_dimensionality(cls.criteria['units'][axis]['units']))
                     ) or (
-                        cls.criteria['units'][axis]['match'] == 'name' and
-                        var.attrs.get('units') in cls.criteria['units'][axis]['units']
+                        cls.criteria['units'][axis]['match'] == 'name'
+                        and var.attrs.get('units') in cls.criteria['units'][axis]['units']
                     ))):
                 return True
 
@@ -287,8 +287,8 @@ class CFConventionHandler(object):
     def _fixup_coords(self, var):
         """Clean up the units on the coordinate variables."""
         for coord_name, data_array in var.coords.items():
-            if (self.check_axis(data_array, 'x', 'y') and
-                    not self.check_axis(data_array, 'lon', 'lat')):
+            if (self.check_axis(data_array, 'x', 'y')
+                    and not self.check_axis(data_array, 'lon', 'lat')):
                 try:
                     var.coords[coord_name].metpy.convert_units('meters')
                 except DimensionalityError:  # Radians!
@@ -362,9 +362,9 @@ class CFConventionHandler(object):
             return
 
         # Ambiguous axis, raise warning and do not parse
-        warnings.warn('DataArray of requested variable has more than one ' +
-                      cf_to_readable_axes[axis] + ' coordinate. Specify the unique axes ' +
-                      'using the coordinates argument.')
+        warnings.warn('DataArray of requested variable has more than one '
+                      + cf_to_readable_axes[axis]
+                      + ' coordinate. Specify the unique axes using the coordinates argument.')
         coord_lists[axis] = []
 
 
@@ -386,8 +386,8 @@ def check_matching_coordinates(func):
     """Decorate a function to make sure all given DataArrays have matching coordinates."""
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        data_arrays = ([a for a in args if isinstance(a, xr.DataArray)] +
-                       [a for a in kwargs.values() if isinstance(a, xr.DataArray)])
+        data_arrays = ([a for a in args if isinstance(a, xr.DataArray)]
+                       + [a for a in kwargs.values() if isinstance(a, xr.DataArray)])
         if len(data_arrays) > 1:
             first = data_arrays[0]
             for other in data_arrays[1:]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = F405 D999
+ignore = F405 D999 W503
 max-line-length = 95
 exclude = metpy/_version.py
 application-import-names = metpy
@@ -11,7 +11,7 @@ multiline-quotes = double
 
 [tool:pytest]
 norecursedirs = build docs .idea
-flake8-ignore = *.py F405
+flake8-ignore = *.py F405 W503
                 examples/*.py D T003 T001
                 tutorials/*.py D T003 T001
                 versioneer.py ALL

--- a/tutorials/xarray_tutorial.py
+++ b/tutorials/xarray_tutorial.py
@@ -248,8 +248,8 @@ ax.add_feature(cfeature.LAKES.with_scale('50m'), facecolor=cfeature.COLORS['wate
                edgecolor='#c7c783', zorder=0)
 
 # Set a title and show the plot
-ax.set_title(('500 hPa Heights (m), Temperature (K), Humidity (%) at ' +
-              time[0].dt.strftime('%Y-%m-%d %H:%MZ')))
+ax.set_title('500 hPa Heights (m), Temperature (K), Humidity (%) at '
+             + time[0].dt.strftime('%Y-%m-%d %H:%MZ'))
 plt.show()
 
 #########################################################################


### PR DESCRIPTION
- Pin pycodestyle  to < 2.4 in `environment.yml` to avoid installing newer version that conda-forge allows. This new version starts complaining about breaking lines with binary operators at the end rather than beginning (which I'm coming around to); more annoying is that this set of versions is not what you get from PyPI, which is why we only fail on windows ATM. For now, let's pin. Once flake8 > 3.5.0 is out on PyPI, we can revisit (at which point we'll see errors on Travis to remind us)
- Clean up warnings from tests by using pytest's warning filter rather than `warnings.simplefilter`
- Remove filtering our deprecation warnings from `test_indices`; these should be errors now anyway.