### PR TITLE
MNT: Remove use of numpy.asscalar

### DIFF
--- a/metpy/plots/station_plot.py
+++ b/metpy/plots/station_plot.py
@@ -325,7 +325,7 @@ class StationPlot(object):
             def formatter(s):
                 """Turn a format string into a callable."""
                 if hasattr(s, 'units'):
-                    s = np.asscalar(s)
+                    s = s.item()
                 return format(s, fmt)
         else:
             formatter = fmt


### PR DESCRIPTION
Numpy 1.16 will deprecate numpy.asscalar.