### PR TITLE
Change axis-tracking attribute from axis to _metpy_axis

### DIFF
--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -925,7 +925,7 @@ def xarray_derivative_wrap(func):
             # Initialize new kwargs with the axis number
             new_kwargs = {'axis': f.get_axis_num(axis)}
 
-            if f[axis].attrs.get('axis') == 'T':
+            if f[axis].attrs.get('_metpy_axis') == 'T':
                 # Time coordinate, need to convert to seconds from datetimes
                 new_kwargs['x'] = f[axis].metpy.as_timestamp().metpy.unit_array
             elif CFConventionHandler.check_axis(f[axis], 'lon'):

--- a/metpy/tests/test_xarray.py
+++ b/metpy/tests/test_xarray.py
@@ -222,12 +222,13 @@ def test_missing_coordinate_type(test_ds_generic):
     assert 'not available' in str(exc.value)
 
 
-def test_assign_axes_overwrite(test_ds_generic):
-    """Test that CFConventionHandler._assign_axis overwrites past axis attributes."""
+def test_assign_axes_not_overwrite(test_ds_generic):
+    """Test that CFConventionHandler._assign_axis does not overwrite past axis attributes."""
     data = test_ds_generic.copy()
     data['c'].attrs['axis'] = 'X'
     data.metpy._assign_axes({'Y': data['c']}, data['test'])
-    assert data['c'].attrs['axis'] == 'Y'
+    assert data['c'].identical(data['test'].metpy.y)
+    assert data['c'].attrs['axis'] == 'X'
 
 
 def test_resolve_axis_conflict_lonlat_and_xy(test_ds_generic):
@@ -447,7 +448,7 @@ def test_as_timestamp(test_var):
                          name='time',
                          coords=time.coords,
                          dims='time',
-                         attrs={'long_name': 'forecast time', 'axis': 'T',
+                         attrs={'long_name': 'forecast time', '_metpy_axis': 'T',
                                 'units': 'seconds'})
     assert truth.identical(time.metpy.as_timestamp())
 

--- a/metpy/xarray.py
+++ b/metpy/xarray.py
@@ -70,7 +70,7 @@ class MetPyAccessor(object):
         """Return the coordinate variable corresponding to the given individual axis type."""
         if axis in readable_to_cf_axes:
             for coord_var in self._data_array.coords.values():
-                if coord_var.attrs.get('axis') == readable_to_cf_axes[axis]:
+                if coord_var.attrs.get('_metpy_axis') == readable_to_cf_axes[axis]:
                     return coord_var
             raise AttributeError(axis + ' attribute is not available.')
         else:
@@ -114,7 +114,8 @@ class MetPyAccessor(object):
     def as_timestamp(self):
         """Return the data as unix timestamp (for easier time derivatives)."""
         attrs = {key: self._data_array.attrs[key] for key in
-                 {'standard_name', 'long_name', 'axis'} & set(self._data_array.attrs)}
+                 {'standard_name', 'long_name', 'axis', '_metpy_axis'}
+                 & set(self._data_array.attrs)}
         attrs['units'] = 'seconds'
         return xr.DataArray(self._data_array.values.astype('datetime64[s]').astype('int'),
                             name=self._data_array.name,
@@ -337,12 +338,9 @@ class CFConventionHandler(object):
     @staticmethod
     def _assign_axes(coord_map, var):
         """Assign axis attribute to coordinates in var according to coord_map."""
-        for coord_var in var.coords.values():
-            if 'axis' in coord_var.attrs:
-                del coord_var.attrs['axis']
         for axis in coord_map:
             if coord_map[axis] is not None:
-                coord_map[axis].attrs['axis'] = axis
+                coord_map[axis].attrs['_metpy_axis'] = axis
 
     def _resolve_axis_conflict(self, axis, coord_lists):
         """Handle axis conflicts if they arise."""


### PR DESCRIPTION
Previously, any existing `axis` attribute was removed in `parse_cf()`. Now, with this PR, the axis is tracked in `_metpy_axis` to avoid collisions.

Closes #981.