### PR TITLE
MNT: Make io module docstring conform to standards

### DIFF
--- a/metpy/io/__init__.py
+++ b/metpy/io/__init__.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2015,2016,2018 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
-"""MetPy's IO module contains classes for reading files. These classes are written
-to take both file names (for local files) or file-like objects; this allows reading files
-that are already in memory (using :class:`python:io.StringIO`) or remote files
-(using :func:`~python:urllib.request.urlopen`).
+"""Classes for reading various file formats.
+
+These classes are written to take both file names (for local files) or file-like objects;
+this allows reading files that are already in memory (using :class:`python:io.StringIO`)
+or remote files (using :func:`~python:urllib.request.urlopen`).
 """
 
 from .gini import *  # noqa: F403


### PR DESCRIPTION
Picked up by pydocstyle 3.0.