### PR TITLE
Set __module__ for exported functions.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,7 @@ import traitlets
 import xarray
 
 import metpy.calc
+import metpy.units
 
 # Need to disable fallback before importing pint
 os.environ['PINT_ARRAY_PROTOCOL_FALLBACK'] = '0'
@@ -42,7 +43,9 @@ def doctest_available_modules(doctest_namespace):
     """Make modules available automatically to doctests."""
     doctest_namespace['metpy'] = metpy
     doctest_namespace['metpy.calc'] = metpy.calc
+    doctest_namespace['np'] = numpy
     doctest_namespace['plt'] = matplotlib.pyplot
+    doctest_namespace['units'] = metpy.units.units
 
 
 @pytest.fixture()

--- a/src/metpy/calc/__init__.py
+++ b/src/metpy/calc/__init__.py
@@ -10,6 +10,7 @@ from .kinematics import *  # noqa: F403
 from .thermo import *  # noqa: F403
 from .tools import *  # noqa: F403
 from .turbulence import *  # noqa: F403
+from ..package_tools import set_module
 
 __all__ = basic.__all__[:]  # pylint: disable=undefined-variable
 __all__.extend(cross_sections.__all__)  # pylint: disable=undefined-variable
@@ -18,3 +19,5 @@ __all__.extend(kinematics.__all__)  # pylint: disable=undefined-variable
 __all__.extend(thermo.__all__)  # pylint: disable=undefined-variable
 __all__.extend(tools.__all__)  # pylint: disable=undefined-variable
 __all__.extend(turbulence.__all__)  # pylint: disable=undefined-variable
+
+set_module(globals())

--- a/src/metpy/interpolate/__init__.py
+++ b/src/metpy/interpolate/__init__.py
@@ -8,9 +8,12 @@ from .one_dimension import *  # noqa: F403
 from .points import *  # noqa: F403
 from .slices import *  # noqa: F403
 from .tools import *  # noqa: F403
+from ..package_tools import set_module
 
 __all__ = grid.__all__[:]  # pylint: disable=undefined-variable
 __all__.extend(one_dimension.__all__)  # pylint: disable=undefined-variable
 __all__.extend(points.__all__)  # pylint: disable=undefined-variable
 __all__.extend(slices.__all__)  # pylint: disable=undefined-variable
 __all__.extend(tools.__all__)  # pylint: disable=undefined-variable
+
+set_module(globals())

--- a/src/metpy/io/__init__.py
+++ b/src/metpy/io/__init__.py
@@ -12,6 +12,9 @@ from .gini import *  # noqa: F403
 from .metar import *  # noqa: F403
 from .nexrad import *  # noqa: F403
 from .station_data import *  # noqa: F403
+from ..package_tools import set_module
 
 __all__ = gini.__all__[:]  # pylint: disable=undefined-variable
 __all__.extend(nexrad.__all__)  # pylint: disable=undefined-variable
+
+set_module(globals())

--- a/src/metpy/io/__init__.py
+++ b/src/metpy/io/__init__.py
@@ -15,6 +15,8 @@ from .station_data import *  # noqa: F403
 from ..package_tools import set_module
 
 __all__ = gini.__all__[:]  # pylint: disable=undefined-variable
+__all__.extend(metar.__all__)  # pylint: disable=undefined-variable
 __all__.extend(nexrad.__all__)  # pylint: disable=undefined-variable
+__all__.extend(station_data.__all__)  # pylint: disable=undefined-variable
 
 set_module(globals())

--- a/src/metpy/package_tools.py
+++ b/src/metpy/package_tools.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015,2019 MetPy Developers.
+# Copyright (c) 2015,2018,2019 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Collection of tools for managing the package."""
@@ -37,3 +37,25 @@ class Exporter:
         """Exit the instance tracking block."""
         self.exports.extend(set(self.globls) - self.start_vars)
         del self.start_vars
+
+
+def set_module(globls):
+    """Set the module for all functions in ``__all__``.
+
+    This sets the ``__module__`` attribute of all items within the ``__all__`` list
+    for the calling module.
+
+    This supports our hoisting of functions out of individual modules, which are
+    considered implementation details, into the namespace of the top-level subpackage.
+
+    Parameters
+    ----------
+    globls : Dict[str, object]
+        Mapping of all global variables for the module. This contains all needed
+        python special ("dunder") variables needed to be modified.
+
+    """
+    for item in globls['__all__']:
+        obj = globls[item]
+        if hasattr(obj, '__module__'):
+            obj.__module__ = globls['__name__']

--- a/src/metpy/plots/__init__.py
+++ b/src/metpy/plots/__init__.py
@@ -14,6 +14,7 @@ from .declarative import *  # noqa: F403
 from .skewt import *  # noqa: F403
 from .station_plot import *  # noqa: F403
 from .wx_symbols import *  # noqa: F403
+from ..package_tools import set_module
 
 logger = logging.getLogger(__name__)
 
@@ -29,3 +30,5 @@ try:
     __all__.extend(['USCOUNTIES', 'USSTATES'])
 except ImportError:
     logger.warning('Cannot import USCOUNTIES and USSTATES without Cartopy installed.')
+
+set_module(globals())

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2018 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Test packaging details."""
+
+from metpy.calc import tke
+from metpy.interpolate import interpolate_to_grid
+from metpy.io import Level2File
+from metpy.plots import StationPlot
+
+
+def test_modules_set():
+    """Test that functions from each subpackage have correct module set."""
+    assert Level2File.__module__ == 'metpy.io'
+    assert StationPlot.__module__ == 'metpy.plots'
+    assert interpolate_to_grid.__module__ == 'metpy.interpolate'
+    assert tke.__module__ == 'metpy.calc'


### PR DESCRIPTION
Fixes #968. Resets the `__module__` on our exported functions so that they appear from the proper namespace when printed in IPython/Jupyter notebook. Also fixes a couple places where we were incorrectly putting the objects themselves, rather than their names, into `__all__`. (Found because those cases break this new code.)