### PR TITLE
migrate mpl.cbook.iterable to numpy.iterable

### DIFF
--- a/metpy/cbook.py
+++ b/metpy/cbook.py
@@ -5,8 +5,8 @@
 
 import os
 
-from matplotlib.cbook import iterable
 import numpy as np
+from numpy import iterable
 import pooch
 
 from . import __version__


### PR DESCRIPTION
matplotlib.cbook.iterable was deprecated in Matplotlib 3.1