### PR TITLE
Allow lists of variable names in parse_cf

### DIFF
--- a/metpy/tests/test_xarray.py
+++ b/metpy/tests/test_xarray.py
@@ -590,3 +590,11 @@ def test_check_axis_with_bad_unit(test_ds_generic):
     var = test_ds_generic['e']
     var.attrs['units'] = 'nondimensional'
     assert not check_axis(var, 'x', 'y', 'vertical', 'time')
+
+
+def test_dataset_parse_cf_varname_list(test_ds):
+    """Test that .parse_cf() returns correct subset of dataset when given list of vars."""
+    full_ds = test_ds.copy().metpy.parse_cf()
+    partial_ds = test_ds.metpy.parse_cf(['u_wind', 'v_wind'])
+
+    assert full_ds[['u_wind', 'v_wind']].identical(partial_ds)

--- a/tutorials/xarray_tutorial.py
+++ b/tutorials/xarray_tutorial.py
@@ -59,6 +59,10 @@ data = data.metpy.parse_cf()
 # it will return just that data variable as a DataArray.
 data_var = data.metpy.parse_cf('Temperature_isobaric')
 
+# If we want only a subset of variables, we can pass a list of variable names as well.
+data_subset = data.metpy.parse_cf(['u-component_of_wind_isobaric',
+                                   'v-component_of_wind_isobaric'])
+
 # To rename variables, supply a dictionary between old and new names to the rename method
 data.rename({
     'Vertical_velocity_pressure_isobaric': 'omega',
@@ -264,7 +268,7 @@ ax.add_feature(cfeature.LAKES.with_scale('50m'), facecolor=cfeature.COLORS['wate
 
 # Set a title and show the plot
 ax.set_title('500 hPa Heights (m), Temperature (\u00B0C), Humidity (%) at '
-             + time[0].dt.strftime('%Y-%m-%d %H:%MZ'))
+             + time[0].dt.strftime('%Y-%m-%d %H:%MZ').item())
 plt.show()
 
 #########################################################################


### PR DESCRIPTION
#### Description Of Changes

**Motivation:** When using `xr.open_dataset` with OPeNDAP to access model/analysis data on a THREDDS server, or really open any large dataset with many different variables/vertical coordinates, I like to trim down on the number of variables kept in the dataset to have cleaner output. Subsetting before `ds.metpy.parse_cf()` makes it easy to forget the grid mapping variable, and subsetting after is not as efficient, so, it would be nice to pass a list of variable names to `ds.metpy.parse_cf()` to only parse the variables needed. This could also make it easier to work around having multiple grid mappings in the same dataset by being able to subset on the variables that share a common grid mapping (xref https://github.com/Unidata/MetPy/issues/965).

This PR modifies `parse_cf()` to accept an iterable of variable names for the `varname` argument. 

Also fixes a small issue that popped up in the xarray tutorial in the docs (`time[0].dt.strftime('%Y-%m-%d %H:%MZ')` in the combined figure example was outputing a full DataArray repr, rather than just the formatted time string).

#### Checklist

- [x] Tests added
- [x] Fully documented