### PR TITLE
DOC: Clarify x-axis variables in cross section example

### DIFF
--- a/examples/cross_section.py
+++ b/examples/cross_section.py
@@ -136,3 +136,8 @@ ax.set_xlabel('Longitude (degrees east)')
 rh_colorbar.set_label('Relative Humidity (dimensionless)')
 
 plt.show()
+
+##############################
+# Note: The x-axis can display any variable that is the same length as the
+# plotted variables, including latitude. Additionally, arguments can be provided
+# to ``ax.set_xticklabels`` to label lat/lon pairs, similar to the default NCL output.


### PR DESCRIPTION
Per feedback from an eSupport question, a note was added at the end of the cross-section example that the x-axis variable can be anything of the same length (mainly providing clarification that this can be latitude as well as longitude) and that the axis can be relabeled to look like the NCL example of lat/lon pairs if so desired.