### PR TITLE
Fix precision issue with interpolation in profile helper

### DIFF
--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -359,6 +359,12 @@ def lcl(pressure, temperature, dewpt, max_iters=50, eps=1e-5):
     fp = so.fixed_point(_lcl_iter, pressure.m, args=(pressure.m, w, temperature),
                         xtol=eps, maxiter=max_iters)
     lcl_p = fp * pressure.units
+
+    # Conditional needed due to precision error with np.log in dewpoint.
+    # Causes issues with parcel_profile_with_lcl if removed. Issue #1187
+    if np.isclose(lcl_p, pressure):
+        lcl_p = pressure
+
     return lcl_p, dewpoint(vapor_pressure(lcl_p, w)).to(temperature.units)
 
 

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1406,3 +1406,12 @@ def test_specific_humidity_from_dewpoint():
     p = 1013.25 * units.mbar
     q = specific_humidity_from_dewpoint(16.973 * units.degC, p)
     assert_almost_equal(q, 0.012 * units.dimensionless, 3)
+
+
+def test_lcl_convergence_issue():
+    """Test profile where LCL wouldn't converge (#1187)."""
+    pressure = np.array([990, 973, 931, 925, 905]) * units.hPa
+    temperature = np.array([14.4, 14.2, 13, 12.6, 11.4]) * units.degC
+    dewpoint = np.array([14.4, 11.7, 8.2, 7.8, 7.6]) * units.degC
+    lcl_pressure, _ = lcl(pressure[0], temperature[0], dewpoint[0])
+    assert_almost_equal(lcl_pressure, 990 * units.hPa, 0)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
Ah, precision issues. This bug was due to the LCL pressure having rounding issues and being greater than the surface profile pressure in the helper function for `parcel_profile_with_lcl`. A simple rounding to take care of the precision issue solves this.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1187
- [x] Tests added