### PR TITLE
Update GitHub issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,8 @@
-### For feature requests
-
-Include a clear description and an example or even a scholarly source of information about how the calculation, plot, etc. works
-
-### For bugs
-
+---
+name: Bug Report
+about: Let us know that something isn't working properly
+labels: "Type: Bug"
+---
 Try to include: 
 - Code Sample, a copy-pastable example if possible
 - A ["Minimal, Complete and Verifiable Example"](http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) will make it much easier for maintainers to help you
@@ -14,6 +13,7 @@ Try to include:
 ```
 - Problem description: this should explain **why** the current behavior is a problem and why the expected output is a better solution.
 - Expected output
+- Which platform (Linux, Windows, Mac, etc.)
 - Versions. Include the output of:
   * `python --version`
   * `python -c 'import metpy; print(metpy.__version__)'

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,6 @@
+---
+name: Feature Request
+about: Suggest an idea for something new to add
+labels: "Type: Feature"
+---
+Include a clear description and an example or even a scholarly source of information about how the calculation, plot, etc. works

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+<!--
+Thanks for contributing a pull request! Please ensure you have taken a look at
+the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
+-->
+
+#### Description Of Changes
+
+#### Checklist
+<!--
+Feel free to remove check-list items aren't relevant to your change
+
+Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
+requests you resolved, so that they will automatically be closed when your pull
+request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
+-->
+- [ ] Closes #xxxx
+- [ ] Tests added
+- [ ] Fully documented


### PR DESCRIPTION
Add a default, basic PR template. Also move from legacy singular issue template to the newer, "select an option" issue template style on GitHub.

No way to really test this before merge, but are there any suggestions on wording? Things to add? More options?