### PR TITLE
Pandas support for interpolate grid

### DIFF
--- a/metpy/interpolate/grid.py
+++ b/metpy/interpolate/grid.py
@@ -13,6 +13,7 @@ from .points import (interpolate_to_points, inverse_distance_to_points,
                      natural_neighbor_to_points)
 from ..deprecation import deprecated
 from ..package_tools import Exporter
+from ..pandas import preprocess_pandas
 
 exporter = Exporter(globals())
 
@@ -255,6 +256,7 @@ inverse_distance.__doc__ = (inverse_distance_to_grid.__doc__
 
 
 @exporter.export
+@preprocess_pandas
 def interpolate_to_grid(x, y, z, interp_type='linear', hres=50000,
                         minimum_neighbors=3, gamma=0.25, kappa_star=5.052,
                         search_radius=None, rbf_func='linear', rbf_smooth=0,
@@ -339,6 +341,7 @@ def interpolate_to_grid(x, y, z, interp_type='linear', hres=50000,
 
 
 @exporter.export
+@preprocess_pandas
 def interpolate_to_isosurface(level_var, interp_var, level, **kwargs):
     r"""Linear interpolation of a variable to a given vertical level from given values.
 

--- a/metpy/interpolate/tests/test_interpolate_tools.py
+++ b/metpy/interpolate/tests/test_interpolate_tools.py
@@ -14,7 +14,6 @@ from scipy.spatial.distance import cdist
 from metpy.interpolate import (remove_nan_observations, remove_observations_below_value,
                                remove_repeat_coordinates, interpolate_to_grid)
 from metpy.interpolate.tools import barnes_weights, calc_kappa, cressman_weights
-from metpy.units import units
 
 
 @pytest.fixture()

--- a/metpy/interpolate/tests/test_interpolate_tools.py
+++ b/metpy/interpolate/tests/test_interpolate_tools.py
@@ -11,8 +11,9 @@ import pandas as pd
 import pytest
 from scipy.spatial.distance import cdist
 
-from metpy.interpolate import (remove_nan_observations, remove_observations_below_value,
-                               remove_repeat_coordinates, interpolate_to_grid)
+from metpy.interpolate import (interpolate_to_grid, remove_nan_observations,
+                               remove_observations_below_value,
+                               remove_repeat_coordinates)
 from metpy.interpolate.tools import barnes_weights, calc_kappa, cressman_weights
 
 

--- a/metpy/interpolate/tests/test_interpolate_tools.py
+++ b/metpy/interpolate/tests/test_interpolate_tools.py
@@ -7,12 +7,14 @@ from __future__ import division
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
+import pandas as pd
 import pytest
 from scipy.spatial.distance import cdist
 
 from metpy.interpolate import (remove_nan_observations, remove_observations_below_value,
-                               remove_repeat_coordinates)
+                               remove_repeat_coordinates, interpolate_to_grid)
 from metpy.interpolate.tools import barnes_weights, calc_kappa, cressman_weights
+from metpy.units import units
 
 
 @pytest.fixture()
@@ -126,3 +128,14 @@ def test_cressman_weights():
              0.219512195121951]
 
     assert_array_almost_equal(truth, weights)
+
+
+def test_interpolate_to_grid_pandas():
+    r"""Test whether this accepts a pd.Series without crashing."""
+    df = pd.DataFrame({
+        'lat': [38, 39, 31, 30, 41, 35],
+        'lon': [-106, -105, -86, -96, -74, -70],
+        'tmp': [-10, -16, 13, 16, 0, 3.5]
+    }, index=[1, 2, 3, 4, 5, 6])
+    gx, gy, img = interpolate_to_grid(df['lon'], df['lat'], df['tmp'],
+        interp_type='natural_neighbor', hres=0.5)

--- a/metpy/interpolate/tests/test_interpolate_tools.py
+++ b/metpy/interpolate/tests/test_interpolate_tools.py
@@ -131,11 +131,12 @@ def test_cressman_weights():
 
 
 def test_interpolate_to_grid_pandas():
-    r"""Test whether this accepts a pd.Series without crashing."""
+    r"""Test whether this accepts a `pd.Series` without crashing."""
     df = pd.DataFrame({
         'lat': [38, 39, 31, 30, 41, 35],
         'lon': [-106, -105, -86, -96, -74, -70],
         'tmp': [-10, -16, 13, 16, 0, 3.5]
     }, index=[1, 2, 3, 4, 5, 6])
-    gx, gy, img = interpolate_to_grid(df['lon'], df['lat'], df['tmp'],
+    interpolate_to_grid(
+        df['lon'], df['lat'], df['tmp'],
         interp_type='natural_neighbor', hres=0.5)

--- a/metpy/pandas.py
+++ b/metpy/pandas.py
@@ -1,14 +1,12 @@
-# Copyright (c) 2018 MetPy Developers.
+# Copyright (c) 2019 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
-"""Provide accessors to enhance interoperability between XArray and MetPy."""
+"""Provide accessors to enhance interoperability between Pandas and MetPy."""
 from __future__ import absolute_import
-from collections.abc import Iterable
 
 import functools
 import logging
 
-import numpy as np
 import pandas as pd
 
 __all__ = []
@@ -16,8 +14,7 @@ log = logging.getLogger(__name__)
 
 
 def preprocess_pandas(func):
-    """Decorate a function to convert all data series arguments to np.ndarray.
-    """
+    """Decorate a function to convert all data series arguments to `np.ndarray`."""
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         # not using hasattr(a, values) because it picks up dict.values()

--- a/metpy/pandas.py
+++ b/metpy/pandas.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2018 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Provide accessors to enhance interoperability between XArray and MetPy."""
+from __future__ import absolute_import
+from collections.abc import Iterable
+
+import functools
+import logging
+
+import numpy as np
+import pandas as pd
+
+__all__ = []
+log = logging.getLogger(__name__)
+
+
+def preprocess_pandas(func):
+    """Decorate a function to convert all data series arguments to np.ndarray.
+    """
+    def _if_units_strip(val):
+        if hasattr(val, 'm'):
+            return val.m
+        else:
+            return val
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        # not using hasattr(a, values) because it picks up dict.values()
+        # and this is more explictly handling pandas
+        args = tuple(a.values if isinstance(a, pd.Series) else a for a in args)
+        kwargs = {name: (v.values if isinstance(v, pd.Series) else v)
+                  for name, v in kwargs.items()}
+        return func(*args, **kwargs)
+    return wrapper

--- a/metpy/pandas.py
+++ b/metpy/pandas.py
@@ -18,12 +18,6 @@ log = logging.getLogger(__name__)
 def preprocess_pandas(func):
     """Decorate a function to convert all data series arguments to np.ndarray.
     """
-    def _if_units_strip(val):
-        if hasattr(val, 'm'):
-            return val.m
-        else:
-            return val
-
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         # not using hasattr(a, values) because it picks up dict.values()


### PR DESCRIPTION
Fixes https://github.com/Unidata/MetPy/issues/1029

```
import numpy as np
import xarray as xr
import pandas as pd

from metpy.cbook import get_test_data
from metpy.interpolate import interpolate_to_grid

df = pd.read_csv(get_test_data('station_data.txt'))
df = df.iloc[:, [2, 3, 5]]
df.columns = ['lat', 'lon', 'tmp']

gx, gy, img = interpolate_to_grid(df['lon'], df['lat'], df['tmp'], interp_type='natural_neighbor', hres=1)
```

![image](https://user-images.githubusercontent.com/15331990/57351997-c6349780-7118-11e9-96f1-b24e88e27df0.png)

I didn't use hasattr(var, 'values') because it picks up on the dict.values() too, but the `values` in dict are methods, not attributes, leading to an uninstantiated builtin-function.


This decorator is only useful for operations that doesn't require units since `pd.Series([0, 1, 2]) * units('K')` doesn't actually add the units or store them anywhere, so any function that uses units requires users to call series.values * units ahead of time.