### PR TITLE
plot_colormapped update for Hodograph

### DIFF
--- a/examples/plots/Hodograph_Inset.py
+++ b/examples/plots/Hodograph_Inset.py
@@ -38,6 +38,7 @@ df = df.dropna(subset=('temperature', 'dewpoint', 'direction', 'speed',
 # We will pull the data out of the example dataset into individual variables and
 # assign units.
 
+hght = df['height'].values * units.hPa
 p = df['pressure'].values * units.hPa
 T = df['temperature'].values * units.degC
 Td = df['dewpoint'].values * units.degC
@@ -73,7 +74,7 @@ skew.ax.set_xlim(-50, 60)
 ax_hod = inset_axes(skew.ax, '40%', '40%', loc=1)
 h = Hodograph(ax_hod, component_range=80.)
 h.add_grid(increment=20)
-h.plot_colormapped(u, v, np.hypot(u, v))
+h.plot_colormapped(u, v, hght)
 
 # Show the plot
 plt.show()

--- a/metpy/plots/skewt.py
+++ b/metpy/plots/skewt.py
@@ -791,20 +791,17 @@ class Hodograph(object):
         return self.ax.quiver(center_position, center_position,
                               u, v, **quiver_args)
 
-    def plot_colormapped(self, u, v, c, bounds=None, colors=None, **kwargs):
+    def plot_colormapped(self, u, v, c, cint=None, colors=None, **kwargs):
         r"""Plot u, v data, with line colored based on a third set of data.
 
         Plots the wind data on the hodograph, but with a colormapped line. Takes a third
-        variable besides the winds and either a colormap to color it with or a series of
-        bounds and colors to create a colormap and norm to control colormapping.
-        The bounds must always be in increasing order. For using custom bounds with
-        height data, the function will automatically interpolate to the actual bounds from the
-        height and wind data, as well as convert the input bounds from
-        height AGL to height above MSL to work with the provided heights.
-
-        Simple wrapper around plot so that pressure is the first (independent)
-        input. This is essentially a wrapper around `semilogy`. It also
-        sets some appropriate ticking and plot ranges.
+        variable besides the winds (e.g. heights or pressure levels) and either a colormap to
+        color it with or a series of contour intervals and colors to create a colormap and
+        norm to control colormapping. The contour intervals (`cint`) must always be in
+        increasing order. For using custom contour intervals with height data, the function
+        will automatically interpolate to the contour intervals from the height and wind data,
+        as well as convert the input contour intervals from height AGL to MSL to work with the
+        provided heights.
 
         Parameters
         ----------
@@ -813,9 +810,9 @@ class Hodograph(object):
         v : array_like
             v-component of wind
         c : array_like
-            data to use for colormapping
-        bounds: array-like, optional
-            Array of bounds for c to use in coloring the hodograph.
+            data to use for colormapping (e.g. heights, pressure, wind speed)
+        cint: array-like, optional
+            Array of contour intervals for c to use in coloring the hodograph.
         colors: list, optional
             Array of strings representing colors for the hodograph segments.
         kwargs
@@ -836,12 +833,12 @@ class Hodograph(object):
         # Plotting a color segmented hodograph
         if colors:
             cmap = mcolors.ListedColormap(colors)
-            # If we are segmenting by height (a length), interpolate the bounds
-            if bounds.dimensionality == {'[length]': 1.0}:
+            # If we are segmenting by height (a length), interpolate the contour intervals
+            if cint.dimensionality == {'[length]': 1.0}:
 
-                # Find any bounds not in the data and interpolate them
-                interpolation_heights = [bound.m for bound in bounds if bound not in c]
-                interpolation_heights = np.array(interpolation_heights) * bounds.units
+                # Find any contour intervals not in the data and interpolate them
+                interpolation_heights = [bound.m for bound in cint if bound not in c]
+                interpolation_heights = np.array(interpolation_heights) * cint.units
                 interpolation_heights = (np.sort(interpolation_heights)
                                          * interpolation_heights.units)
                 (interpolated_heights, interpolated_u,
@@ -859,12 +856,12 @@ class Hodograph(object):
                 # Unit conversion required for coloring of bounds/data in dissimilar units
                 # to work properly.
                 c = c.to_base_units()  # TODO: This shouldn't be required!
-                bounds = bounds.to_base_units()
+                cint = cint.to_base_units()
             # If segmenting by anything else, do not interpolate, just use the data
             else:
-                bounds = np.asarray(bounds) * bounds.units
+                cint = np.asarray(cint) * cint.units
 
-            norm = mcolors.BoundaryNorm(bounds.magnitude, cmap.N)
+            norm = mcolors.BoundaryNorm(cint.magnitude, cmap.N)
             cmap.set_over('none')
             cmap.set_under('none')
             kwargs['cmap'] = cmap

--- a/metpy/plots/skewt.py
+++ b/metpy/plots/skewt.py
@@ -7,6 +7,7 @@ Contain tools for making Skew-T Log-P plots, including the base plotting class,
 `SkewT`, as well as a class for making a `Hodograph`.
 """
 
+import warnings
 try:
     from contextlib import ExitStack
 except ImportError:
@@ -27,6 +28,7 @@ import numpy as np
 from ._util import colored_line
 from ..calc import dewpoint, dry_lapse, moist_lapse, vapor_pressure
 from ..calc.tools import _delete_masked_points
+from ..deprecation import metpyDeprecation
 from ..interpolate import interpolate_1d
 from ..package_tools import Exporter
 from ..units import concatenate, units
@@ -791,15 +793,15 @@ class Hodograph(object):
         return self.ax.quiver(center_position, center_position,
                               u, v, **quiver_args)
 
-    def plot_colormapped(self, u, v, c, cint=None, colors=None, **kwargs):
+    def plot_colormapped(self, u, v, c, intervals=None, colors=None, **kwargs):
         r"""Plot u, v data, with line colored based on a third set of data.
 
         Plots the wind data on the hodograph, but with a colormapped line. Takes a third
         variable besides the winds (e.g. heights or pressure levels) and either a colormap to
         color it with or a series of contour intervals and colors to create a colormap and
-        norm to control colormapping. The contour intervals (`cint`) must always be in
-        increasing order. For using custom contour intervals with height data, the function
-        will automatically interpolate to the contour intervals from the height and wind data,
+        norm to control colormapping. The intervals must always be in increasing
+        order. For using custom contour intervals with height data, the function will
+        automatically interpolate to the contour intervals from the height and wind data,
         as well as convert the input contour intervals from height AGL to MSL to work with the
         provided heights.
 
@@ -811,8 +813,8 @@ class Hodograph(object):
             v-component of wind
         c : array_like
             data to use for colormapping (e.g. heights, pressure, wind speed)
-        cint: array-like, optional
-            Array of contour intervals for c to use in coloring the hodograph.
+        intervals: array-like, optional
+            Array of intervals for c to use in coloring the hodograph.
         colors: list, optional
             Array of strings representing colors for the hodograph segments.
         kwargs
@@ -827,18 +829,29 @@ class Hodograph(object):
         --------
         :meth:`Hodograph.plot`
 
+        Notes
+        -----
+        `plot_colormapped` previously accepted `bounds` as a parameter for coordinate values.
+        This has been deprecated in 0.11 in favor of `intervals`.
+
         """
+        bounds = kwargs.pop('bounds', None)
+        if bounds is not None:
+            intervals = bounds
+            warnings.warn('The use of "bounds" as a parameter has been deprecated in '
+                          'favor of "intervals",', metpyDeprecation)
+
         u, v, c = _delete_masked_points(u, v, c)
 
         # Plotting a color segmented hodograph
         if colors:
             cmap = mcolors.ListedColormap(colors)
             # If we are segmenting by height (a length), interpolate the contour intervals
-            if cint.dimensionality == {'[length]': 1.0}:
+            if intervals.dimensionality == {'[length]': 1.0}:
 
-                # Find any contour intervals not in the data and interpolate them
-                interpolation_heights = [bound.m for bound in cint if bound not in c]
-                interpolation_heights = np.array(interpolation_heights) * cint.units
+                # Find any intervals not in the data and interpolate them
+                interpolation_heights = [bound.m for bound in intervals if bound not in c]
+                interpolation_heights = np.array(interpolation_heights) * intervals.units
                 interpolation_heights = (np.sort(interpolation_heights)
                                          * interpolation_heights.units)
                 (interpolated_heights, interpolated_u,
@@ -856,12 +869,12 @@ class Hodograph(object):
                 # Unit conversion required for coloring of bounds/data in dissimilar units
                 # to work properly.
                 c = c.to_base_units()  # TODO: This shouldn't be required!
-                cint = cint.to_base_units()
+                intervals = intervals.to_base_units()
             # If segmenting by anything else, do not interpolate, just use the data
             else:
-                cint = np.asarray(cint) * cint.units
+                intervals = np.asarray(intervals) * intervals.units
 
-            norm = mcolors.BoundaryNorm(cint.magnitude, cmap.N)
+            norm = mcolors.BoundaryNorm(intervals.magnitude, cmap.N)
             cmap.set_over('none')
             cmap.set_under('none')
             kwargs['cmap'] = cmap

--- a/metpy/plots/tests/test_skewt.py
+++ b/metpy/plots/tests/test_skewt.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from metpy.plots import Hodograph, SkewT
+from metpy.testing import check_and_silence_deprecation
 # Fixtures to make sure we have the right backend and consistent round
 from metpy.testing import patch_round, set_agg_backend  # noqa: F401, I202
 from metpy.units import units
@@ -263,13 +264,13 @@ def test_hodograph_plot_layers():
     u = np.zeros((6)) * units.knots
     v = np.array([0, 10, 20, 30, 40, 50]) * units.knots
     heights = np.array([0, 1000, 2000, 3000, 4000, 5000]) * units.m
-    cint = np.array([500, 1500, 2500, 3500, 4500]) * units.m
+    intervals = np.array([500, 1500, 2500, 3500, 4500]) * units.m
     colors = ['r', 'g', 'b', 'r']
     fig = plt.figure(figsize=(7, 7))
     ax1 = fig.add_subplot(1, 1, 1)
     h = Hodograph(ax1)
     h.add_grid(increment=10)
-    h.plot_colormapped(u, v, heights, colors=colors, cint=cint)
+    h.plot_colormapped(u, v, heights, colors=colors, intervals=intervals)
     ax1.set_xlim(-50, 50)
     ax1.set_ylim(-5, 50)
 
@@ -282,13 +283,13 @@ def test_hodograph_plot_layers_different_units():
     u = np.zeros((6)) * units.knots
     v = np.array([0, 10, 20, 30, 40, 50]) * units.knots
     heights = np.array([0, 1, 2, 3, 4, 5]) * units.km
-    cint = np.array([500, 1500, 2500, 3500, 4500]) * units.m
+    intervals = np.array([500, 1500, 2500, 3500, 4500]) * units.m
     colors = ['r', 'g', 'b', 'r']
     fig = plt.figure(figsize=(7, 7))
     ax1 = fig.add_subplot(1, 1, 1)
     h = Hodograph(ax1)
     h.add_grid(increment=10)
-    h.plot_colormapped(u, v, heights, colors=colors, cint=cint)
+    h.plot_colormapped(u, v, heights, colors=colors, intervals=intervals)
     ax1.set_xlim(-50, 50)
     ax1.set_ylim(-5, 50)
     return fig
@@ -300,13 +301,13 @@ def test_hodograph_plot_layers_bound_units():
     u = np.zeros((6)) * units.knots
     v = np.array([0, 10, 20, 30, 40, 50]) * units.knots
     heights = np.array([0, 1000, 2000, 3000, 4000, 5000]) * units.m
-    cint = np.array([0.5, 1.5, 2.5, 3.5, 4.5]) * units.km
+    intervals = np.array([0.5, 1.5, 2.5, 3.5, 4.5]) * units.km
     colors = ['r', 'g', 'b', 'r']
     fig = plt.figure(figsize=(7, 7))
     ax1 = fig.add_subplot(1, 1, 1)
     h = Hodograph(ax1)
     h.add_grid(increment=10)
-    h.plot_colormapped(u, v, heights, colors=colors, cint=cint)
+    h.plot_colormapped(u, v, heights, colors=colors, intervals=intervals)
     ax1.set_xlim(-50, 50)
     ax1.set_ylim(-5, 50)
     return fig
@@ -324,7 +325,7 @@ def test_hodograph_plot_arbitrary_layer():
     ax = fig.add_subplot(1, 1, 1)
     hodo = Hodograph(ax, component_range=80)
     hodo.add_grid(increment=20, color='k')
-    hodo.plot_colormapped(u, v, speed, cint=levels, colors=colors)
+    hodo.plot_colormapped(u, v, speed, intervals=levels, colors=colors)
 
     return fig
 
@@ -348,3 +349,17 @@ def test_united_hodograph_range():
     fig = plt.figure(figsize=(6, 6))
     ax = fig.add_subplot(1, 1, 1)
     Hodograph(ax, component_range=60. * units.knots)
+
+
+@check_and_silence_deprecation
+def test_plot_colormapped_bounds_deprecation():
+    """Test deprecation of bounds kwarg in `plot_colormapped`."""
+    u = np.zeros((6)) * units.knots
+    v = np.array([0, 10, 20, 30, 40, 50]) * units.knots
+    heights = np.array([0, 1000, 2000, 3000, 4000, 5000]) * units.m
+    intervals = np.array([500, 1500, 2500, 3500, 4500]) * units.m
+    colors = ['r', 'g', 'b', 'r']
+    fig = plt.figure(figsize=(7, 7))
+    ax1 = fig.add_subplot(1, 1, 1)
+    h = Hodograph(ax1)
+    h.plot_colormapped(u, v, heights, colors=colors, bounds=intervals)

--- a/metpy/plots/tests/test_skewt.py
+++ b/metpy/plots/tests/test_skewt.py
@@ -263,13 +263,13 @@ def test_hodograph_plot_layers():
     u = np.zeros((6)) * units.knots
     v = np.array([0, 10, 20, 30, 40, 50]) * units.knots
     heights = np.array([0, 1000, 2000, 3000, 4000, 5000]) * units.m
-    bounds = np.array([500, 1500, 2500, 3500, 4500]) * units.m
+    cint = np.array([500, 1500, 2500, 3500, 4500]) * units.m
     colors = ['r', 'g', 'b', 'r']
     fig = plt.figure(figsize=(7, 7))
     ax1 = fig.add_subplot(1, 1, 1)
     h = Hodograph(ax1)
     h.add_grid(increment=10)
-    h.plot_colormapped(u, v, heights, colors=colors, bounds=bounds)
+    h.plot_colormapped(u, v, heights, colors=colors, cint=cint)
     ax1.set_xlim(-50, 50)
     ax1.set_ylim(-5, 50)
 
@@ -282,13 +282,13 @@ def test_hodograph_plot_layers_different_units():
     u = np.zeros((6)) * units.knots
     v = np.array([0, 10, 20, 30, 40, 50]) * units.knots
     heights = np.array([0, 1, 2, 3, 4, 5]) * units.km
-    bounds = np.array([500, 1500, 2500, 3500, 4500]) * units.m
+    cint = np.array([500, 1500, 2500, 3500, 4500]) * units.m
     colors = ['r', 'g', 'b', 'r']
     fig = plt.figure(figsize=(7, 7))
     ax1 = fig.add_subplot(1, 1, 1)
     h = Hodograph(ax1)
     h.add_grid(increment=10)
-    h.plot_colormapped(u, v, heights, colors=colors, bounds=bounds)
+    h.plot_colormapped(u, v, heights, colors=colors, cint=cint)
     ax1.set_xlim(-50, 50)
     ax1.set_ylim(-5, 50)
     return fig
@@ -300,13 +300,13 @@ def test_hodograph_plot_layers_bound_units():
     u = np.zeros((6)) * units.knots
     v = np.array([0, 10, 20, 30, 40, 50]) * units.knots
     heights = np.array([0, 1000, 2000, 3000, 4000, 5000]) * units.m
-    bounds = np.array([0.5, 1.5, 2.5, 3.5, 4.5]) * units.km
+    cint = np.array([0.5, 1.5, 2.5, 3.5, 4.5]) * units.km
     colors = ['r', 'g', 'b', 'r']
     fig = plt.figure(figsize=(7, 7))
     ax1 = fig.add_subplot(1, 1, 1)
     h = Hodograph(ax1)
     h.add_grid(increment=10)
-    h.plot_colormapped(u, v, heights, colors=colors, bounds=bounds)
+    h.plot_colormapped(u, v, heights, colors=colors, cint=cint)
     ax1.set_xlim(-50, 50)
     ax1.set_ylim(-5, 50)
     return fig
@@ -324,7 +324,7 @@ def test_hodograph_plot_arbitrary_layer():
     ax = fig.add_subplot(1, 1, 1)
     hodo = Hodograph(ax, component_range=80)
     hodo.add_grid(increment=20, color='k')
-    hodo.plot_colormapped(u, v, speed, bounds=levels, colors=colors)
+    hodo.plot_colormapped(u, v, speed, cint=levels, colors=colors)
 
     return fig
 


### PR DESCRIPTION
Update to docstring to be more informative, and to rename bounds to cint to more accurately describe what this method is doing. Also redid the example using `plot_colormapped` to plot by height, which is more informative for a user (similar to SharpPy). 

This should go in before #1117.