### PR TITLE
Xarray: Add warning if lat/lon is assumed for projection

### DIFF
--- a/metpy/xarray.py
+++ b/metpy/xarray.py
@@ -370,6 +370,8 @@ class MetPyDatasetAccessor(object):
             # If we found them, create a lat/lon projection as the crs coord
             if has_lat and has_lon:
                 var.coords['crs'] = CFProjection({'grid_mapping_name': 'latitude_longitude'})
+                log.warning('Found lat/lon values, assuming latitude_longitude '
+                            'for projection grid_mapping variable')
 
         # Assign coordinates if the coordinates argument is given
         if coordinates is not None:


### PR DESCRIPTION
Adds a simple warning that latitude_longitude projection is being assumed if no CRS is found and file has lat/lon variables. 

Closes #1039.