### PR TITLE
Update PV calc for isobaric

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,6 @@ install:
     - cmd: pip install sphinx_rtd_theme==0.2.5b1.post1 -f https://unidata-python.s3.amazonaws.com/wheelhouse/index.html
     - cmd: python --version
     - cmd: conda list
-    - cmd: if %PYTHON_VERSION% == 2.7 conda install -q enum34
     - cmd: pip install ".[test]"
     - cmd: flake8 --version
 


### PR DESCRIPTION
This PR updates the `potential_vorticity_baroclinic` function to work properly for both isentropic as well as isobaric data. It adds the appropriate additional terms needed to calculate the isobaric version properly. This closes #895.

As a result of this re-write it will require the function to have input data in (p, y, x) format in order to work properly; I could not think of or construct a method to be more amenable - this is partly due to needing to know the axis to perform the proper derivatives (comments welcome). This new function will work for either isentropic or isobaric driven data without any additional keyword arguments.

Some tests removed as a result of needing specific axes format, but added some for read datasets for both isentropic and isobaric level data.