### PR TITLE
Updates for testing

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -25,6 +25,7 @@ coverage:
         paths:
           - "metpy/.*/tests/.*"
           - "metpy/tests/.*"
+          - "metpy/testing.py"
 
   notify:
     gitter:

--- a/metpy/calc/tests/test_basic.py
+++ b/metpy/calc/tests/test_basic.py
@@ -14,8 +14,8 @@ from metpy.calc import (add_height_to_pressure, add_pressure_to_height,
                         pressure_to_height_std, sigma_to_pressure, smooth_gaussian,
                         smooth_n_point, wind_components, wind_direction, wind_speed,
                         windchill)
-from metpy.deprecation import MetpyDeprecationWarning
-from metpy.testing import assert_almost_equal, assert_array_almost_equal, assert_array_equal
+from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal,
+                           check_and_silence_deprecation)
 from metpy.units import units
 
 
@@ -137,25 +137,25 @@ def test_scalar_direction():
     assert_almost_equal(d, 216.870 * units.deg, 3)
 
 
+@check_and_silence_deprecation
 def test_get_wind_components():
     """Test that get_wind_components wrapper works (deprecated in 0.9)."""
-    with pytest.warns(MetpyDeprecationWarning):
-        u, v = get_wind_components(8 * units('m/s'), 150 * units.deg)
+    u, v = get_wind_components(8 * units('m/s'), 150 * units.deg)
     assert_almost_equal(u, -4 * units('m/s'), 3)
     assert_almost_equal(v, 6.9282 * units('m/s'), 3)
 
 
+@check_and_silence_deprecation
 def test_get_wind_speed():
     """Test that get_wind_speed wrapper works (deprecated in 0.9)."""
-    with pytest.warns(MetpyDeprecationWarning):
-        s = get_wind_speed(-3. * units('m/s'), -4. * units('m/s'))
+    s = get_wind_speed(-3. * units('m/s'), -4. * units('m/s'))
     assert_almost_equal(s, 5. * units('m/s'), 3)
 
 
+@check_and_silence_deprecation
 def test_get_wind_dir():
     """Test that get_wind_dir wrapper works (deprecated in 0.9)."""
-    with pytest.warns(MetpyDeprecationWarning):
-        d = get_wind_dir(3. * units('m/s'), 4. * units('m/s'))
+    d = get_wind_dir(3. * units('m/s'), 4. * units('m/s'))
     assert_almost_equal(d, 216.870 * units.deg, 3)
 
 

--- a/metpy/calc/tests/test_calc_tools.py
+++ b/metpy/calc/tests/test_calc_tools.py
@@ -20,7 +20,8 @@ from metpy.calc.tools import (_delete_masked_points, _get_bound_pressure_height,
                               _greater_or_close, _less_or_close, _next_non_masked_element,
                               DIR_STRS)
 from metpy.deprecation import MetpyDeprecationWarning
-from metpy.testing import assert_almost_equal, assert_array_almost_equal, assert_array_equal
+from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal,
+                           check_and_silence_deprecation)
 from metpy.units import units
 
 
@@ -105,6 +106,7 @@ def test_find_intersections_intersections_in_data_at_ends(direction, expected):
     assert_array_almost_equal(expected, find_intersections(x, y1, y2, direction=direction), 2)
 
 
+@check_and_silence_deprecation
 def test_interpolate_nan_linear():
     """Test deprecated interpolate_nans function."""
     x = np.linspace(0, 20, 15)
@@ -112,8 +114,7 @@ def test_interpolate_nan_linear():
     nan_indexes = [1, 5, 11, 12]
     y_with_nan = y.copy()
     y_with_nan[nan_indexes] = np.nan
