### PR TITLE
Add 'wide' and 'most_cape' options for LFC/EL, options for CAPE

### DIFF
--- a/src/metpy/calc/basic.py
+++ b/src/metpy/calc/basic.py
@@ -94,7 +94,7 @@ def wind_direction(u, v, convention='from'):
     if convention == 'to':
         wdir -= 180 * units.deg
     elif convention not in ('to', 'from'):
-        raise KeyError('Invalid kwarg for "convention". Valid options are "from" or "to".')
+        raise ValueError('Invalid kwarg for "convention". Valid options are "from" or "to".')
 
     wdir[wdir <= 0] += 360. * units.deg
     # avoid unintended modification of `pint.Quantity` by direct use of magnitude

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -484,16 +484,19 @@ def _multiple_el_lfc_options(intersect_pressures, intersect_temperatures, valid_
         # zip the LFC and EL lists together and find greatest difference
         if type == 'LFC':
             # Find EL intersection pressure values
-            p_list_other, _ = find_intersections(pressure[1:], parcel_temperature_profile[1:],
-                                                 temperature[1:], direction='decreasing',
-                                                 log_x=True)
+            lfc_p_list = p_list
+            el_p_list, _ = find_intersections(pressure[1:], parcel_temperature_profile[1:],
+                                              temperature[1:], direction='decreasing',
+                                              log_x=True)
+
         elif type == 'EL':
+            el_p_list = p_list
             # Find LFC intersection pressure values
-            p_list_other, _ = find_intersections(pressure, parcel_temperature_profile,
-                                                 temperature, direction='increasing',
-                                                 log_x=True)
+            lfc_p_list, _ = find_intersections(pressure, parcel_temperature_profile,
+                                               temperature, direction='increasing',
+                                               log_x=True)
         diff = []
-        [diff.append(lfc_p.m-el_p.m) for lfc_p, el_p in zip(p_list, p_list_other)]
+        [diff.append(lfc_p.m-el_p.m) for lfc_p, el_p in zip(lfc_p_list, el_p_list)]
         x, y = p_list[np.where(diff == np.max(diff))][0], t_list[np.where(diff == np.max(diff))][0]
 
     elif which == 'most_cape':
@@ -565,7 +568,7 @@ def el(pressure, temperature, dewpt, parcel_temperature_profile=None, which='top
     idx = x < lcl_p
     if len(x) > 0 and x[-1] < lcl_p:
         return _multiple_el_lfc_options(x, y, idx, which, pressure,
-                                        parcel_temperature_profile, temperature,type='EL')
+                                        parcel_temperature_profile, temperature, type='EL')
     else:
         return np.nan * pressure.units, np.nan * temperature.units
 

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -488,8 +488,8 @@ def _multiple_el_lfc_options(intersect_pressures, intersect_temperatures, valid_
         x, y = _most_cape_option(intersect_type, p_list, t_list, pressure, temperature,
                                  dewpoint, parcel_temperature_profile)
     else:
-        raise KeyError('Invalid option for "which". Valid options are "top", "bottom", "wide"'
-                       ', "most_cape", and "all".')
+        raise ValueError('Invalid option for "which". Valid options are "top", "bottom", '
+                         '"wide", "most_cape", and "all".')
     return x, y
 
 

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -414,7 +414,7 @@ def lfc(pressure, temperature, dewpt, parcel_temperature_profile=None, dewpt_sta
     # Default to surface parcel if no profile or starting pressure level is given
     if parcel_temperature_profile is None:
         new_stuff = parcel_profile_with_lcl(pressure, temperature, dewpt)
-        pressure, temperature, _, parcel_temperature_profile = new_stuff
+        pressure, temperature, dewpt, parcel_temperature_profile = new_stuff
         parcel_temperature_profile = parcel_temperature_profile.to(temperature.units)
 
     if dewpt_start is None:
@@ -583,7 +583,7 @@ def el(pressure, temperature, dewpt, parcel_temperature_profile=None, which='top
     # Default to surface parcel if no profile or starting pressure level is given
     if parcel_temperature_profile is None:
         new_stuff = parcel_profile_with_lcl(pressure, temperature, dewpt)
-        pressure, temperature, _, parcel_temperature_profile = new_stuff
+        pressure, temperature, dewpt, parcel_temperature_profile = new_stuff
         parcel_temperature_profile = parcel_temperature_profile.to(temperature.units)
 
     # If the top of the sounding parcel is warmer than the environment, there is no EL

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -1428,13 +1428,14 @@ def relative_humidity_from_specific_humidity(specific_humidity, temperature, pre
 @exporter.export
 @preprocess_xarray
 @check_units('[pressure]', '[temperature]', '[temperature]', '[temperature]')
-def cape_cin(pressure, temperature, dewpt, parcel_profile):
+def cape_cin(pressure, temperature, dewpt, parcel_profile, which_lfc='bottom',
+             which_el='top'):
     r"""Calculate CAPE and CIN.
 
     Calculate the convective available potential energy (CAPE) and convective inhibition (CIN)
     of a given upper air profile and parcel path. CIN is integrated between the surface and
-    LFC, CAPE is integrated between the LFC and EL (or top of sounding). Intersection points of
-    the measured temperature profile and parcel profile are logarithmically interpolated.
+    LFC, CAPE is integrated between the LFC and EL (or top of sounding). Intersection points
+    of the measured temperature profile and parcel profile are logarithmically interpolated.
 
     Parameters
     ----------
@@ -1447,6 +1448,12 @@ def cape_cin(pressure, temperature, dewpt, parcel_profile):
         The atmospheric dewpoint corresponding to pressure.
     parcel_profile : `pint.Quantity`
         The temperature profile of the parcel.
+    which_lfc : str
+        Choose which LFC to integrate from. Valid options are 'top', 'bottom', 'wide',
+        and 'most_cape'. Default is 'bottom'.
+    which_el : str
+        Choose which EL to integrate to. Valid options are 'top', 'bottom', 'wide',
+        and 'most_cape'. Default is 'top'.
 
     Returns
     -------
@@ -1484,7 +1491,7 @@ def cape_cin(pressure, temperature, dewpt, parcel_profile):
                                                                 parcel_profile)
     # Calculate LFC limit of integration
     lfc_pressure, _ = lfc(pressure, temperature, dewpt,
-                          parcel_temperature_profile=parcel_profile)
+                          parcel_temperature_profile=parcel_profile, which=which_lfc)
 
     # If there is no LFC, no need to proceed.
     if np.isnan(lfc_pressure):
@@ -1494,7 +1501,7 @@ def cape_cin(pressure, temperature, dewpt, parcel_profile):
 
     # Calculate the EL limit of integration
     el_pressure, _ = el(pressure, temperature, dewpt,
-                        parcel_temperature_profile=parcel_profile)
+                        parcel_temperature_profile=parcel_profile, which=which_el)
 
     # No EL and we use the top reading of the sounding.
     if np.isnan(el_pressure):

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -509,8 +509,7 @@ def _wide_option(intersect_type, p_list, t_list, pressure, parcel_temperature_pr
         lfc_p_list, _ = find_intersections(pressure, parcel_temperature_profile,
                                            temperature, direction='increasing',
                                            log_x=True)
-    diff = []
-    [diff.append(lfc_p.m - el_p.m) for lfc_p, el_p in zip(lfc_p_list, el_p_list)]
+    diff = [lfc_p.m - el_p.m for lfc_p, el_p in zip(lfc_p_list, el_p_list)]
     return (p_list[np.where(diff == np.max(diff))][0],
             t_list[np.where(diff == np.max(diff))][0])
 

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -497,6 +497,8 @@ def _multiple_el_lfc_options(intersect_pressures, intersect_temperatures, valid_
         x, y = p_list[np.where(diff == np.max(diff))][0], t_list[np.where(diff == np.max(diff))][0]
 
     elif which == 'most_cape':
+        # Need to loop through all possible combinations of cape, find greatest cape profile
+        x, y = 1, 2
 
     else:
         raise KeyError('Invalid option for "which". Valid options are "top", "bottom", "wide"'
@@ -1432,7 +1434,7 @@ def cape_cin(pressure, temperature, dewpt, parcel_profile):
     Calculate the convective available potential energy (CAPE) and convective inhibition (CIN)
     of a given upper air profile and parcel path. CIN is integrated between the surface and
     LFC, CAPE is integrated between the LFC and EL (or top of sounding). Intersection points of
-    the measured temperature profile and parcel profile are linearly interpolated.
+    the measured temperature profile and parcel profile are logarithmically interpolated.
 
     Parameters
     ----------
@@ -1779,7 +1781,7 @@ def surface_based_cape_cin(pressure, temperature, dewpoint):
     of a given upper air profile for a surface-based parcel. CIN is integrated
     between the surface and LFC, CAPE is integrated between the LFC and EL (or top of
     sounding). Intersection points of the measured temperature profile and parcel profile are
-    linearly interpolated.
+    logarithmically interpolated.
 
     Parameters
     ----------
@@ -1817,7 +1819,7 @@ def most_unstable_cape_cin(pressure, temperature, dewpoint, **kwargs):
     Calculate the convective available potential energy (CAPE) and convective inhibition (CIN)
     of a given upper air profile and most unstable parcel path. CIN is integrated between the
     surface and LFC, CAPE is integrated between the LFC and EL (or top of sounding).
-    Intersection points of the measured temperature profile and parcel profile are linearly
+    Intersection points of the measured temperature profile and parcel profile are logarithmically
     interpolated.
 
     Parameters

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -467,12 +467,12 @@ def lfc(pressure, temperature, dewpt, parcel_temperature_profile=None, dewpt_sta
         else:
             return _multiple_el_lfc_options(x, y, idx, which, pressure,
                                             parcel_temperature_profile, temperature,
-                                            dewpt, type='LFC')
+                                            dewpt, intersect_type='LFC')
 
 
 def _multiple_el_lfc_options(intersect_pressures, intersect_temperatures, valid_x,
                              which, pressure, parcel_temperature_profile, temperature,
-                             dewpoint, type):
+                             dewpoint, intersect_type):
     """Choose which ELs and LFCs to return from a sounding."""
     p_list, t_list = intersect_pressures[valid_x], intersect_temperatures[valid_x]
     if which == 'all':
@@ -483,13 +483,13 @@ def _multiple_el_lfc_options(intersect_pressures, intersect_temperatures, valid_
         x, y = p_list[-1], t_list[-1]
     elif which == 'wide':
         # zip the LFC and EL lists together and find greatest difference
-        if type == 'LFC':
+        if intersect_type == 'LFC':
             # Find EL intersection pressure values
             lfc_p_list = p_list
             el_p_list, _ = find_intersections(pressure[1:], parcel_temperature_profile[1:],
                                               temperature[1:], direction='decreasing',
                                               log_x=True)
-        else:  # type == 'EL'
+        else:  # intersect_type == 'EL'
             el_p_list = p_list
             # Find LFC intersection pressure values
             lfc_p_list, _ = find_intersections(pressure, parcel_temperature_profile,
@@ -502,16 +502,15 @@ def _multiple_el_lfc_options(intersect_pressures, intersect_temperatures, valid_
 
     elif which == 'most_cape':
         # Need to loop through all possible combinations of cape, find greatest cape profile
-        cape_list, pair_list = []
+        cape_list, pair_list = [], []
         for which_lfc in ['top', 'bottom']:
             for which_el in ['top', 'bottom']:
                 cape, _ = cape_cin(pressure, temperature, dewpoint, parcel_temperature_profile,
                                    which_lfc=which_lfc, which_el=which_el)
                 cape_list.append(cape.m)
                 pair_list.append([which_lfc, which_el])
-
-        lfc_chosen, el_chosen = pair_list[np.where(cape_list == np.max(cape_list))]
-        if type == 'LFC':
+        (lfc_chosen, el_chosen) = pair_list[np.where(cape_list == np.max(cape_list))[0][0]]
+        if intersect_type == 'LFC':
             if lfc_chosen == 'top':
                 x, y = p_list[-1], t_list[-1]
             else:  # 'bottom' is returned
@@ -587,7 +586,7 @@ def el(pressure, temperature, dewpt, parcel_temperature_profile=None, which='top
     if len(x) > 0 and x[-1] < lcl_p:
         return _multiple_el_lfc_options(x, y, idx, which, pressure,
                                         parcel_temperature_profile, temperature, dewpt,
-                                        type='EL')
+                                        intersect_type='EL')
     else:
         return np.nan * pressure.units, np.nan * temperature.units
 

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -392,8 +392,11 @@ def lfc(pressure, temperature, dewpt, parcel_temperature_profile=None, dewpt_sta
         The dewpoint of the parcel for which to calculate the LFC. Defaults to the surface
         dewpoint.
     which: str, optional
-        Pick which LFC to return. Options are 'top', 'bottom', and 'all'.
-        Default is the 'top' (lowest pressure) LFC.
+        Pick which LFC to return. Options are 'top', 'bottom', 'wide', 'most_cape', and 'all'.
+        'top' returns the lowest-pressure LFC, default.
+        'bottom' returns the highest-pressure LFC.
+        'wide' returns the LFC whose corresponding EL is farthest away.
+        'most_cape' returns the LFC that results in the most CAPE in the profile.
 
     Returns
     -------
@@ -462,11 +465,13 @@ def lfc(pressure, temperature, dewpt, parcel_temperature_profile=None, dewpt_sta
         # Otherwise, find all LFCs that exist above the LCL
         # What is returned depends on which flag as described in the docstring
         else:
-            return _multiple_el_lfc_options(x, y, idx, which)
+            return _multiple_el_lfc_options(x, y, idx, which, pressure,
+                                            parcel_temperature_profile, temperature,
+                                            type='LFC')
 
 
 def _multiple_el_lfc_options(intersect_pressures, intersect_temperatures, valid_x,
-                             which):
+                             which, pressure, parcel_temperature_profile, temperature, type):
     """Choose which ELs and LFCs to return from a sounding."""
     p_list, t_list = intersect_pressures[valid_x], intersect_temperatures[valid_x]
     if which == 'all':
@@ -475,6 +480,27 @@ def _multiple_el_lfc_options(intersect_pressures, intersect_temperatures, valid_
         x, y = p_list[0], t_list[0]
     elif which == 'top':
         x, y = p_list[-1], t_list[-1]
+    elif which == 'wide':
+        # zip the LFC and EL lists together and find greatest difference
+        if type == 'LFC':
+            # Find EL intersection pressure values
+            p_list_other, _ = find_intersections(pressure[1:], parcel_temperature_profile[1:],
+                                                 temperature[1:], direction='decreasing',
+                                                 log_x=True)
+        elif type == 'EL':
+            # Find LFC intersection pressure values
+            p_list_other, _ = find_intersections(pressure, parcel_temperature_profile,
+                                                 temperature, direction='increasing',
+                                                 log_x=True)
+        diff = []
+        [diff.append(lfc_p.m-el_p.m) for lfc_p, el_p in zip(p_list, p_list_other)]
+        x, y = p_list[np.where(diff == np.max(diff))][0], t_list[np.where(diff == np.max(diff))][0]
+
+    elif which == 'most_cape':
+
+    else:
+        raise KeyError('Invalid option for "which". Valid options are "top", "bottom", "wide"'
+                       ', "most_cape", and "all".')
     return x, y
 
 
@@ -500,8 +526,11 @@ def el(pressure, temperature, dewpt, parcel_temperature_profile=None, which='top
         The parcel temperature profile from which to calculate the EL. Defaults to the
         surface parcel profile.
     which: str, optional
-        Pick which EL to return. Options are 'top', 'bottom', and 'all'.
-        Default is the 'top' (lowest pressure) EL.
+        Pick which LFC to return. Options are 'top', 'bottom', 'wide', 'most_cape', and 'all'.
+        'top' returns the lowest-pressure EL, default.
+        'bottom' returns the highest-pressure EL.
+        'wide' returns the EL whose corresponding LFC is farthest away.
+        'most_cape' returns the EL that results in the most CAPE in the profile.
 
     Returns
     -------
@@ -533,7 +562,8 @@ def el(pressure, temperature, dewpt, parcel_temperature_profile=None, which='top
     lcl_p, _ = lcl(pressure[0], temperature[0], dewpt[0])
     idx = x < lcl_p
     if len(x) > 0 and x[-1] < lcl_p:
-        return _multiple_el_lfc_options(x, y, idx, which)
+        return _multiple_el_lfc_options(x, y, idx, which, pressure,
+                                        parcel_temperature_profile, temperature,type='EL')
     else:
         return np.nan * pressure.units, np.nan * temperature.units
 

--- a/tests/calc/test_basic.py
+++ b/tests/calc/test_basic.py
@@ -105,7 +105,7 @@ def test_oceanographic_direction():
 
 def test_invalid_direction_convention():
     """Test the error that is returned if the convention kwarg is not valid."""
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         wind_direction(1 * units('m/s'), 5 * units('m/s'), convention='test')
 
 

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1373,9 +1373,9 @@ def test_multiple_lfs_wide(multiple_intersections):
 def test_invalid_which(multiple_intersections):
     """Test error message for invalid which option for LFC and EL."""
     levels, temperatures, dewpoints = multiple_intersections
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         lfc(levels, temperatures, dewpoints, which='test')
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         el(levels, temperatures, dewpoints, which='test')
 
 

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1397,6 +1397,15 @@ def test_multiple_els_simple(multiple_intersections):
     assert_almost_equal(len(el_pressure_all), 2, 0)
 
 
+def test_cape_cin_top_el_lfc(multiple_intersections):
+    """Test using LFC/EL options for CAPE/CIN."""
+    levels, temperatures, dewpoints = multiple_intersections
+    parcel_prof = parcel_profile(levels, temperatures[0], dewpoints[0]).to('degC')
+    cape, cin = cape_cin(levels, temperatures, dewpoints, parcel_prof, which_lfc='top')
+    assert_almost_equal(cape, 1262.8618 * units('joule / kilogram'), 3)
+    assert_almost_equal(cin, -97.6499 * units('joule / kilogram'), 3)
+
+
 def test_cape_cin_custom_profile():
     """Test the CAPE and CIN calculation with a custom profile passed to LFC and EL."""
     p = np.array([959., 779.2, 751.3, 724.3, 700., 269.]) * units.mbar

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1414,6 +1414,30 @@ def test_muliple_el_most_cape(multiple_intersections):
     assert_almost_equal(el_temp_wide, -56.8123126 * units.degC, 6)
 
 
+def test_muliple_lfc_most_cape(multiple_intersections):
+    """Test 'most_cape' LFC for sounding with multiple LFCs."""
+    levels, temperatures, dewpoints = multiple_intersections
+    lfc_pressure_wide, lfc_temp_wide = lfc(levels, temperatures, dewpoints, which='most_cape')
+    assert_almost_equal(lfc_pressure_wide, 705.4346277 * units.hPa, 6)
+    assert_almost_equal(lfc_temp_wide, 4.8922235 * units.degC, 6)
+
+
+def test_el_lfc_most_cape_bottom():
+    """Test 'most_cape' LFC/EL when the bottom combination produces the most CAPE."""
+    levels = np.array([966., 937.2, 904.6, 872.6, 853., 850., 836., 821., 811.6, 782.3,
+                       754.2, 726.9, 700., 648.9]) * units.mbar
+    temperatures = np.array([18.2, 16.5, 15.1, 11.5, 11.0, 12.4, 14., 14.4,
+                             13.7, 11.4, 9.1, 6.8, 3.8, 1.5]) * units.degC
+    dewpoints = np.array([16.9, 15.9, 14.2, 11, 9.5, 8.6, 0., -3.6, -4.4,
+                          -6.9, -9.5, -12., -14.6, -15.8]) * units.degC
+    lfc_pres, lfc_temp = lfc(levels, temperatures, dewpoints, which='most_cape')
+    el_pres, el_temp = el(levels, temperatures, dewpoints, which='most_cape')
+    assert_almost_equal(lfc_pres, 900.7395292 * units.hPa, 6)
+    assert_almost_equal(lfc_temp, 14.672512 * units.degC, 6)
+    assert_almost_equal(el_pres, 849.7942184 * units.hPa, 6)
+    assert_almost_equal(el_temp, 12.4233265 * units.degC, 6)
+
+
 def test_cape_cin_top_el_lfc(multiple_intersections):
     """Test using LFC/EL options for CAPE/CIN."""
     levels, temperatures, dewpoints = multiple_intersections

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1322,13 +1322,9 @@ def test_lfc_not_below_lcl():
     assert_almost_equal(lfc_temp, 6.4992871 * units.celsius, 3)
 
 
-def test_multiple_lfcs():
-    """Test sounding with multiple LFCs.
-
-    If which='top', return lowest-pressure LFC.
-    If which='all', return all LFCs
-
-    """
+@pytest.fixture
+def multiple_intersections():
+    """Create profile with multiple LFCs and ELs for testing."""
     levels = np.array([966., 937.2, 925., 904.6, 872.6, 853., 850., 836., 821., 811.6, 782.3,
                        754.2, 726.9, 700., 648.9, 624.6, 601.1, 595., 587., 576., 555.7,
                        534.2, 524., 500., 473.3, 400., 384.5, 358., 343., 308.3, 300., 276.,
@@ -1343,6 +1339,18 @@ def test_multiple_lfcs():
                           -44.1, -45.6, -46.3, -45.5, -47.1, -52.1, -50.4, -47.3, -57.1,
                           -57.9, -58.1, -60.9, -61.4, -62.1, -65.1, -65.6,
                           -66.7, -70.5]) * units.degC
+    return levels, temperatures, dewpoints
+
+
+def test_multiple_lfcs_simple(multiple_intersections):
+    """Test sounding with multiple LFCs.
+
+    If which='top', return lowest-pressure LFC.
+    If which='bottom', return the highest-pressure LFC.
+    If which='all', return all LFCs
+
+    """
+    levels, temperatures, dewpoints = multiple_intersections
     lfc_pressure_top, lfc_temp_top = lfc(levels, temperatures, dewpoints)
     lfc_pressure_bottom, lfc_temp_bottom = lfc(levels, temperatures, dewpoints,
                                                which='bottom')
@@ -1354,27 +1362,31 @@ def test_multiple_lfcs():
     assert_almost_equal(len(lfc_pressure_all), 2, 0)
 
 
-def test_multiple_els():
+def test_multiple_lfs_wide(multiple_intersections):
+    """Test 'wide' LFC for sounding with multiple LFCs."""
+    levels, temperatures, dewpoints = multiple_intersections
+    lfc_pressure_wide, lfc_temp_wide = lfc(levels, temperatures, dewpoints, which='wide')
+    assert_almost_equal(lfc_pressure_wide, 705.4346277 * units.hPa, 6)
+    assert_almost_equal(lfc_temp_wide, 4.8922235 * units.degC, 6)
+
+
+def test_invalid_which(multiple_intersections):
+    """Test error message for invalid which option for LFC and EL."""
+    levels, temperatures, dewpoints = multiple_intersections
+    with pytest.raises(KeyError):
+        lfc(levels, temperatures, dewpoints, which='test')
+        el(levels, temperatures, dewpoints, which='test')
+
+
+def test_multiple_els_simple(multiple_intersections):
     """Test sounding with multiple ELs.
 
     If which='top', return lowest-pressure EL.
+    If which='bottom', return the highest-pressure EL.
     If which='all', return all ELs
 
     """
-    levels = np.array([966., 937.2, 925., 904.6, 872.6, 853., 850., 836., 821., 811.6, 782.3,
-                       754.2, 726.9, 700., 648.9, 624.6, 601.1, 595., 587., 576., 555.7,
-                       534.2, 524., 500., 473.3, 400., 384.5, 358., 343., 308.3, 300., 276.,
-                       273., 268.5, 250., 244.2, 233., 200.]) * units.mbar
-    temperatures = np.array([18.2, 16.8, 16.2, 15.1, 13.3, 12.2, 12.4, 14., 14.4,
-                             13.7, 11.4, 9.1, 6.8, 4.4, -1.4, -4.4, -7.3, -8.1,
-                             -7.9, -7.7, -8.7, -9.8, -10.3, -13.5, -17.1, -28.1, -30.7,
-                             -35.3, -37.1, -43.5, -45.1, -49.9, -50.4, -51.1, -54.1, -55.,
-                             -56.7, -57.5]) * units.degC
-    dewpoints = np.array([16.9, 15.9, 15.5, 14.2, 12.1, 10.8, 8.6, 0., -3.6, -4.4,
-                          -6.9, -9.5, -12., -14.6, -15.8, -16.4, -16.9, -17.1, -27.9, -42.7,
-                          -44.1, -45.6, -46.3, -45.5, -47.1, -52.1, -50.4, -47.3, -57.1,
-                          -57.9, -58.1, -60.9, -61.4, -62.1, -65.1, -65.6,
-                          -66.7, -70.5]) * units.degC
+    levels, temperatures, dewpoints = multiple_intersections
     el_pressure_top, el_temp_top = el(levels, temperatures, dewpoints)
     el_pressure_bottom, el_temp_bottom = el(levels, temperatures, dewpoints, which='bottom')
     el_pressure_all, _ = el(levels, temperatures, dewpoints, which='all')

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1375,6 +1375,7 @@ def test_invalid_which(multiple_intersections):
     levels, temperatures, dewpoints = multiple_intersections
     with pytest.raises(KeyError):
         lfc(levels, temperatures, dewpoints, which='test')
+    with pytest.raises(KeyError):
         el(levels, temperatures, dewpoints, which='test')
 
 
@@ -1401,6 +1402,14 @@ def test_multiple_el_wide(multiple_intersections):
     """Test 'wide' EL for sounding with multiple ELs."""
     levels, temperatures, dewpoints = multiple_intersections
     el_pressure_wide, el_temp_wide = el(levels, temperatures, dewpoints, which='wide')
+    assert_almost_equal(el_pressure_wide, 228.0575059 * units.hPa, 6)
+    assert_almost_equal(el_temp_wide, -56.8123126 * units.degC, 6)
+
+
+def test_muliple_el_most_cape(multiple_intersections):
+    """Test 'most_cape' EL for sounding with multiple ELs."""
+    levels, temperatures, dewpoints = multiple_intersections
+    el_pressure_wide, el_temp_wide = el(levels, temperatures, dewpoints, which='most_cape')
     assert_almost_equal(el_pressure_wide, 228.0575059 * units.hPa, 6)
     assert_almost_equal(el_temp_wide, -56.8123126 * units.degC, 6)
 

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1397,11 +1397,38 @@ def test_multiple_els_simple(multiple_intersections):
     assert_almost_equal(len(el_pressure_all), 2, 0)
 
 
+def test_multiple_el_wide(multiple_intersections):
+    """Test 'wide' EL for sounding with multiple ELs."""
+    levels, temperatures, dewpoints = multiple_intersections
+    el_pressure_wide, el_temp_wide = el(levels, temperatures, dewpoints, which='wide')
+    assert_almost_equal(el_pressure_wide, 228.0575059 * units.hPa, 6)
+    assert_almost_equal(el_temp_wide, -56.8123126 * units.degC, 6)
+
+
 def test_cape_cin_top_el_lfc(multiple_intersections):
     """Test using LFC/EL options for CAPE/CIN."""
     levels, temperatures, dewpoints = multiple_intersections
     parcel_prof = parcel_profile(levels, temperatures[0], dewpoints[0]).to('degC')
     cape, cin = cape_cin(levels, temperatures, dewpoints, parcel_prof, which_lfc='top')
+    assert_almost_equal(cape, 1262.8618 * units('joule / kilogram'), 3)
+    assert_almost_equal(cin, -97.6499 * units('joule / kilogram'), 3)
+
+
+def test_cape_cin_bottom_el_lfc(multiple_intersections):
+    """Test using LFC/EL options for CAPE/CIN."""
+    levels, temperatures, dewpoints = multiple_intersections
+    parcel_prof = parcel_profile(levels, temperatures[0], dewpoints[0]).to('degC')
+    cape, cin = cape_cin(levels, temperatures, dewpoints, parcel_prof, which_el='bottom')
+    assert_almost_equal(cape, 2.1967 * units('joule / kilogram'), 3)
+    assert_almost_equal(cin, -8.1545 * units('joule / kilogram'), 3)
+
+
+def test_cape_cin_wide_el_lfc(multiple_intersections):
+    """Test using LFC/EL options for CAPE/CIN."""
+    levels, temperatures, dewpoints = multiple_intersections
+    parcel_prof = parcel_profile(levels, temperatures[0], dewpoints[0]).to('degC')
+    cape, cin = cape_cin(levels, temperatures, dewpoints, parcel_prof, which_lfc='wide',
+                         which_el='wide')
     assert_almost_equal(cape, 1262.8618 * units('joule / kilogram'), 3)
     assert_almost_equal(cin, -97.6499 * units('joule / kilogram'), 3)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
Follow-on from #1059 (see that PR for discussion about changes within this PR). Adds the `most_cape` and `wide` options for `lfc` and `el`. The `wide` implementation is pretty straightforward. The `most_cape` is pretty hacky at the moment, and could probably use some refactoring. Tests have been added based on the one case provided in #862, but additional test cases could be good if anyone has any to contribute.

Also adds options to specify which LFC and EL to use to calculate CAPE and CIN. It defaults to `bottom` and `top`, respectively, which was the previous implicit assumption before #1059 was merged. 

Finally, cleans up a couple docstrings that still stated we interpolated intersections linearly, which was changed to logarithmically in #1062.
#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #862
- [x] Tests added
- [ ] Fully documented - leaving this unchecked for others to review the docstrings for comprehension