### PR TITLE
xarray Coordinate Identification Refactor

### DIFF
--- a/metpy/calc/cross_sections.py
+++ b/metpy/calc/cross_sections.py
@@ -13,7 +13,7 @@ import xarray as xr
 from .basic import coriolis_parameter
 from .tools import first_derivative
 from ..package_tools import Exporter
-from ..xarray import CFConventionHandler, check_matching_coordinates
+from ..xarray import check_axis, check_matching_coordinates
 
 exporter = Exporter(globals())
 
@@ -33,8 +33,7 @@ def distances_from_cross_section(cross):
         A tuple of the x and y distances as DataArrays
 
     """
-    if (CFConventionHandler.check_axis(cross.metpy.x, 'lon')
-            and CFConventionHandler.check_axis(cross.metpy.y, 'lat')):
+    if check_axis(cross.metpy.x, 'lon') and check_axis(cross.metpy.y, 'lat'):
         # Use pyproj to obtain x and y distances
         from pyproj import Geod
 
@@ -53,8 +52,7 @@ def distances_from_cross_section(cross):
         x = xr.DataArray(x, coords=lon.coords, dims=lon.dims, attrs={'units': 'meters'})
         y = xr.DataArray(y, coords=lat.coords, dims=lat.dims, attrs={'units': 'meters'})
 
-    elif (CFConventionHandler.check_axis(cross.metpy.x, 'x')
-            and CFConventionHandler.check_axis(cross.metpy.y, 'y')):
+    elif check_axis(cross.metpy.x, 'x') and check_axis(cross.metpy.y, 'y'):
 
         # Simply return what we have
         x = cross.metpy.x
@@ -81,7 +79,7 @@ def latitude_from_cross_section(cross):
 
     """
     y = cross.metpy.y
-    if CFConventionHandler.check_axis(y, 'lat'):
+    if check_axis(y, 'lat'):
         return y
     else:
         import cartopy.crs as ccrs

--- a/metpy/calc/tests/test_calc_tools.py
+++ b/metpy/calc/tests/test_calc_tools.py
@@ -986,13 +986,13 @@ def test_gradient_xarray(test_da_xy):
     xr.testing.assert_allclose(deriv_p, truth_p)
     assert deriv_p.metpy.units == truth_p.metpy.units
 
-    # Assert alternative specifications give same results
-    xr.testing.assert_identical(deriv_x_alt1, deriv_x)
-    xr.testing.assert_identical(deriv_y_alt1, deriv_y)
-    xr.testing.assert_identical(deriv_p_alt1, deriv_p)
-    xr.testing.assert_identical(deriv_x_alt2, deriv_x)
-    xr.testing.assert_identical(deriv_y_alt2, deriv_y)
-    xr.testing.assert_identical(deriv_p_alt2, deriv_p)
+    # Assert alternative specifications give same results (up to attribute differences)
+    xr.testing.assert_equal(deriv_x_alt1, deriv_x)
+    xr.testing.assert_equal(deriv_y_alt1, deriv_y)
+    xr.testing.assert_equal(deriv_p_alt1, deriv_p)
+    xr.testing.assert_equal(deriv_x_alt2, deriv_x)
+    xr.testing.assert_equal(deriv_y_alt2, deriv_y)
+    xr.testing.assert_equal(deriv_p_alt2, deriv_p)
 
 
 def test_gradient_xarray_implicit_axes(test_da_xy):

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -25,7 +25,7 @@ from ..deprecation import deprecated, metpyDeprecation
 from ..interpolate.one_dimension import interpolate_1d, interpolate_nans_1d, log_interpolate_1d
 from ..package_tools import Exporter
 from ..units import atleast_1d, check_units, concatenate, diff, units
-from ..xarray import CFConventionHandler, preprocess_xarray
+from ..xarray import check_axis, preprocess_xarray
 
 exporter = Exporter(globals())
 
@@ -928,10 +928,10 @@ def xarray_derivative_wrap(func):
             if f[axis].attrs.get('_metpy_axis') == 'T':
                 # Time coordinate, need to convert to seconds from datetimes
                 new_kwargs['x'] = f[axis].metpy.as_timestamp().metpy.unit_array
-            elif CFConventionHandler.check_axis(f[axis], 'lon'):
+            elif check_axis(f[axis], 'lon'):
                 # Longitude coordinate, need to get grid deltas
                 new_kwargs['delta'], _ = grid_deltas_from_dataarray(f)
-            elif CFConventionHandler.check_axis(f[axis], 'lat'):
+            elif check_axis(f[axis], 'lat'):
                 # Latitude coordinate, need to get grid deltas
                 _, new_kwargs['delta'] = grid_deltas_from_dataarray(f)
             else:

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -925,7 +925,7 @@ def xarray_derivative_wrap(func):
             # Initialize new kwargs with the axis number
             new_kwargs = {'axis': f.get_axis_num(axis)}
 