-    with pytest.warns(MetpyDeprecationWarning):
-        assert_array_almost_equal(y, interpolate_nans(x, y_with_nan), 2)
+    assert_array_almost_equal(y, interpolate_nans(x, y_with_nan), 2)
 
 
 @pytest.mark.parametrize('mask, expected_idx, expected_element', [
@@ -190,25 +191,25 @@ def test_delete_masked_points():
     assert_array_equal(b, expected)
 
 
+@check_and_silence_deprecation
 def test_interp():
     """Test deprecated interp function."""
     x = np.array([1., 2., 3., 4.])
     y = x
     x_interp = np.array([3.5000000, 2.5000000])
     y_interp_truth = np.array([3.5000000, 2.5000000])
-    with pytest.warns(MetpyDeprecationWarning):
-        y_interp = interp(x_interp, x, y)
+    y_interp = interp(x_interp, x, y)
     assert_array_almost_equal(y_interp, y_interp_truth, 7)
 
 
+@check_and_silence_deprecation
 def test_log_interp():
     """Test deprecated log_interp function."""
     x_log = np.array([1e3, 1e4, 1e5, 1e6])
     y_log = np.log(x_log) * 2 + 3
     x_interp = np.array([5e3, 5e4, 5e5])
     y_interp_truth = np.array([20.0343863828, 24.6395565688, 29.2447267548])
-    with pytest.warns(MetpyDeprecationWarning):
-        y_interp = log_interp(x_interp, x_log, y_log)
+    y_interp = log_interp(x_interp, x_log, y_log)
     assert_array_almost_equal(y_interp, y_interp_truth, 7)
 
 

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -347,8 +347,8 @@ def test_no_lfc():
     temperatures = np.array([22.2, 17.4, 14.6, 1.4, -17.6, -39.4, -52.5]) * units.celsius
     dewpoints = np.array([9., 4.3, -21.2, -26.7, -31., -53.3, -66.7]) * units.celsius
     lfc_pressure, lfc_temperature = lfc(levels, temperatures, dewpoints)
-    assert assert_nan(lfc_pressure, levels.units)
-    assert assert_nan(lfc_temperature, temperatures.units)
+    assert_nan(lfc_pressure, levels.units)
+    assert_nan(lfc_temperature, temperatures.units)
 
 
 def test_lfc_inversion():
@@ -432,8 +432,8 @@ def test_lfc_pos_area_below_lcl():
           -92.92464, -91.57479] * units.degC
     prof = parcel_profile(p, t[0], td[0]).to('degC')
     lfc_p, lfc_t = lfc(p, t, td, prof)
-    assert assert_nan(lfc_p, p.units)
-    assert assert_nan(lfc_t, t.units)
+    assert_nan(lfc_p, p.units)
+    assert_nan(lfc_t, t.units)
 
 
 def test_saturation_mixing_ratio():
@@ -516,8 +516,8 @@ def test_no_el():
     temperatures = np.array([22.2, 17.4, 14.6, 1.4, -17.6, -39.4, -52.5]) * units.celsius
     dewpoints = np.array([19., 14.3, -11.2, -16.7, -21., -43.3, -56.7]) * units.celsius
     el_pressure, el_temperature = el(levels, temperatures, dewpoints)
-    assert assert_nan(el_pressure, levels.units)
-    assert assert_nan(el_temperature, temperatures.units)
+    assert_nan(el_pressure, levels.units)
+    assert_nan(el_temperature, temperatures.units)
 
 
 def test_no_el_multi_crossing():
@@ -530,8 +530,8 @@ def test_no_el_multi_crossing():
     dewpoints = np.array([19.5, 17.8, 16.7, 16.5, 15.8, 15.7, 15.3, 13.1, 12.9, 11.9, 6.4,
                           3.2, 2.6, -0.6, -4.4, -6.6, -9.3, -10.4, -10.5]) * units.celsius
     el_pressure, el_temperature = el(levels, temperatures, dewpoints)
-    assert assert_nan(el_pressure, levels.units)
-    assert assert_nan(el_temperature, temperatures.units)
+    assert_nan(el_pressure, levels.units)
+    assert_nan(el_temperature, temperatures.units)
 
 
 def test_el_lfc_equals_lcl():
@@ -567,8 +567,8 @@ def test_el_small_surface_instability():
                           -10.4, -10.2, -9.8, -9.4, -9., -15.8, -15.7, -14.8, -14.,
                           -13.9, -17.9]) * units.degC
     el_pressure, el_temperature = el(levels, temperatures, dewpoints)
