### PR TITLE
Add mixed-layer CAPE

### DIFF
--- a/docs/_templates/overrides/metpy.calc.rst
+++ b/docs/_templates/overrides/metpy.calc.rst
@@ -74,6 +74,7 @@ Soundings
       lcl
       lfc
       mixed_layer
+      mixed_layer_cape_cin
       mixed_parcel
       most_unstable_cape_cin
       most_unstable_parcel

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -2000,8 +2000,7 @@ def mixed_parcel(p, temperature, dewpt, parcel_start_pressure=None,
                                                 interpolate=interpolate)
 
     # Convert back to temperature
-    mean_temperature = (mean_theta / potential_temperature(parcel_start_pressure,
-                                                           1 * units.kelvin)) * units.kelvin
+    mean_temperature = mean_theta * exner_function(parcel_start_pressure)
 
     # Convert back to dewpoint
     mean_vapor_pressure = vapor_pressure(parcel_start_pressure, mean_mixing_ratio)

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -1871,6 +1871,8 @@ def most_unstable_cape_cin(pressure, temperature, dewpoint, **kwargs):
         Temperature profile
     dewpoint : `pint.Quantity`
         Dew point profile
+    kwargs
+        Additional keyword arguments to pass to `most_unstable_parcel`
 
     Returns
     -------
@@ -1913,6 +1915,8 @@ def mixed_layer_cape_cin(pressure, temperature, dewpoint, **kwargs):
         Temperature profile
     dewpoint : `pint.Quantity`
         Dewpoint profile
+    kwargs
+        Additional keyword arguments to pass to `mixed_parcel`
 
     Returns
     -------

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -1930,11 +1930,8 @@ def mixed_layer_cape_cin(pressure, temperature, dewpoint, **kwargs):
     cape_cin, mixed_parcel, parcel_profile
     """
     depth = kwargs.get('depth', 100 * units.hPa)
-    _, parcel_temp, parcel_dewpoint = mixed_parcel(pressure, temperature,
-                                                   dewpoint, **kwargs)
-
-    # Find the mean pressure value in the layer
-    parcel_pressure = mixed_layer(pressure, pressure, **kwargs)[0]
+    parcel_pressure, parcel_temp, parcel_dewpoint = mixed_parcel(pressure, temperature,
+                                                                 dewpoint, **kwargs)
 
     # Remove values below top of mixed layer and add in the mixed layer values
     pressure_prof = pressure[pressure < (pressure[0] - depth)]

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -13,7 +13,8 @@ from metpy.calc import (brunt_vaisala_frequency, brunt_vaisala_frequency_squared
                         dewpoint_rh, dry_lapse, dry_static_energy, el,
                         equivalent_potential_temperature,
                         exner_function, isentropic_interpolation, lcl, lfc, mixed_layer,
-                        mixed_parcel, mixing_ratio, mixing_ratio_from_relative_humidity,
+                        mixed_layer_cape_cin, mixed_parcel, mixing_ratio,
+                        mixing_ratio_from_relative_humidity,
                         mixing_ratio_from_specific_humidity, moist_lapse,
                         moist_static_energy, most_unstable_cape_cin, most_unstable_parcel,
                         parcel_profile, parcel_profile_with_lcl, potential_temperature,
@@ -1104,6 +1105,14 @@ def test_mixed_parcel():
     assert_almost_equal(parcel_pressure, 959. * units.hPa, 6)
     assert_almost_equal(parcel_temperature, 28.7363771 * units.degC, 6)
     assert_almost_equal(parcel_dewpoint, 7.1534658 * units.degC, 6)
+
+
+def test_mixed_layer_cape_cin(multiple_intersections):
+    """Test the calculation of mixed layer cape/cin."""
+    pressure, temperature, dewpoint = multiple_intersections
+    mlcape, mlcin = mixed_layer_cape_cin(pressure, temperature, dewpoint)
+    assert_almost_equal(mlcape, 991.4484 * units('joule / kilogram'), 2)
+    assert_almost_equal(mlcin, -20.6552 * units('joule / kilogram'), 2)
 
 
 def test_mixed_layer():


### PR DESCRIPTION
### Description Of Changes
This PR adds a `mixed_layer_cape_cin` function. Given that this hasn't existed before and the numerous (almost unimaginable) number of caveats and special cases that could exist, I know this is a Pandora's box of potential issues. That being said, I think this is something that is frequently desired and currently takes users more lines of code than is probably desirable, so I took a crack at it to see what it could look like. Unfortunately, I don't think the answer in this [StackOverflow answer](https://stackoverflow.com/questions/52737277/sounding-mixed-layer-cape-calculation) is the fully appropriate solution, as the parcel profile won't include the LCL, which caused issues in MUCAPE (see #1108 and #1109) and would likely cause the same problem here too. Additionally, the documentation on how to actually calculate MLCAPE is very thin at best (i.e. do you replace all values in the mixed layer with the single mixed value, which is what I've implemented here, or do you handle it differently?).

I haven't added any tests yet, as I would like a review of the logic first, and would like to know where to go for test cases, so I'm not just inventing something to get a number back. I'm guessing this will take a decent amount of review and thought for how to implement with all of the kwargs that can be passed to `mixed_parcel`, so I'm happy to take all the feedback anyone wants to share. 

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
--> 
- [x] Closes #1185 
- [x] Tests added
- [x] Fully documented