### PR TITLE
Return input temperature units for LCL/LFC/EL temperature, disallow LFC if EL below LCL

### DIFF
--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -435,10 +435,10 @@ def lfc(pressure, temperature, dewpt, parcel_temperature_profile=None, dewpt_sta
         mask = pressure < this_lcl[0]
         if np.all(_less_or_close(parcel_temperature_profile[mask], temperature[mask])):
             # LFC doesn't exist
-            return np.nan * pressure.units, np.nan * temperature.units
+            x, y = np.nan * pressure.units, np.nan * temperature.units
         else:  # LFC = LCL
             x, y = this_lcl
-            return x, y
+        return x, y
 
     # LFC exists. Make sure it is no lower than the LCL
     else:
@@ -448,11 +448,11 @@ def lfc(pressure, temperature, dewpt, parcel_temperature_profile=None, dewpt_sta
             el_pres, _ = find_intersections(pressure[1:], parcel_temperature_profile[1:],
                                             temperature[1:], direction='decreasing',
                                             log_x=True)
-            if el_pres > this_lcl[0]:
-                return np.nan * pressure.units, np.nan * temperature.units
+            if np.min(el_pres) > this_lcl[0]:
+                x, y = np.nan * pressure.units, np.nan * temperature.units
             else:
                 x, y = this_lcl
-                return x, y
+            return x, y
         # Otherwise, find all LFCs that exist above the LCL
         # What is returned depends on which flag as described in the docstring
         else:

--- a/metpy/calc/thermo.py
+++ b/metpy/calc/thermo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008,2015,2016,2017,2018 MetPy Developers.
+# Copyright (c) 2008,2015,2016,2017,2018,2019 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Contains a collection of thermodynamic calculations."""
@@ -359,7 +359,7 @@ def lcl(pressure, temperature, dewpt, max_iters=50, eps=1e-5):
     fp = so.fixed_point(_lcl_iter, pressure.m, args=(pressure.m, w, temperature),
                         xtol=eps, maxiter=max_iters)
     lcl_p = fp * pressure.units
-    return lcl_p, dewpoint(vapor_pressure(lcl_p, w))
+    return lcl_p, dewpoint(vapor_pressure(lcl_p, w)).to(temperature.units)
 
 
 @exporter.export
@@ -406,8 +406,7 @@ def lfc(pressure, temperature, dewpt, parcel_temperature_profile=None, dewpt_sta
     if parcel_temperature_profile is None:
         new_stuff = parcel_profile_with_lcl(pressure, temperature, dewpt)
         pressure, temperature, _, parcel_temperature_profile = new_stuff
-        temperature = temperature.to('degC')
-        parcel_temperature_profile = parcel_temperature_profile.to('degC')
+        parcel_temperature_profile = parcel_temperature_profile.to(temperature.units)
 
     if dewpt_start is None:
         dewpt_start = dewpt[0]
@@ -446,8 +445,14 @@ def lfc(pressure, temperature, dewpt, parcel_temperature_profile=None, dewpt_sta
         idx = x < this_lcl[0]
         # LFC height < LCL height, so set LFC = LCL
         if not any(idx):
-            x, y = this_lcl
-            return x, y
+            el_pres, _ = find_intersections(pressure[1:], parcel_temperature_profile[1:],
+                                            temperature[1:], direction='decreasing',
+                                            log_x=True)
+            if el_pres > this_lcl[0]:
+                return np.nan * pressure.units, np.nan * temperature.units
+            else:
+                x, y = this_lcl
+                return x, y
         # Otherwise, find all LFCs that exist above the LCL
         # What is returned depends on which flag as described in the docstring
         else:
@@ -508,8 +513,7 @@ def el(pressure, temperature, dewpt, parcel_temperature_profile=None, which='top
     if parcel_temperature_profile is None:
         new_stuff = parcel_profile_with_lcl(pressure, temperature, dewpt)
         pressure, temperature, _, parcel_temperature_profile = new_stuff
-        temperature = temperature.to('degC')
-        parcel_temperature_profile = parcel_temperature_profile.to('degC')
+        parcel_temperature_profile = parcel_temperature_profile.to(temperature.units)
 
     # If the top of the sounding parcel is warmer than the environment, there is no EL
     if parcel_temperature_profile[-1] > temperature[-1]:


### PR DESCRIPTION
#### Description Of Changes
First, allows for return of LCL/LFC/EL temperature in the units of the input temperature. There may still be a bug in `SkewT.plot` that I need to investigate more, as I don't think things are getting auto-converted to the same units when you plot multiple things. 

Second, this disallows a LFC below a LCL when an "EL" is also below the LCL. This bug was causing CAPE to calculate as the LFC was being adjusted to the LCL, and it didn't see an end to the profile (ending up in very large values of negative CAPE). 

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1167 and closes #1170
- [x] Tests added