### PR TITLE
Add FutureWarning to ageostrophic_wind for variable reorder

### DIFF
--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -5,6 +5,7 @@
 from __future__ import division
 
 import functools
+import warnings
 
 import numpy as np
 
@@ -477,6 +478,8 @@ def ageostrophic_wind(heights, f, dx, dy, u, v, dim_order='yx'):
 
     """
     u_geostrophic, v_geostrophic = geostrophic_wind(heights, f, dx, dy, dim_order=dim_order)
+    warnings.warn('Input variables will be reordered in 1.0 to be (heights, u, v, f, dx, dy)',
+                  FutureWarning)
     return u - u_geostrophic, v - v_geostrophic
 
 

--- a/metpy/calc/kinematics.py
+++ b/metpy/calc/kinematics.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009,2017,2018 MetPy Developers.
+# Copyright (c) 2009,2017,2018,2019 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Contains calculation of kinematic parameters (e.g. divergence or vorticity)."""
@@ -443,8 +443,6 @@ def geostrophic_wind(heights, f, dx, dy):
 
 
 @exporter.export
-@preprocess_xarray
-@ensure_yx_order
 def ageostrophic_wind(heights, f, dx, dy, u, v, dim_order='yx'):
     r"""Calculate the ageostrophic wind given from the heights or geopotential.
 
@@ -476,11 +474,15 @@ def ageostrophic_wind(heights, f, dx, dy, u, v, dim_order='yx'):
     If inputs have more than two dimensions, they are assumed to have either leading dimensions
     of (x, y) or trailing dimensions of (y, x), depending on the value of ``dim_order``.
 
+    The order of the inputs will be changed in 1.0 to be (heights, u, v, f, dx, dy).
+    To updated to the new format, use `from metpy.future import ageostrophic_wind`.
+
     """
-    u_geostrophic, v_geostrophic = geostrophic_wind(heights, f, dx, dy, dim_order=dim_order)
-    warnings.warn('Input variables will be reordered in 1.0 to be (heights, u, v, f, dx, dy)',
-                  FutureWarning)
-    return u - u_geostrophic, v - v_geostrophic
+    warnings.warn('Input variables will be reordered in 1.0 to be (heights, u, v, f, dx, dy).'
+                  'To update to new input format before 1.0 is released, use'
+                  '`from metpy.future import ageostrophic_wind`.', FutureWarning)
+    from ..future import ageostrophic_wind as _ageostrophic_wind
+    return _ageostrophic_wind(heights, u, v, f, dx, dy, dim_order=dim_order)
 
 
 @exporter.export

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -316,8 +316,9 @@ def test_no_ageostrophic_geopotential():
     z = np.array([[48, 49, 48], [49, 50, 49], [48, 49, 48]]) * 100. * units('m^2/s^2')
     u = np.array([[-2, 0, 2]] * 3) * units('m/s')
     v = -u.T
-    uag, vag = ageostrophic_wind(z, 1 / units.sec, 100. * units.meter, 100. * units.meter,
-                                 u, v, dim_order='xy')
+    with pytest.warns(FutureWarning):
+        uag, vag = ageostrophic_wind(z, 1 / units.sec, 100. * units.meter, 100. * units.meter,
+                                     u, v, dim_order='xy')
     true = np.array([[0, 0, 0]] * 3) * units('m/s')
     assert_array_equal(uag, true)
     assert_array_equal(vag, true)
@@ -327,8 +328,9 @@ def test_ageostrophic_geopotential():
     """Test ageostrophic wind calculation with geopotential and ageostrophic wind."""
     z = np.array([[48, 49, 48], [49, 50, 49], [48, 49, 48]]) * 100. * units('m^2/s^2')
     u = v = np.array([[0, 0, 0]] * 3) * units('m/s')
-    uag, vag = ageostrophic_wind(z, 1 / units.sec, 100. * units.meter, 100. * units.meter,
-                                 u, v, dim_order='xy')
+    with pytest.warns(FutureWarning):
+        uag, vag = ageostrophic_wind(z, 1 / units.sec, 100. * units.meter, 100. * units.meter,
+                                     u, v, dim_order='xy')
 
     u_true = np.array([[2, 0, -2]] * 3) * units('m/s')
     v_true = -u_true.T

