### PR TITLE
Specific Humidity From Dewpoint

### DIFF
--- a/docs/_templates/overrides/metpy.calc.rst
+++ b/docs/_templates/overrides/metpy.calc.rst
@@ -51,6 +51,7 @@ calc
       saturation_equivalent_potential_temperature
       saturation_mixing_ratio
       saturation_vapor_pressure
+      specific_humidity_from_dewpoint
       specific_humidity_from_mixing_ratio
       thickness_hydrostatic_from_relative_humidity
       vapor_pressure

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -25,6 +25,7 @@ from metpy.calc import (brunt_vaisala_frequency, brunt_vaisala_frequency_squared
                         saturation_equivalent_potential_temperature,
                         saturation_mixing_ratio,
                         saturation_vapor_pressure,
+                        specific_humidity_from_dewpoint,
                         specific_humidity_from_mixing_ratio, static_stability,
                         surface_based_cape_cin, temperature_from_potential_temperature,
                         thickness_hydrostatic,
@@ -1319,3 +1320,10 @@ def test_vertical_velocity_moist_air():
     w_truth = 0.968897557 * units('cm/s')
     w_test = vertical_velocity(omega, 850. * units.mbar, 280. * units.K, 8 * units('g/kg'))
     assert_almost_equal(w_test, w_truth, 6)
+
+
+def test_specific_humidity_from_dewpoint():
+    """Specific humidity from dewpoint."""
+    p = 1013.25 * units.mbar
+    q = specific_humidity_from_dewpoint(16.973 * units.degC, p)
+    assert_almost_equal(q, 0.012 * units.dimensionless, 3)

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -2427,7 +2427,7 @@ def specific_humidity_from_dewpoint(dewpoint, pressure):
     dewpoint: `pint.Quantity`
         dewpoint temperature
 
-    pressure: `pint.Quantity
+    pressure: `pint.Quantity`
         pressure
 
     Returns

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -2414,3 +2414,31 @@ def vertical_velocity(omega, pressure, temperature, mixing=0):
     """
     rho = density(pressure, temperature, mixing)
     return (omega / (- mpconsts.g * rho)).to('m/s')
+
+
+@exporter.export
+@preprocess_xarray
+@check_units('[temperature]', '[pressure]')
+def specific_humidity_from_dewpoint(dewpoint, pressure):
+    r"""Calculate the specific humidity from the dewpoint temperature and pressure.
+
+    Parameters
+    ----------
+    dewpoint: `pint.Quantity`
+        dewpoint temperature
+
+    pressure: `pint.Quantity
+        pressure
+
+    Returns
+    -------
+    `pint.Quantity`
+        Specific humidity
+
+    See Also
+    --------
+    mixing_ratio, saturation_mixing_ratio
+
+    """
+    mixing_ratio = saturation_mixing_ratio(pressure, dewpoint)
+    return specific_humidity_from_mixing_ratio(mixing_ratio)


### PR DESCRIPTION
Calculate specific humidity from dew point temperature and pressure. Leverages existing computations for saturation mixing ratio and specific humidity from mixing ratio. Test uses same values as in test_dewpoint_specific_humidity. Closes #791 