### PR TITLE
Drop central_longitude from mercator projection

### DIFF
--- a/metpy/plots/mapping.py
+++ b/metpy/plots/mapping.py
@@ -139,11 +139,13 @@ def make_mercator(attrs_dict, globe):
     kwargs = CFProjection.build_projection_kwargs(attrs_dict, attr_mapping)
 
     # Work around the fact that in CartoPy <= 0.16 can't handle the easting/northing
-    # in Mercator
+    # or central_latitude in Mercator
     if not kwargs.get('false_easting'):
         kwargs.pop('false_easting', None)
     if not kwargs.get('false_northing'):
         kwargs.pop('false_northing', None)
+    if not kwargs.get('central_latitude'):
+        kwargs.pop('central_latitude', None)
 
     return ccrs.Mercator(globe=globe, **kwargs)
 

--- a/metpy/plots/tests/test_mapping.py
+++ b/metpy/plots/tests/test_mapping.py
@@ -98,7 +98,8 @@ def test_lcc_single_std_parallel():
 def test_mercator():
     """Test handling a mercator projection."""
     attrs = {'grid_mapping_name': 'mercator', 'standard_parallel': 25,
-             'longitude_of_projection_origin': -100, 'false_easting': 0, 'false_westing': 0}
+             'longitude_of_projection_origin': -100, 'false_easting': 0, 'false_westing': 0,
+             'central_latitude': 0}
     crs = CFProjection(attrs).to_cartopy()
 
     assert isinstance(crs, ccrs.Mercator)


### PR DESCRIPTION
Drop `central_longitude` from `attrs`, similar to what's done in `make_geo`.

Closes #1101.