### PR TITLE
Update PyPI upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ before_install:
   # Cython needs to be installed before even downloading CartoPy
   - python -m pip install Cython;
   - python -m pip download -d $WHEELDIR ".[$EXTRA_INSTALLS]" $EXTRA_PACKAGES -f $WHEELHOUSE $PRE $VERSIONS;
-  - touch $WHEELDIR/download_marker && ls -lrt $WHEELDIR;
+  - touch $WHEELDIR/download_marker;
   - travis_wait python -m pip wheel -w $WHEELDIR $EXTRA_PACKAGES -f $WHEELHOUSE $PRE $VERSIONS;
   - python -m pip install $EXTRA_PACKAGES --upgrade --upgrade-strategy=eager --no-index -f file://$PWD/$WHEELDIR $VERSIONS;
   - travis_wait 30 python -m pip wheel -w $WHEELDIR ".[$EXTRA_INSTALLS]" $EXTRA_PACKAGES -f $WHEELHOUSE $PRE $VERSIONS;
@@ -149,6 +149,8 @@ after_script:
       python-codacy-coverage -r coverage.xml;
       codeclimate-test-reporter;
     fi
+  - ls -lr --full-time $WHEELDIR;
+  - echo $(find $WHEELDIR -newer $WHEELDIR/download_marker -name *.whl | tr [:space:] :)
 
 before_deploy:
   # Remove unused, unminified javascript from sphinx

--- a/.travis.yml
+++ b/.travis.yml
@@ -160,11 +160,8 @@ before_deploy:
 
 deploy:
   - provider: pypi
-    user: dopplershift
-    password:
-      secure: VYbxLZZnQ1hR2WZwe6+NXLNVbxceDQzlaVM/G3PW8mYlnyWgIVJBgCcgpH22wT4IsNQqo1r9ow9HiybzwcU1VTZ9KXjYsjre/kCZob0jmuPKlDtujOLaMJFf0XzOw7Y/AFXaMakFA8ZOYJLaMXc0WMLwGT7Hw/oP/e2ztpVLxRA=
+    username: __token__
     distributions: sdist bdist_wheel
-    upload_docs: no
     on:
       repo: Unidata/MetPy
       python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,25 +61,17 @@ matrix:
       env: TASK="docs" PRE="--pre"
     - python: nightly
       env: PRE="--pre"
-    - python: 3.7
+    - python: "3.7-dev"
       env:
         - TASK="coverage"
         - VERSIONS="git+git://github.com/hgrecco/pint@master#egg=pint git+git://github.com/pydata/xarray@master#egg=xarray"
-    - python: 3.7
+    - python: "3.7-dev"
       env:
         - TASK="docs"
         - VERSIONS="git+git://github.com/hgrecco/pint@master#egg=pint git+git://github.com/pydata/xarray@master#egg=xarray"
   allow_failures:
     - python: "3.7-dev"
     - python: nightly
-    - python: 3.7
-      env:
-        - TASK="coverage"
-        - VERSIONS="git+git://github.com/hgrecco/pint@master#egg=pint git+git://github.com/pydata/xarray@master#egg=xarray"
-    - python: 3.7
-      env:
-        - TASK="docs"
-        - VERSIONS="git+git://github.com/hgrecco/pint@master#egg=pint git+git://github.com/pydata/xarray@master#egg=xarray"
 
 before_install:
   # We hard-code the sphinx_rtd_theme to lock in our build with patch for
@@ -175,7 +167,7 @@ deploy:
     upload_docs: no
     on:
       repo: Unidata/MetPy
-      python: 3.6
+      python: 3.7
       condition: '$TASK != "docs"'
       tags: true
   - provider: script
@@ -183,7 +175,7 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
-      python: 3.6
+      python: 3.7
       condition: '$TASK == "docs"'
 
 notifications:


### PR DESCRIPTION
This changes how we handle credentials for uploading to PyPI. We used to have my PyPI password, encrypted, in `.travis.yml`. Now that PyPI has support for tokens (which have only *upload* access), we can use that instead. This is set as an encrypted environment variable, `PYPI_PASSWORD` over on our Travis repo config (not in `.travis.yml`). This also makes it easy to update if there's something wrong with it at release time. Huge win to our security. It does seem like the token is attached to my account rather than the project, but at least it's not my own password nor does it have *all* permissions.

I've played with this on the PyPI test instance on the `test-travis` branch, since it needs to be a live branch to use Travis' deploy support. Everything seems to be working. You can see it [here](https://test.pypi.org/project/MetPy/), along with the much improved project page with the new build stuff that's gone in.

This also moves our official release stuff to use Python 3.7; to keep that easy I moved the git-based builds for xarray and pint to use python 3.7-dev on Travis.

I also added some more output to try to help diagnose what's going on when we upload a ton of wheels to S3.