--- a/metpy/calc/tests/test_kinematics.py
+++ b/metpy/calc/tests/test_kinematics.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008,2015,2017,2018 MetPy Developers.
+# Copyright (c) 2008,2015,2017,2018,2019 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Test the `kinematics` module."""
@@ -17,6 +17,7 @@ from metpy.calc import (absolute_vorticity, advection, ageostrophic_wind, coriol
                         static_stability, storm_relative_helicity, stretching_deformation,
                         total_deformation, vorticity, wind_components)
 from metpy.constants import g, omega, Re
+from metpy.future import ageostrophic_wind as ageostrophic_wind_future
 from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal,
                            get_test_data)
 from metpy.units import concatenate, units
@@ -335,6 +336,30 @@ def test_ageostrophic_geopotential():
     u_true = np.array([[2, 0, -2]] * 3) * units('m/s')
     v_true = -u_true.T
 
+    assert_array_equal(uag, u_true)
+    assert_array_equal(vag, v_true)
+
+
+def test_no_ageostrophic_geopotential_future():
+    """Test the updated ageostrophic wind function."""
+    z = np.array([[48, 49, 48], [49, 50, 49], [48, 49, 48]]) * 100. * units('m^2/s^2')
+    u = np.array([[-2, 0, 2]] * 3) * units('m/s')
+    v = -u.T
+    uag, vag = ageostrophic_wind_future(z, u, v, 1 / units.sec, 100. * units.meter,
+                                        100. * units.meter, dim_order='xy')
+    true = np.array([[0, 0, 0]] * 3) * units('m/s')
+    assert_array_equal(uag, true)
+    assert_array_equal(vag, true)
+
+
+def test_ageostrophic_geopotential_future():
+    """Test ageostrophic wind calculation with future input variable order."""
+    z = np.array([[48, 49, 48], [49, 50, 49], [48, 49, 48]]) * 100. * units('m^2/s^2')
+    u = v = np.array([[0, 0, 0]] * 3) * units('m/s')
+    uag, vag = ageostrophic_wind_future(z, u, v, 1 / units.sec, 100. * units.meter,
+                                        100. * units.meter, dim_order='xy')
+    u_true = np.array([[2, 0, -2]] * 3) * units('m/s')
+    v_true = -u_true.T
     assert_array_equal(uag, u_true)
     assert_array_equal(vag, v_true)
 

--- a/metpy/future.py
+++ b/metpy/future.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2019 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Contains updated functions that will be modified in a future release."""
+
+from .calc.kinematics import ensure_yx_order, geostrophic_wind
+from .package_tools import Exporter
+from .xarray import preprocess_xarray
+
+
+exporter = Exporter(globals())
+
+
+@exporter.export
+@preprocess_xarray
+@ensure_yx_order
+def ageostrophic_wind(heights, u, v, f, dx, dy, dim_order='yx'):
+    r"""Calculate the ageostrophic wind given from the heights or geopotential.
+
+    Parameters
+    ----------
+    heights : (M, N) ndarray
+        The height field.
+    u : (M, N) ndarray
+        The u wind field.
+    v : (M, N) ndarray
+        The u wind field.
+    f : array_like
+        The coriolis parameter.  This can be a scalar to be applied
+        everywhere or an array of values.
+    dx : float or ndarray
+        The grid spacing(s) in the x-direction. If an array, there should be one item less than
+        the size of `heights` along the applicable axis.
+    dy : float or ndarray
+        The grid spacing(s) in the y-direction. If an array, there should be one item less than
+        the size of `heights` along the applicable axis.
+
+    Returns
+    -------
+    A 2-item tuple of arrays
+        A tuple of the u-component and v-component of the ageostrophic wind.
+
+    Notes
+    -----
+    If inputs have more than two dimensions, they are assumed to have either leading dimensions
+    of (x, y) or trailing dimensions of (y, x), depending on the value of ``dim_order``.
+
+    This function contains an updated input variable order from the same function in the
+    kinematics module. This version will be fully implemented in 1.0 and moved from the
+    `future` module back to the `kinematics` module.
+
+    """
+    u_geostrophic, v_geostrophic = geostrophic_wind(heights, f, dx, dy, dim_order=dim_order)
+    return u - u_geostrophic, v - v_geostrophic


### PR DESCRIPTION
#### Description Of Changes
Adds a FutureWarning for the next two releases before reordering the variable order of `ageostrophic_wind` and breaking in 1.0.

#### Checklist
- [x] See #1112
- [x] Tests added