### PR TITLE
MNT: Update doc8 configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ script:
       else
         export DOC_TEST_RESULT=0;
       fi;
-      doc8 --file-encoding utf8 README.rst docs/;
+      doc8 README.rst docs/;
       if [[ $? -ne 0 || $DOC_BUILD_RESULT -ne 0 || $DOC_TEST_RESULT -ne 0 ]]; then
         false;
       fi;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ requesting something you think is missing.
 We recommend using the [conda](https://conda.io/docs/) package manager for your Python 
 environments. Our recommended setup for contributing is:
 
-* Install [miniconda](https://conda.io/miniconda.html) on your system.
+* Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) on your system.
 * Install git on your system if it is not already there (install XCode command line tools on
   a Mac or git bash on Windows)
 * Login to your GitHub account and make a fork of the 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ contribution.
 
 ## Code Style
 MetPy uses the Python code style outlined in `PEP8
-<http://pep8.org>`_. For better or worse, this is what the majority
+<https://pep8.org>`_. For better or worse, this is what the majority
 of the Python world uses. The one deviation is that line length limit is 95 characters. 80 is a
 good target, but some times longer lines are needed.
 
@@ -255,7 +255,7 @@ couple of days. We may suggest some changes or improvements or alternatives.
 Some things that will increase the chance that your pull request is accepted quickly:
 
 * Write tests.
-* Follow [PEP8][http://pep8.org] for style. (The `flake8` utility can help with this.)
+* Follow [PEP8][https://pep8.org] for style. (The `flake8` utility can help with this.)
 * Write a [good commit message][https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html].
 
 Pull requests will automatically have tests run by Travis. This includes

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,7 +74,7 @@ Media
 * `SciPy 2017 poster`_ and `repository <https://github.com/jrleeman/CAPE-SciPy-2017>`_
   about reproducing a classic CAPE paper with MetPy.
 * `SciPy 2017 talk`_ and `slides
-  <http://nbviewer.jupyter.org/format/slides/github/dopplershift/
+  <https://nbviewer.jupyter.org/format/slides/github/dopplershift/
   Talks/blob/master/SciPy2017/MetPy%20Units.ipynb>`_
   about challenges developing MetPy with units
 * MetPy was featured on `Episode 100 of Podcast.__init__`_

--- a/docs/installguide.rst
+++ b/docs/installguide.rst
@@ -8,7 +8,7 @@ Installation Guide
 Python 2.7 Support
 ------------------
 In the Fall 2019, we will be dropping support for Python 2.7. This follows movement from
-other packages within the `scientific Python ecosystem <http://python3statement.org/>`_.
+other packages within the `scientific Python ecosystem <https://python3statement.org/>`_.
 This includes:
 
 * Core Python developers will

--- a/docs/units.rst
+++ b/docs/units.rst
@@ -6,7 +6,7 @@ unit-correctness. This simplifies the MetPy API by eliminating the need to speci
 various functions. Instead, only the final results need to be converted to desired units. For
 more information on unit support, see the documentation for
 `Pint <http://pint.readthedocs.io>`_. Particular attention should be paid to the support
-for `temperature units <http://pint.readthedocs.io/en/latest/nonmult.html>`_.
+for `temperature units <https://pint.readthedocs.io/en/latest/nonmult.html>`_.
 
 ------------
 Construction

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ mpl-results-path = test_output
 log_print = False
 
 [doc8]
-ignore-path = docs/build,docs/api,docs/_templates
-
+ignore-path = docs/build,docs/api/generated,docs/_templates,docs/tutorials,docs/examples
+file-encoding = utf8
 max-line-length = 95
 
 [pydocstyle]


### PR DESCRIPTION
Sphinx-gallery changed their output and it completely buggers doc8.
Probably shouldn't be running doc8 on generated files anyway. This does
eliminate checking some of our index.rst files, but it's a small price
to pay to have things working again.