-    assert assert_nan(el_pressure, levels.units)
-    assert assert_nan(el_temperature, temperatures.units)
+    assert_nan(el_pressure, levels.units)
+    assert_nan(el_temperature, temperatures.units)
 
 
 def test_no_el_parcel_colder():
@@ -586,8 +586,8 @@ def test_no_el_parcel_colder():
                           -8.8, -28.1, -18.9, -14.5, -15.2, -15.1, -21.6, -41.5, -45.5,
                           -29.6, -30.6, -32.1]) * units.celsius
     el_pressure, el_temperature = el(levels, temperatures, dewpoints)
-    assert assert_nan(el_pressure, levels.units)
-    assert assert_nan(el_temperature, temperatures.units)
+    assert_nan(el_pressure, levels.units)
+    assert_nan(el_temperature, temperatures.units)
 
 
 def test_el_below_lcl():
@@ -611,8 +611,8 @@ def test_el_below_lcl():
           -92.92464, -91.57479] * units.degC
     prof = parcel_profile(p, t[0], td[0]).to('degC')
     el_p, el_t = el(p, t, td, prof)
-    assert assert_nan(el_p, p.units)
-    assert assert_nan(el_t, t.units)
+    assert_nan(el_p, p.units)
+    assert_nan(el_t, t.units)
 
 
 def test_wet_psychrometric_vapor_pressure():

--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -672,9 +672,23 @@ def test_mixing_ratio_from_specific_humidity():
     assert_almost_equal(w, 0.01215, 3)
 
 
+def test_mixing_ratio_from_specific_humidity_no_units():
+    """Test mixing ratio from specific humidity works without units."""
+    q = 0.012
+    w = mixing_ratio_from_specific_humidity(q)
+    assert_almost_equal(w, 0.01215, 3)
+
+
 def test_specific_humidity_from_mixing_ratio():
     """Test specific humidity from mixing ratio."""
     w = 0.01215 * units.dimensionless
+    q = specific_humidity_from_mixing_ratio(w)
+    assert_almost_equal(q, 0.01200, 5)
+
+
+def test_specific_humidity_from_mixing_ratio_no_units():
+    """Test specific humidity from mixing ratio works without units."""
+    w = 0.01215
     q = specific_humidity_from_mixing_ratio(w)
     assert_almost_equal(q, 0.01200, 5)
 
@@ -793,7 +807,7 @@ def test_isentropic_pressure_p_increase():
     assert_almost_equal(isentprs[0], trueprs, 3)
 
 
-def test_isentropic_pressure_adition_args():
+def test_isentropic_pressure_additional_args():
     """Test calculation of isentropic pressure function, additional args."""
     lev = [100000., 95000., 90000., 85000.] * units.Pa
     tmp = np.ones((4, 5, 5))

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -1694,11 +1694,8 @@ def isentropic_interpolation(theta_levels, pressure, temperature, *args, **kwarg
     # do an interpolation for each additional argument
     if args:
         others = interpolate_1d(isentlevels, pres_theta.m, *(arr[sorter] for arr in args),
-                                axis=axis)
-        if len(args) > 1:
-            ret.extend(others)
-        else:
-            ret.append(others)
+                                axis=axis, return_list_always=True)
+        ret.extend(others)
 
     return ret
 

--- a/metpy/interpolate/geometry.py
+++ b/metpy/interpolate/geometry.py
@@ -148,45 +148,6 @@ def distance(p0, p1):
     return math.sqrt(dist_2(p0[0], p0[1], p1[0], p1[1]))
 
 
