### PR TITLE
Add xarray module to Reference Guide

### DIFF
--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -1,4 +1,4 @@
-{% if fullname in ['metpy.calc'] %}
+{% if fullname in ['metpy.calc', 'metpy.xarray'] %}
 
 {% include 'overrides/' ~ fullname ~ '.rst' with context %}
 

--- a/docs/_templates/overrides/metpy.xarray.rst
+++ b/docs/_templates/overrides/metpy.xarray.rst
@@ -1,0 +1,13 @@
+xarray
+==========
+
+.. automodule:: metpy.xarray
+
+Accessors
+---------
+
+.. autoclass:: MetPyDataArrayAccessor()
+    :members:
+
+.. autoclass:: MetPyDatasetAccessor()
+    :members:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -17,6 +17,7 @@ Reference Guide
    metpy.plots.ctables
    metpy.interpolate
    metpy.gridding
+   metpy.xarray
 
 * :ref:`modindex`
 * :ref:`genindex`

--- a/docs/override_check.py
+++ b/docs/override_check.py
@@ -13,11 +13,17 @@ import os
 import sys
 
 
+modules_to_skip = ['metpy.xarray']
+
+
 failed = False
 for full_path in glob.glob('_templates/overrides/metpy.*.rst'):
 
     filename = os.path.basename(full_path)
     module = filename.split('.rst')[0]
+
+    if module in modules_to_skip:
+        continue
 
     # Get all functions in the module
     i = importlib.import_module(module)

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,7 @@ multiline-quotes = double
 rst-roles = class, data, func, meth, mod
 rst-directives = plot
 docstring-convention = numpy
+per-file-ignores = metpy/xarray.py:RST304
 
 [tool:pytest]
 # https://github.com/matplotlib/pytest-mpl/issues/69
@@ -96,6 +97,7 @@ flake8-ignore = *.py F405 W503 RST902
                 metpy/interpolate/*.py RST306
                 metpy/io/__init__.py D999
                 metpy/plots/__init__.py D999
+                metpy/xarray.py RST304
 flake8-max-line-length = 95
 doctest_optionflags = NORMALIZE_WHITESPACE
 mpl-results-path = test_output


### PR DESCRIPTION
#### Description Of Changes

This adds docstrings to attributes and methods on the xarray accessors where they were missing, and tweaks a few others. Also adds the xarray module to the Reference Guide via autosummary.

This is an early attempt at getting this set. Beyond going back through all the docstrings, still need to figure out the proper way to link to CF website and the xarray tutorial, as well as how to avoid the `__init__` docstring being added to the docstring displayed for the overall class (or alternatively, find the best way to let users know not to instantiate these classes directly).

#### Checklist
- [x] Closes #1156