### PR TITLE
Include LCL in MUCIN calculations if parcel starts below LCL

### DIFF
--- a/metpy/calc/tests/test_thermo.py
+++ b/metpy/calc/tests/test_thermo.py
@@ -960,7 +960,7 @@ def test_most_unstable_cape_cin_surface():
     dewpoint = np.array([19., -11.2, -10.8, -10.4, -10., -53.2]) * units.celsius
     mucape, mucin = most_unstable_cape_cin(pressure, temperature, dewpoint)
     assert_almost_equal(mucape, 75.7340825 * units('joule / kilogram'), 6)
-    assert_almost_equal(mucin, -89.8179205 * units('joule / kilogram'), 6)
+    assert_almost_equal(mucin, -136.607809 * units('joule / kilogram'), 6)
 
 
 def test_most_unstable_cape_cin():
@@ -970,7 +970,7 @@ def test_most_unstable_cape_cin():
     dewpoint = np.array([19., 19., 14.3, 0., -10., 0.]) * units.celsius
     mucape, mucin = most_unstable_cape_cin(pressure, temperature, dewpoint)
     assert_almost_equal(mucape, 157.1401 * units('joule / kilogram'), 4)
-    assert_almost_equal(mucin, -15.75216 * units('joule / kilogram'), 4)
+    assert_almost_equal(mucin, -31.82547 * units('joule / kilogram'), 4)
 
 
 def test_mixed_parcel():

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -1774,13 +1774,11 @@ def most_unstable_cape_cin(pressure, temperature, dewpoint, **kwargs):
     cape_cin, most_unstable_parcel, parcel_profile
 
     """
-    _, parcel_temperature, parcel_dewpoint, parcel_idx = most_unstable_parcel(pressure,
-                                                                              temperature,
-                                                                              dewpoint,
-                                                                              **kwargs)
-    mu_profile = parcel_profile(pressure[parcel_idx:], parcel_temperature, parcel_dewpoint)
-    return cape_cin(pressure[parcel_idx:], temperature[parcel_idx:],
-                    dewpoint[parcel_idx:], mu_profile)
+    _, _, _, parcel_idx = most_unstable_parcel(pressure, temperature, dewpoint, **kwargs)
+    p, t, td, mu_profile = parcel_profile_with_lcl(pressure[parcel_idx:],
+                                                   temperature[parcel_idx:],
+                                                   dewpoint[parcel_idx:])
+    return cape_cin(p, t, td, mu_profile)
 
 
 @exporter.export


### PR DESCRIPTION
Previously, the SBCIN and MUCIN did not match values. This was due to the exclusion of the LCL as a point in the MU profile, while it was included in the SB profile. This PR adds a conditional statement to examine if the most unstable parcel starts below the LCL, and if so, includes the LCL in the profile path. Otherwise, the calculation remains the same as before. 

Closes #1108.