-def circumcircle_radius_2(pt0, pt1, pt2):
-    r"""Calculate and return the squared radius of a given triangle's circumcircle.
-
-    This is faster than calculating radius but should only be used with comparable ratios.
-
-    Parameters
-    ----------
-    pt0: (x, y)
-        Starting vertex of triangle
-    pt1: (x, y)
-        Second vertex of triangle
-    pt2: (x, y)
-        Final vertex of a triangle
-
-    Returns
-    -------
-    r: float
-        circumcircle radius
-
-    See Also
-    --------
-    circumcenter
-
-    """
-    a = distance(pt0, pt1)
-    b = distance(pt1, pt2)
-    c = distance(pt2, pt0)
-
-    t_area = triangle_area(pt0, pt1, pt2)
-    prod2 = a * b * c
-
-    if t_area > 0:
-        radius = prod2 * prod2 / (16 * t_area * t_area)
-    else:
-        radius = np.nan
-
-    return radius
-
-
 def circumcircle_radius(pt0, pt1, pt2):
     r"""Calculate and return the radius of a given triangle's circumcircle.
 
@@ -365,9 +326,9 @@ def find_nn_triangles_point(tri, cur_tri, point):
 
         triangle = tri.points[tri.simplices[neighbor]]
         cur_x, cur_y = circumcenter(triangle[0], triangle[1], triangle[2])
-        r = circumcircle_radius_2(triangle[0], triangle[1], triangle[2])
+        r = circumcircle_radius(triangle[0], triangle[1], triangle[2])
 
-        if dist_2(point[0], point[1], cur_x, cur_y) < r:
+        if dist_2(point[0], point[1], cur_x, cur_y) < r * r:
 
             nn.append(neighbor)
 

--- a/metpy/interpolate/one_dimension.py
+++ b/metpy/interpolate/one_dimension.py
@@ -76,6 +76,10 @@ def interpolate_1d(x, xp, *args, **kwargs):
         Specify handling of interpolation points out of data bounds. If None, will return
         ValueError if points are out of bounds. Defaults to nan.
 
+    return_list_always: bool, optional
+        Whether to always return a list of interpolated arrays, even when only a single
+        array is passed to `args`. Defaults to ``False``.
+
     Returns
     -------
     array-like
@@ -97,6 +101,7 @@ def interpolate_1d(x, xp, *args, **kwargs):
     # Pull out keyword args
     fill_value = kwargs.pop('fill_value', np.nan)
     axis = kwargs.pop('axis', 0)
+    return_list_always = kwargs.pop('return_list_always', False)
 
     # Handle units
     x, xp = _strip_matching_units(x, xp)
@@ -168,10 +173,11 @@ def interpolate_1d(x, xp, *args, **kwargs):
             var_interp = np.swapaxes(np.swapaxes(var_interp, 0, axis)[::-1], 0, axis)
         # Output to list
         ret.append(var_interp)
-    if len(ret) == 1:
-        return ret[0]
-    else:
+
+    if return_list_always or len(ret) > 1:
         return ret
+    else:
+        return ret[0]
 
 
 @exporter.export

--- a/metpy/interpolate/tests/test_geometry.py
+++ b/metpy/interpolate/tests/test_geometry.py
@@ -11,9 +11,8 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_almost_equal, assert_array_equal
 from scipy.spatial import Delaunay
 
-from metpy.interpolate.geometry import (area, circumcenter, circumcircle_radius,
-                                        circumcircle_radius_2, dist_2, distance,
-                                        find_local_boundary, find_natural_neighbors,
+from metpy.interpolate.geometry import (area, circumcenter, circumcircle_radius, dist_2,
+                                        distance, find_local_boundary, find_natural_neighbors,
                                         find_nn_triangles_point, get_point_count_within_r,
                                         get_points_within_r, order_edges, triangle_area)
 
@@ -104,19 +103,6 @@ def test_distance():
     assert_almost_equal(truth, dist)
 
 
-def test_circumcircle_radius_2():
-    r"""Test squared circumcircle radius function."""
-    pt0 = [0, 0]
-    pt1 = [10, 10]
-    pt2 = [10, 0]
-
-    cc_r2 = circumcircle_radius_2(pt0, pt1, pt2)
-
-    truth = 50
-
-    assert_almost_equal(truth, cc_r2, decimal=2)
-
-
 def test_circumcircle_radius():
     r"""Test circumcircle radius function."""
     pt0 = [0, 0]
@@ -128,6 +114,15 @@ def test_circumcircle_radius():
     truth = 7.07
 
     assert_almost_equal(truth, cc_r, decimal=2)
+
+
+def test_circumcircle_radius_degenerate():
+    """Test that circumcircle_radius handles a degenerate triangle."""
+    pt0 = [0, 0]
+    pt1 = [10, 10]
+    pt2 = [0, 0]
+
+    assert np.isnan(circumcircle_radius(pt0, pt1, pt2))
 
 
 def test_circumcenter():

--- a/metpy/testing.py
+++ b/metpy/testing.py
@@ -196,11 +196,12 @@ def patch_round(monkeypatch):
     monkeypatch.setitem(__builtins__, 'round', np.round)
 
 
-def ignore_deprecation(func):
+def check_and_silence_deprecation(func):
     """Decorate a function to swallow metpy deprecation warnings, making sure they are present.
 
