### PR TITLE
Quick fix for test_narr_example_variable_without_grid_mapping test (broken by xarray v0.14)

### DIFF
--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -428,11 +428,10 @@ class MetPyDatasetAccessor(object):
         from .plots.mapping import CFProjection
 
         if varname is None:
-            # If no varname is given, parse the entire dataset
-            return self._dataset.apply(lambda da: self.parse_cf(da.name,
-                                                                coordinates=coordinates),
-                                       keep_attrs=True)
-        elif iterable(varname) and not is_string_like(varname):
+            # If no varname is given, parse all variables in the dataset
+            varname = list(self._dataset.data_vars)
+
+        if iterable(varname) and not is_string_like(varname):
             # If non-string iterable is given, apply recursively across the varnames
             subset = xr.merge([self.parse_cf(single_varname, coordinates=coordinates)
                                for single_varname in varname])


### PR DESCRIPTION
With xarray v0.14 (in particular, after https://github.com/pydata/xarray/pull/3234), MetPy's usage of `xarray.Dataset.apply` in `parse_cf` results in a duplicated coordinate issue, like that observed in 2fe00b6. It seems like it is a very subtle index issue with xarray, however, it can be avoided entirely through using `xarray.merge` instead. ~~The likely upstream issue remains, but this at least fixes MetPy for now.~~