### PR TITLE
Fix pint 0.9 errors from units.wraps and iterable

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy
   - scipy
   - matplotlib
-  - pint!=0.9
+  - pint
   - netcdf4
   - xarray
   - pandas

--- a/metpy/cbook.py
+++ b/metpy/cbook.py
@@ -6,7 +6,6 @@
 import os
 
 import numpy as np
-from numpy import iterable
 import pooch
 
 from . import __version__
@@ -100,6 +99,14 @@ def broadcast_indices(x, minv, ndim, axis):
             dim_inds = np.arange(x.shape[dim])
             ret.append(dim_inds[tuple(broadcast_slice)])
     return tuple(ret)
+
+
+def iterable(value):
+    """Determine if value can be iterated over."""
+    # Special case for pint Quantities
+    if hasattr(value, 'magnitude'):
+        value = value.magnitude
+    return np.iterable(value)
 
 
 __all__ = ('Registry', 'broadcast_indices', 'get_test_data', 'is_string_like', 'iterable')

--- a/metpy/tests/test_units.py
+++ b/metpy/tests/test_units.py
@@ -8,6 +8,7 @@ import sys
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import pint
 import pytest
 
 from metpy.testing import assert_array_almost_equal, assert_array_equal
@@ -35,6 +36,8 @@ def test_concatenate_masked():
     assert_array_equal(result.mask, np.array([False, True, False, False]))
 
 
+@pytest.mark.skipif(pint.__version__ == '0.9', reason=('Currently broken upstream (see '
+                                                       'pint#751'))
 @pytest.mark.mpl_image_compare(tolerance=0, remove_text=True)
 def test_axhline():
     r"""Ensure that passing a quantity to axhline does not error."""
@@ -45,6 +48,8 @@ def test_axhline():
     return fig
 
 
+@pytest.mark.skipif(pint.__version__ == '0.9', reason=('Currently broken upstream (see '
+                                                       'pint#751'))
 @pytest.mark.mpl_image_compare(tolerance=0, remove_text=True)
 def test_axvline():
     r"""Ensure that passing a quantity to axvline does not error."""

--- a/metpy/units.py
+++ b/metpy/units.py
@@ -18,6 +18,7 @@ from __future__ import division
 
 import functools
 import logging
+import warnings
 
 import numpy as np
 import pint
@@ -45,6 +46,10 @@ try:
     units._units['gpm'] = units._units['meter']
 except AttributeError:
     log.warning('Failed to add gpm alias to meters.')
+
+# Silence UnitStrippedWarning
+if hasattr(pint, 'UnitStrippedWarning'):
+    warnings.simplefilter('ignore', category=pint.UnitStrippedWarning)
 
 
 def pandas_dataframe_to_unit_arrays(df, column_units=None):

--- a/metpy/units.py
+++ b/metpy/units.py
@@ -322,7 +322,7 @@ def check_units(*units_by_pos, **units_by_name):
 try:
     # Try to enable pint's built-in support
     units.setup_matplotlib()
-except (AttributeError, RuntimeError):  # Pint's not available, try to enable our own
+except (AttributeError, RuntimeError, ImportError):  # Pint's not available, try our own
     import matplotlib.units as munits
 
     # Inheriting from object fixes the fact that matplotlib 1.4 doesn't

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
 
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
     install_requires=['matplotlib>=2.0.0', 'numpy>=1.12.0', 'scipy>=0.17.0',
-                      'pint!=0.9', 'xarray>=0.10.7', 'enum34;python_version<"3.4"',
+                      'pint', 'xarray>=0.10.7', 'enum34;python_version<"3.4"',
                       'contextlib2;python_version<"3.6"',
                       'pooch>=0.1', 'traitlets>=4.3.0'],
     extras_require={


### PR DESCRIPTION
As discussed in #997, there were two main issues with pint 0.9 and MetPy: `@units.wraps` and single value Quantities being evaluated as iterable. This PR implements an alternate way of ensuring matching units (and stripping the units) for the interpolation functions that previously used `@units.wraps`, as well as an `iterable` function that checks against the magnitude of the argument.

The two tests with matplotlib and scalar Quantities remain broken. I marked them as skipped for pint 0.9, but if a monkey patch of some kind based on the fix discussed in https://github.com/hgrecco/pint/issues/751 is preferred, I can see what can be done.

Fixes #997.