-            if f[axis].attrs.get('_metpy_axis') == 'T':
+            if check_axis(f[axis], 'time'):
                 # Time coordinate, need to convert to seconds from datetimes
                 new_kwargs['x'] = f[axis].metpy.as_timestamp().metpy.unit_array
             elif check_axis(f[axis], 'lon'):

--- a/metpy/interpolate/slices.py
+++ b/metpy/interpolate/slices.py
@@ -7,7 +7,7 @@ import numpy as np
 import xarray as xr
 
 from ..package_tools import Exporter
-from ..xarray import CFConventionHandler
+from ..xarray import check_axis
 
 exporter = Exporter(globals())
 
@@ -166,7 +166,7 @@ def cross_section(data, start, end, steps=100, interp_type='linear'):
         points_cross = geodesic(crs_data, start, end, steps)
 
         # Patch points_cross to match given longitude range, whether [0, 360) or (-180,  180]
-        if CFConventionHandler.check_axis(x, 'lon') and (x > 180).any():
+        if check_axis(x, 'lon') and (x > 180).any():
             points_cross[points_cross[:, 0] < 0, 0] += 360.
 
         # Return the interpolated data

--- a/metpy/interpolate/tests/test_slices.py
+++ b/metpy/interpolate/tests/test_slices.py
@@ -227,9 +227,9 @@ def test_cross_section_dataset_and_nearest_interp(test_ds_lonlat):
 
 def test_interpolate_to_slice_error_on_missing_coordinate(test_ds_lonlat):
     """Test that the proper error is raised with missing coordinate."""
-    # Use a variable with a coordinate dimension that has attributes removed
+    # Use a variable with a coordinate removed
     data_bad = test_ds_lonlat['temperature'].copy()
-    data_bad['lat'].attrs = {}
+    del data_bad['lat']
     path = np.array([[265.0, 30.],
                      [265.0, 36.],
                      [265.0, 42.]])

--- a/metpy/tests/test_xarray.py
+++ b/metpy/tests/test_xarray.py
@@ -13,7 +13,7 @@ import xarray as xr
 
 from metpy.testing import assert_almost_equal, assert_array_equal, get_test_data
 from metpy.units import units
-from metpy.xarray import check_matching_coordinates, preprocess_xarray
+from metpy.xarray import check_axis, check_matching_coordinates, preprocess_xarray
 
 
 # Seed RandomState for deterministic tests
@@ -231,7 +231,7 @@ def test_missing_coordinate_type(test_ds_generic):
 
 
 def test_assign_axes_not_overwrite(test_ds_generic):
-    """Test that CFConventionHandler._assign_axis does not overwrite past axis attributes."""
+    """Test that MetPyDatasetAccessor._assign_axis does not overwrite past axis attributes."""
     data = test_ds_generic.copy()
     data['c'].attrs['axis'] = 'X'
     data.metpy._assign_axes({'Y': data['c']}, data['test'])
