### PR TITLE
fix divergence unit requirement

### DIFF
--- a/src/metpy/calc/kinematics.py
+++ b/src/metpy/calc/kinematics.py
@@ -128,16 +128,16 @@ def vorticity(u, v, dx, dy):
 @exporter.export
 @preprocess_xarray
 @ensure_yx_order
-@check_units('[speed]', '[speed]', '[length]', '[length]')
+@check_units(dx='[length]', dy='[length]')
 def divergence(u, v, dx, dy):
-    r"""Calculate the horizontal divergence of the horizontal wind.
+    r"""Calculate the horizontal divergence of a vector.
 
     Parameters
     ----------
     u : (M, N) `pint.Quantity`
-        x component of the wind
+        x component of the vector
     v : (M, N) `pint.Quantity`
-        y component of the wind
+        y component of the vector
     dx : `pint.Quantity`
         The grid spacing(s) in the x-direction. If an array, there should be one item less than
         the size of `u` along the applicable axis.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
This change removes the requirement that divergence must take wind speed. There are other variables that the divergence of a vector can be taken, which is not wind components. The prime example is Q-vectors.
#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x ] Fixes #1196 