### PR TITLE
Add convention to wind_direction

### DIFF
--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -58,7 +58,7 @@ def wind_speed(u, v):
 
 @exporter.export
 @preprocess_xarray
-def wind_direction(u, v):
+def wind_direction(u, v, convention='from'):
     r"""Compute the wind direction from u and v-components.
 
     Parameters
@@ -67,12 +67,16 @@ def wind_direction(u, v):
         Wind component in the X (East-West) direction
     v : array_like
         Wind component in the Y (North-South) direction
+    convention : str
+        Convention to return direction. 'from' returns the direction the wind is coming from
+        (meteorological convention). 'to' returns the direction the wind is going towards
+        (oceanographic convention). Default is 'from'.
 
     Returns
     -------
     direction: `pint.Quantity`
-        The direction of the wind in interval [0, 360] degrees, specified as the direction from
-        which it is blowing, with 360 being North.
+        The direction of the wind in interval [0, 360] degrees, with 360 being North, with the
+        direction defined by the convention kwarg.
 
     See Also
     --------
@@ -87,6 +91,13 @@ def wind_direction(u, v):
     wdir = 90. * units.deg - np.arctan2(-v, -u)
     origshape = wdir.shape
     wdir = atleast_1d(wdir)
+
+    # Handle oceanographic convection
+    if convention == 'to':
+        wdir -= 180 * units.deg
+    elif convention not in ('to', 'from'):
+        raise KeyError('Invalid kwarg for "convention". Valid options are "from" or "to".')
+
     wdir[wdir <= 0] += 360. * units.deg
     # Need to be able to handle array-like u and v (with or without units)
     # np.any check required for legacy numpy which treats 0-d False boolean index as zero

--- a/metpy/calc/tests/test_basic.py
+++ b/metpy/calc/tests/test_basic.py
@@ -110,6 +110,19 @@ def test_direction_dimensions():
     assert str(d.units) == 'degree'
 
 
+def test_oceanographic_direction():
+    """Test oceanographic direction (to) convention."""
+    d = wind_direction(5 * units('m/s'), -5 * units('m/s'), convention='to')
+    true_dir = 135 * units.deg
+    assert_almost_equal(d, true_dir, 4)
+
+
+def test_invalid_direction_convention():
+    """Test the error that is returned if the convention kwarg is not valid."""
+    with pytest.raises(KeyError):
+        wind_direction(1 * units('m/s'), 5 * units('m/s'), convention='test')
+
+
 def test_speed_direction_roundtrip():
     """Test round-tripping between speed/direction and components."""
     # Test each quadrant of the whole circle


### PR DESCRIPTION
#### Description Of Changes
Adds a `convention` kwarg to `wind_direction`, which allows for the oceanographic (to) direction to be returned if specified. Defaults to 'from', which is the meteorological convention. Returns a KeyError if something other than 'to' or 'from' are passed to `convention`.

#### Checklist

- [x] Closes #954.
- [x] Tests added
- [x] Fully documented