### PR TITLE
Force x and y to be np.arrays within StationPlot

### DIFF
--- a/metpy/plots/station_plot.py
+++ b/metpy/plots/station_plot.py
@@ -15,6 +15,7 @@ from .wx_symbols import (current_weather, high_clouds, low_clouds, mid_clouds,
                          pressure_tendency, sky_cover, wx_symbol_font)
 from ..cbook import is_string_like
 from ..package_tools import Exporter
+from ..units import atleast_1d
 
 exporter = Exporter(globals())
 
@@ -59,8 +60,8 @@ class StationPlot(object):
 
         """
         self.ax = ax
-        self.x = x
-        self.y = y
+        self.x = atleast_1d(x)
+        self.y = atleast_1d(y)
         self.fontsize = fontsize
         self.spacing = fontsize if spacing is None else spacing
         self.transform = transform

--- a/metpy/plots/tests/test_station_plot.py
+++ b/metpy/plots/tests/test_station_plot.py
@@ -277,6 +277,20 @@ def test_barb_projection():
     return fig
 
 
+def test_barb_projection_list():
+    """Test that barbs will be projected when lat/lon lists are provided."""
+    lat = [38.22, 38.18, 38.25]
+    lon = [-85.76, -85.86, -85.77]
+    u = [1.89778964, -3.83776523, 3.64147732] * units('m/s')
+    v = [1.93480072, 1.31000184, 1.36075552] * units('m/s')
+
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1)
+    stnplot = StationPlot(ax, lon, lat)
+    stnplot.plot_barb(u, v)
+    assert stnplot.barbs
+
+
 @pytest.mark.mpl_image_compare(tolerance={'1.4': 2.28}.get(MPL_VERSION, 0.0048),
                                remove_text=True)
 def test_barb_unit_conversion():


### PR DESCRIPTION
As raised by an eSupport issue, x and y need to be arrays in order for CartoPy to transform wind barbs within StationPlot.