### PR TITLE
Conditional import of the DatetimeAccessor due to xarray update

### DIFF
--- a/metpy/xarray.py
+++ b/metpy/xarray.py
@@ -10,7 +10,6 @@ import re
 import warnings
 
 import xarray as xr
-from xarray.core.accessors import DatetimeAccessor
 from xarray.core.indexing import expanded_indexer
 from xarray.core.utils import either_dict_or_kwargs, is_dict_like
 
@@ -475,17 +474,21 @@ def check_matching_coordinates(func):
     return wrapper
 
 
-# If DatetimeAccessor does not have a strftime, monkey patch one in
-if not hasattr(DatetimeAccessor, 'strftime'):
-    def strftime(self, date_format):
-        """Format time as a string."""
-        import pandas as pd
-        values = self._obj.data
-        values_as_series = pd.Series(values.ravel())
-        strs = values_as_series.dt.strftime(date_format)
-        return strs.values.reshape(values.shape)
+# If DatetimeAccessor does not have a strftime (xarray <0.12.2), monkey patch one in
+try:
+    from xarray.core.accessors import DatetimeAccessor
+    if not hasattr(DatetimeAccessor, 'strftime'):
+        def strftime(self, date_format):
+            """Format time as a string."""
+            import pandas as pd
+            values = self._obj.data
+            values_as_series = pd.Series(values.ravel())
+            strs = values_as_series.dt.strftime(date_format)
+            return strs.values.reshape(values.shape)
 
-    DatetimeAccessor.strftime = strftime
+        DatetimeAccessor.strftime = strftime
+except ImportError:
+    pass
 
 
 def _reassign_quantity_indexer(data, indexers):


### PR DESCRIPTION
Xarray v0.12.2 changed how it handles the DatetimeAccessor. As a result, a conditional import is needed to allow for Python 2 support. This can be updated back to a simple import of the v0.12.2 version once Python 2 support is dropped.

Fixes #1077.