### PR TITLE
Deprecate the viridis colortable

### DIFF
--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -1,4 +1,4 @@
-{% if fullname in ['metpy.calc', 'metpy.xarray'] %}
+{% if fullname in ['metpy.calc', 'metpy.plots.ctables', 'metpy.xarray'] %}
 
 {% include 'overrides/' ~ fullname ~ '.rst' with context %}
 

--- a/docs/_templates/overrides/metpy.plots.ctables.rst
+++ b/docs/_templates/overrides/metpy.plots.ctables.rst
@@ -1,0 +1,26 @@
+
+
+ctables
+===================
+
+.. automodule:: metpy.plots.ctables
+
+
+
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree: ./
+
+      convert_gempak_table
+      read_colortable
+      resource_listdir
+      resource_stream
+
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree: ./
+
+      ColortableRegistry
+      colortables

--- a/examples/formats/NEXRAD_Level_2_File.py
+++ b/examples/formats/NEXRAD_Level_2_File.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015,2018 MetPy Developers.
+# Copyright (c) 2015,2018,2019 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """
@@ -12,7 +12,7 @@ import numpy as np
 
 from metpy.cbook import get_test_data
 from metpy.io import Level2File
-from metpy.plots import add_metpy_logo, add_timestamp, colortables
+from metpy.plots import add_metpy_logo, add_timestamp
 
 ###########################################
 
@@ -53,8 +53,7 @@ for var_data, var_range, ax in zip((ref, rho), (ref_range, rho_range), axes):
     ylocs = var_range * np.cos(np.deg2rad(az[:, np.newaxis]))
 
     # Plot the data
-    cmap = colortables.get_colortable('viridis')
-    ax.pcolormesh(xlocs, ylocs, data, cmap=cmap)
+    ax.pcolormesh(xlocs, ylocs, data, cmap='viridis')
     ax.set_aspect('equal', 'datalim')
     ax.set_xlim(-40, 20)
     ax.set_ylim(-30, 30)

--- a/metpy/plots/ctables.py
+++ b/metpy/plots/ctables.py
@@ -185,7 +185,7 @@ class ColortableRegistry(dict):
 
         """
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=metpyDeprecation)
+            warnings.filterwarnings('ignore', category=metpyDeprecation)
             self[name] = read_colortable(fobj)
             self[name + '_r'] = self[name][::-1]
 

--- a/metpy/plots/ctables.py
+++ b/metpy/plots/ctables.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014,2015,2017 MetPy Developers.
+# Copyright (c) 2014,2015,2017,2019 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Work with custom color tables.
@@ -46,10 +46,12 @@ import glob
 import logging
 import os.path
 import posixpath
+import warnings
 
 import matplotlib.colors as mcolors
 from pkg_resources import resource_listdir, resource_stream
 
+from ..deprecation import metpyDeprecation
 from ..package_tools import Exporter
 
 exporter = Exporter(globals())
@@ -127,6 +129,13 @@ class ColortableRegistry(dict):
     matplotlib's Normalize instances to go with the colortable.
     """
 
+    def __getitem__(self, key):
+        """Handle viridis deprecation."""
+        if key == 'viridis':
+            warnings.warn('Viridis has been deprecated in v0.11. Please use '
+                          "matplotlib's 'viridis'.", metpyDeprecation)
+        return super(ColortableRegistry, self).__getitem__(key)
+
     def scan_resource(self, pkg, path):
         r"""Scan a resource directory for colortable files and add them to the registry.
 
@@ -175,8 +184,10 @@ class ColortableRegistry(dict):
             The name under which the color table will be stored
 
         """
-        self[name] = read_colortable(fobj)
-        self[name + '_r'] = self[name][::-1]
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=metpyDeprecation)
+            self[name] = read_colortable(fobj)
+            self[name + '_r'] = self[name][::-1]
 
     def get_with_steps(self, name, start, step):
         r"""Get a color table from the registry with a corresponding norm.

--- a/metpy/plots/tests/test_ctables.py
+++ b/metpy/plots/tests/test_ctables.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015,2016,2017 MetPy Developers.
+# Copyright (c) 2015,2016,2017,2019 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Tests for the `ctables` module."""
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 
 from metpy.plots.ctables import ColortableRegistry, convert_gempak_table
+from metpy.testing import check_and_silence_deprecation
 
 
 @pytest.fixture()
@@ -136,3 +137,10 @@ def test_gempak():
     result = outfile.read()
 
     assert result == '(0.000000, 0.000000, 0.000000)\n(1.000000, 1.000000, 1.000000)\n'
+
+
+@check_and_silence_deprecation
+def test_viridis(registry):
+    """Test viridis deprecation warning."""
+    registry.scan_resource('metpy.plots', 'colortable_files')
+    registry.get_colortable('viridis')

--- a/metpy/plots/tests/test_ctables.py
+++ b/metpy/plots/tests/test_ctables.py
@@ -15,8 +15,8 @@ except ImportError:
 import numpy as np
 import pytest
 
+from metpy.deprecation import MetpyDeprecationWarning
 from metpy.plots.ctables import ColortableRegistry, convert_gempak_table
-from metpy.testing import check_and_silence_deprecation
 
 
 @pytest.fixture()
@@ -139,8 +139,8 @@ def test_gempak():
     assert result == '(0.000000, 0.000000, 0.000000)\n(1.000000, 1.000000, 1.000000)\n'
 
 
-@check_and_silence_deprecation
 def test_viridis(registry):
     """Test viridis deprecation warning."""
-    registry.scan_resource('metpy.plots', 'colortable_files')
-    registry.get_colortable('viridis')
+    with pytest.warns(MetpyDeprecationWarning):
+        registry.scan_resource('metpy.plots', 'colortable_files')
+        registry.get_colortable('viridis')


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
Deprecate the viridis colortable and suggest usage of the matplotlib version.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1136
- [x] Tests added
- [x] Fully documented