@@ -334,7 +334,7 @@ criterion_matches = [
 def test_check_axis_criterion_match(test_ds_generic, test_tuple):
     """Test the variety of possibilities for check_axis in the criterion match."""
     test_ds_generic['e'].attrs[test_tuple[0]] = test_tuple[1]
-    assert test_ds_generic.metpy.check_axis(test_ds_generic['e'], test_tuple[2])
+    assert check_axis(test_ds_generic['e'], test_tuple[2])
 
 
 unit_matches = [
@@ -360,7 +360,7 @@ unit_matches = [
 def test_check_axis_unit_match(test_ds_generic, test_tuple):
     """Test the variety of possibilities for check_axis in the unit match."""
     test_ds_generic['e'].attrs['units'] = test_tuple[0]
-    assert test_ds_generic.metpy.check_axis(test_ds_generic['e'], test_tuple[1])
+    assert check_axis(test_ds_generic['e'], test_tuple[1])
 
 
 regex_matches = [
@@ -401,7 +401,7 @@ regex_matches = [
 def test_check_axis_regular_expression_match(test_ds_generic, test_tuple):
     """Test the variety of possibilities for check_axis in the regular expression match."""
     data = test_ds_generic.rename({'e': test_tuple[0]})
-    assert data.metpy.check_axis(data[test_tuple[0]], test_tuple[1])
+    assert check_axis(data[test_tuple[0]], test_tuple[1])
 
 
 def test_narr_example_variable_without_grid_mapping(test_ds):

--- a/metpy/tests/test_xarray.py
+++ b/metpy/tests/test_xarray.py
@@ -535,3 +535,11 @@ def test_dataset_loc_without_dict(test_ds):
     """Test that .metpy.loc for Datasets raises error when used with a non-dict."""
     with pytest.raises(TypeError):
         test_ds.metpy.loc[:, 700 * units.hPa]
+
+
+def test_dataset_parse_cf_keep_attrs(test_ds):
+    """Test that .parse_cf() does not remove attributes on the parsed dataset."""
+    parsed_ds = test_ds.metpy.parse_cf()
+
+    assert parsed_ds.attrs  # Must be non-empty
+    assert parsed_ds.attrs == test_ds.attrs  # Must match

--- a/metpy/xarray.py
+++ b/metpy/xarray.py
@@ -197,7 +197,8 @@ class CFConventionHandler(object):
         # If no varname is given, parse the entire dataset
         if varname is None:
             return self._dataset.apply(lambda da: self.parse_cf(da.name,
-                                                                coordinates=coordinates))
+                                                                coordinates=coordinates),
+                                       keep_attrs=True)
 
         var = self._dataset[varname]
         if 'grid_mapping' in var.attrs:

--- a/tutorials/xarray_tutorial.py
+++ b/tutorials/xarray_tutorial.py
@@ -44,8 +44,8 @@ print(data)
 # Preparing Data
 # --------------
 #
-# To make use of the data within MetPy, we need to parse the dataset for projection and
-# coordinate information following the CF conventions. For this, we use the
+# To make use of the data within MetPy, we need to parse the dataset for projection
+# information following the CF conventions. For this, we use the
 # ``data.metpy.parse_cf()`` method, which will return a new, parsed ``DataArray`` or
 # ``Dataset``.
 #
@@ -274,7 +274,7 @@ plt.show()
 # Depending on your dataset and what you are trying to do, you might run into problems with
 # xarray and MetPy. Below are examples of some of the most common issues
 #
-# - ``parse_cf`` not able to parse due to conflict
+# - Multiple coordinate conflict
 # - An axis not being available
 # - An axis not being interpretable
 # - Arrays not broadcasting in calculations
@@ -285,27 +285,36 @@ plt.show()
 #
 # ::
 #
-#     temperature = data.metpy.parse_cf('Temperature')
+#     x = data['Temperature'].metpy.x
 #
 # Error Message:
 #
 # ::
 #
-#     /home/user/env/MetPy/metpy/xarray.py:305: UserWarning: DataArray
-#     of requested variable has more than one x coordinate. Specify the
-#     unique axes using the coordinates argument.
+#     /home/user/env/MetPy/metpy/xarray.py:305: UserWarning: More than
+#     one x coordinate present for variable "Temperature".
 #
 # Fix:
 #
-# Specify the ``coordinates`` argument to the ``parse_cf`` method to map the ``T`` (time),
-# ``Z`` (vertical), ``Y``, and ``X`` axes (as applicable to your dataset) to the corresponding
-# coordinates.
+# Manually assign the coordinates using the ``assign_coordinates()`` method on your DataArray,
+# or by specifying the ``coordinates`` argument to the ``parse_cf()`` method on your Dataset,
+# to map the ``T`` (time), ``Z`` (vertical), ``Y``, and ``X`` axes (as applicable to your
+# data) to the corresponding coordinates.
+#
+# ::
+#
+#     data['Temperature'].assign_coordinates({'T': 'time', 'Z': 'isobaric',
+#                                             'Y': 'y', 'X': 'x'})
+#     x = data['Temperature'].metpy.x
+#
+# or
 #
 # ::
 #
 #     temperature = data.metpy.parse_cf('Temperature',
 #                                       coordinates={'T': 'time', 'Z': 'isobaric',
 #                                                    'Y': 'y', 'X': 'x'})
+#     x = temperature.metpy.x
 #
 # **Axis Unavailable**
 #
@@ -324,8 +333,7 @@ plt.show()
 # This means that your data variable does not have the coordinate that was requested, at
 # least as far as the parser can recognize. Verify that you are requesting a
 # coordinate that your data actually has, and if it still is not available,
-# you will need to manually specify the coordinates via the coordinates argument
-# discussed above.
+# you will need to manually specify the coordinates as discussed above.
 #
 # **Axis Not Interpretable**
 #


### PR DESCRIPTION
This PR changes how the systematic coordinate identification is done: previously, the parsing was a part of `parse_cf()` on the Dataset accessor, but now, as requested in #1030, it is done on-demand within the DataArray accessor. This allows the coordinate identification features to be used even when someone only has a DataArray and doesn't have a Dataset. These changes also come with a rename of the accessors to `MetPyDataArrayAccessor` and `MetPyDatasetAccessor`, and changing `check_axis()` from being a class method on the Dataset accessor to a function in the xarray module (since it is now used several times in calc and interpolate). Since it was an easy change along the way, this PR also sets the `keep_attrs` option on `xarray.Dataset.apply()` to `True` in `parse_cf()` to keep the attributes around after parsing.

Closes #1030 and closes #1051.