### PR TITLE
allow any pooch >= 0.1 to be used

### DIFF
--- a/docs/installguide.rst
+++ b/docs/installguide.rst
@@ -42,7 +42,7 @@ currently supporting Python 2.7.
 * xarray >= 0.10.7
 * traitlets >= 4.3.0
 * enum34 (for python < 3.4)
-* pooch >= 0.1, < 0.3
+* pooch >= 0.1
 
 ------------
 Installation

--- a/environment.yml
+++ b/environment.yml
@@ -35,4 +35,4 @@ dependencies:
   - cartopy
   - doc8
   - m2r
-  - pooch>=0.1, <0.3
+  - pooch>=0.1

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     install_requires=['matplotlib>=2.0.0', 'numpy>=1.12.0', 'scipy>=0.17.0',
                       'pint!=0.9', 'xarray>=0.10.7', 'enum34;python_version<"3.4"',
                       'contextlib2;python_version<"3.6"',
-                      'pooch>=0.1, <0.3', 'traitlets>=4.3.0'],
+                      'pooch>=0.1', 'traitlets>=4.3.0'],
     extras_require={
         'dev': ['ipython[all]>=3.1'],
         'doc': ['sphinx>=1.4', 'sphinx-gallery', 'doc8', 'm2r',


### PR DESCRIPTION
See previous discussion with #978, my issue is that conda-forge has `pooch=0.4` now which ends up downgrading metpy to an old version that did not have pooch pinned :)  So will see if we can march pooch forward here and then with another PR to the conda-forge recipe.