### PR TITLE
Units: convert '%' to 'percent' for within the xarray MetPy accessor

### DIFF
--- a/metpy/tests/test_xarray.py
+++ b/metpy/tests/test_xarray.py
@@ -84,6 +84,14 @@ def test_units(test_var):
     assert test_var.metpy.units == units('kelvin')
 
 
+def test_units_percent():
+    """Test that '%' is converted to 'percent'."""
+    test_var_percent = xr.open_dataset(
+        get_test_data('irma_gfs_example.nc',
+                      as_file_obj=False))['Relative_humidity_isobaric']
+    assert test_var_percent.metpy.units == units('percent')
+
+
 def test_convert_units(test_var):
     """Test in-place conversion of units."""
     test_var.metpy.convert_units('degC')

--- a/metpy/xarray.py
+++ b/metpy/xarray.py
@@ -34,7 +34,10 @@ class MetPyAccessor(object):
 
     @property
     def units(self):
-        return units(self._units)
+        if self._units != '%':
+            return units(self._units)
+        else:
+            return units('percent')
 
     @property
     def unit_array(self):


### PR DESCRIPTION
Because pint does not support '%' as a unit, this update converts DataArray units that are provided as such to 'percent'.

Fixes #1038.