### PR TITLE
Update standard atmosphere reference to U.S. 1976

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -95,6 +95,11 @@ References
 .. [Markowski2010] Markowski, P. and Y. Richardson, 2010: *Mesoscale Meteorology in the
            Midlatitudes*. Wiley, 430 pp.
 
+.. [NOAA1976] National Oceanic and Atmospheric Administration, National Aeronautics and
+           Space Administration, and U. S. Air Force, 1976: `U. S. Standard Atmosphere 1976
+           <https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770009539.pdf>`_,
+           U.S. Government Printing Office, Washington, DC.
+
 .. [NWS10201] 2017: `National Weather Service Instruction 10-201 <_static/NWS_10-201.pdf>`_.
 
 .. [Philips1957] Philips, N. A., 1957: A coordinate system having some special

--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008,2015,2016,2017,2018 MetPy Developers.
+# Copyright (c) 2008,2015,2016,2017,2018,2019 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Contains a collection of basic calculations.
@@ -439,7 +439,7 @@ def apparent_temperature(temperature, rh, speed, face_level_winds=False, mask_un
 @preprocess_xarray
 @check_units('[pressure]')
 def pressure_to_height_std(pressure):
-    r"""Convert pressure data to heights using the U.S. standard atmosphere.
+    r"""Convert pressure data to heights using the U.S. standard atmosphere [NOAA1976]_.
 
     The implementation uses the formula outlined in [Hobbs1977]_ pg.60-61.
 
@@ -555,7 +555,7 @@ def geopotential_to_height(geopot):
 @preprocess_xarray
 @check_units('[length]')
 def height_to_pressure_std(height):
-    r"""Convert height data to pressures using the U.S. standard atmosphere.
+    r"""Convert height data to pressures using the U.S. standard atmosphere [NOAA1976]_.
 
     The implementation inverts the formula outlined in [Hobbs1977]_ pg.60-61.
 
@@ -606,7 +606,7 @@ def coriolis_parameter(latitude):
 def add_height_to_pressure(pressure, height):
     r"""Calculate the pressure at a certain height above another pressure level.
 
-    This assumes a standard atmosphere.
+    This assumes a standard atmosphere [NOAA1976]_.
 
     Parameters
     ----------
@@ -635,7 +635,7 @@ def add_height_to_pressure(pressure, height):
 def add_pressure_to_height(height, pressure):
     r"""Calculate the height at a certain pressure above another height.
 
-    This assumes a standard atmosphere.
+    This assumes a standard atmosphere [NOAA1976]_.
 
     Parameters
     ----------
@@ -866,7 +866,7 @@ def altimeter_to_station_pressure(altimeter_value, height):
     are taken from [Smithsonian1951]_ Altimeter setting is the
     pressure value to which an aircraft altimeter scale is set so that it will
     indicate the altitude above mean sea-level of an aircraft on the ground at the
-    location for which the value is determined. It assumes a standard atmosphere.
+    location for which the value is determined. It assumes a standard atmosphere [NOAA1976]_.
     Station pressure is the atmospheric pressure at the designated station elevation.
     Finding the station pressure can be helpful for calculating sea-level pressure
     or other parameters.
@@ -907,7 +907,7 @@ def altimeter_to_station_pressure(altimeter_value, height):
 
     :math:`p_{1} = p_{mb} - 0.3` when :math:`p_{0} = 1013.25 mb`
 
-    gamma = lapse rate in NACA standard atmosphere below the isothermal layer
+    gamma = lapse rate in [NOAA1976]_ standard atmosphere below the isothermal layer
     :math:`6.5^{\circ}C. km.^{-1}`
 
     :math:`t_{0}` = standard sea-level temperature 288 K

--- a/metpy/calc/tools.py
+++ b/metpy/calc/tools.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016,2017,2018 MetPy Developers.
+# Copyright (c) 2016,2017,2018,2019 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Contains a collection of generally useful calculation tools."""
@@ -330,8 +330,8 @@ def _get_bound_pressure_height(pressure, bound, heights=None, interpolate=True):
     """Calculate the bounding pressure and height in a layer.
 
     Given pressure, optional heights, and a bound, return either the closest pressure/height
-    or interpolated pressure/height. If no heights are provided, a standard atmosphere is
-    assumed.
+    or interpolated pressure/height. If no heights are provided, a standard atmosphere
+    ([NOAA1976]_) is assumed.
 
     Parameters
     ----------
@@ -542,7 +542,7 @@ def get_layer(pressure, *args, **kwargs):
         Atmospheric variable(s) measured at the given pressures
     heights: array-like, optional
         Atmospheric heights corresponding to the given pressures. Defaults to using
-        heights calculated from ``p`` assuming a standard atmosphere.
+        heights calculated from ``p`` assuming a standard atmosphere [NOAA1976]_.
     bottom : `pint.Quantity`, optional
         The bottom of the layer as a pressure or height above the surface pressure. Defaults
         to the highest pressure or lowest height given.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
Update citation for the standard atmosphere to the U.S. 1976 standard published by NOAA/NASA/USAF. While there are minute differences to the international standard, these only occur above the stratosphere. Additionally, this spec is readily available online, unlike the international one which is hidden behind paywalls frequently.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #420 