### PR TITLE
Refactor xarray axis search to resolve dataset shared coordinate issue

### DIFF
--- a/metpy/tests/test_xarray.py
+++ b/metpy/tests/test_xarray.py
@@ -598,3 +598,39 @@ def test_dataset_parse_cf_varname_list(test_ds):
     partial_ds = test_ds.metpy.parse_cf(['u_wind', 'v_wind'])
 
     assert full_ds[['u_wind', 'v_wind']].identical(partial_ds)
+
+
+def test_coordinate_identification_shared_but_not_equal_coords():
+    """Test that non-shared coords are not skipped after parsing shared coords.
+
+    See GH Issue #1124.
+    """
+    # Create minimal dataset
+    temperature = xr.DataArray([[8, 4], [13, 12]], name='temperature',
+                               dims=('isobaric1', 'x'),
+                               coords={
+                                   'isobaric1': xr.DataArray([700, 850],
+                                                             name='isobaric1',
+                                                             dims='isobaric1',
+                                                             attrs={'units': 'hPa',
+                                                                    'axis': 'Z'}),
+                                   'x': xr.DataArray([0, 450], name='x', dims='x',
+                                                     attrs={'units': 'km', 'axis': 'X'})},
+                               attrs={'units': 'degC'})
+    u = xr.DataArray([[30, 20], [10, 10]], name='u', dims=('isobaric2', 'x'),
+                     coords={
+                         'isobaric2': xr.DataArray([500, 850], name='isobaric2',
+                                                   dims='isobaric2',
+                                                   attrs={'units': 'hPa', 'axis': 'Z'}),
+                         'x': xr.DataArray([0, 450], name='x', dims='x',
+                                           attrs={'units': 'km', 'axis': 'X'})},
+                     attrs={'units': 'kts'})
+    ds = xr.Dataset({'temperature': temperature, 'u': u})
+
+    # Check coordinates on temperature
+    assert ds['isobaric1'].identical(ds['temperature'].metpy.vertical)
+    assert ds['x'].identical(ds['temperature'].metpy.x)
+
+    # Check vertical coordinate on u
+    # Fails prior to resolution of Issue #1124
+    assert ds['isobaric2'].identical(ds['u'].metpy.vertical)


### PR DESCRIPTION
#### Description Of Changes

This is a slight refactor to the axis search and parsing functionality to assign auto-parsed coordinates on a type-by-type basis, rather than all at once. Follows up on https://github.com/Unidata/MetPy/pull/1058. Implements a test that replicates the issue observed in #1124, which is expected to fail before this PR, and pass with it.

#### Checklist
 
- [x] Closes #1124
- [x] Tests added