### PR TITLE
More links to Python Gallery

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,9 @@ still evolving (we won't break things just for fun, but many things are still ch
 work through design issues). Also, for a version `0.x.y`, we change `x` when we
 release new features, and `y` when we make a release with only bug fixes.
 
+For additional MetPy examples not included in this repository, please see the `Unidata Python
+Gallery <https://unidata.github.io/python-gallery/>`_.
+
 We support Python >= 3.6 and currently support Python 2.7.
 
 NOTE: We are dropping support for Python 2.7 in Fall 2019. See

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,9 @@ still evolving (we won't break things just for fun, but many things are still ch
 work through design issues). Also, for a version `0.x.y`, we change `x` when we
 release new features, and `y` when we make a release with only bug fixes.
 
+For additional MetPy examples not included in this repository, please see the `Unidata Python
+Gallery <https://unidata.github.io/python-gallery/>`_.
+
 We support Python >= 3.6 and currently support Python 2.7.
 
 .. warning::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,6 +71,8 @@ __ https://github.com/Unidata/MetPy/issues
 Media
 -----
 
+* `AMS 2019 talk`_ on bringing GEMPAK-like syntax to MetPy's declaritive plotting interface
+* `AMS 2019 poster`_ on recent development and community building with MetPy
 * `SciPy 2018 poster`_ and `abstract <http://johnrleeman.com/pubs/2018/Leeman_2018_SciPy_Abstract.pdf>`_ on building community by John Leeman
 * `SciPy 2018 talk`_ on prototyping MetPy's future declarative plotting interface
 * Presentation on MetPy and Community Development at the `2018 AMS Annual Meeting`_ by Ryan May
@@ -96,6 +98,8 @@ Media
 .. _`2018 AMS Annual Meeting`: https://ams.confex.com/ams/98Annual/webprogram/Paper333578.html
 .. _`SciPy 2018 talk`: https://youtu.be/OKQlUdPY0Jc
 .. _`SciPy 2018 poster`: http://johnrleeman.com/pubs/2018/Leeman_2018_SciPy_Poster.pdf
+.. _`AMS 2019 talk`: https://ams.confex.com/ams/2019Annual/meetingapp.cgi/Paper/352384
+.. _`AMS 2019 poster`: https://ams.confex.com/ams/2019Annual/meetingapp.cgi/Paper/354058
 
 -------
 License

--- a/docs/installguide.rst
+++ b/docs/installguide.rst
@@ -74,4 +74,5 @@ Examples
 
 The MetPy source comes with a set of example scripts in the ``examples``
 directory. These are also available as notebooks in the gallery in
-the :doc:`examples/index`.
+the :doc:`examples/index`. Further examples of MetPy usage are available
+in the `Unidata Python Gallery <https://unidata.github.io/python-gallery/>`_.

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -3,6 +3,8 @@
 Examples
 ========
 
+For more MetPy examples, please visit the `Unidata Python Gallery
+<https://unidata.github.io/python-gallery/>`_.
 
 .. _general-examples:
 


### PR DESCRIPTION
Given conversations at SciPy, we should have more links to the Python Gallery throughout the documentation (until we decide what to do with the gallery in the long-term). I think I caught more of them, but happy to add more as desired.