-    This should be used on deprecation function tests to make sure the deprecation warnings
-    are not failing the tests, but still allow testing of those functions.
+    This should be used on deprecated function tests to make sure the deprecation warnings
+    are not printing in the tests, but checks that the warning is present and makes sure
+    the function still works as intended.
     """
     @functools.wraps(func)
     def wrapper(*args, **kwargs):

--- a/metpy/testing.py
+++ b/metpy/testing.py
@@ -135,11 +135,8 @@ def check_and_drop_units(actual, desired):
 
 def assert_nan(value, units):
     """Check for nan with proper units."""
-    if not np.isnan(value):
-        pytest.fail('{} is not np.nan'.format(value))
-
-    check_and_drop_units(value, np.nan * units)
-    return True
+    value, _ = check_and_drop_units(value, np.nan * units)
+    assert np.isnan(value)
 
 
 def assert_almost_equal(actual, desired, decimal=7):

--- a/metpy/tests/test_units.py
+++ b/metpy/tests/test_units.py
@@ -12,7 +12,7 @@ import pint
 import pytest
 
 from metpy.testing import assert_array_almost_equal, assert_array_equal
-from metpy.testing import set_agg_backend  # noqa: F401
+from metpy.testing import assert_nan, set_agg_backend  # noqa: F401
 from metpy.units import (atleast_1d, atleast_2d, check_units, concatenate, diff,
                          pandas_dataframe_to_unit_arrays, units)
 
@@ -205,3 +205,15 @@ def test_gpm_unit():
     """Test that the gpm unit does alias to meters."""
     x = 1 * units('gpm')
     assert str(x.units) == 'meter'
+
+
+def test_assert_nan():
+    """Test that assert_nan actually fails when not given a NaN."""
+    with pytest.raises(AssertionError):
+        assert_nan(1.0 * units.m, units.inches)
+
+
+def test_assert_nan_checks_units():
+    """Test that assert_nan properly checks units."""
+    with pytest.raises(AssertionError):
+        assert_nan(np.nan * units.m, units.second)


### PR DESCRIPTION
* Update implementation of `assert_nan` to actually assert rather than call `pytest.fail()`.
* Add some tests for failing cases in test code--these weren't covered before
* Make `testing.py` count as part of the `tests` target for codecov. This way we can ensure we're actually running all of it

I expect this to fail right now because we have an `ignore_deprecation` decorator that's not used. Once I prove that codecov fails, I'll be updating to rename and use that decorator across the test suite.

**Update**
So now I've also:
* Used the decorator for tests of deprecated functionality
* Added a couple more tests to hit a few uncovered lines
* Completely blew away an unnecessary function in `geometry.py` and improved coverage there
* Reworked a bit of `isentropic_interpolation` to remove an untested line