### PR TITLE
avoid pint trouble with np.asarray

### DIFF
--- a/src/metpy/calc/basic.py
+++ b/src/metpy/calc/basic.py
@@ -101,9 +101,9 @@ def wind_direction(u, v, convention='from'):
         raise KeyError('Invalid kwarg for "convention". Valid options are "from" or "to".')
 
     wdir[wdir <= 0] += 360. * units.deg
-    # Need to be able to handle array-like u and v (with or without units)
+    # avoid unintended modification of `pint.Quantity` by direct use of magnitude
+    calm_mask = (np.asarray(u.magnitude) == 0.) & (np.asarray(v.magnitude) == 0.)
     # np.any check required for legacy numpy which treats 0-d False boolean index as zero
-    calm_mask = (np.asarray(u) == 0.) & (np.asarray(v) == 0.)
     if np.any(calm_mask):
         wdir[calm_mask] = 0. * units.deg
     return wdir.reshape(origshape).to('degrees')


### PR DESCRIPTION
#### Description Of Changes

As mentioned in passing with #1209, `pint.Quantity` appears to have an issue when `numpy.asarray` is called with it as the argument.  This change hopefully avoids the pint plumbing and allows direct usage of the magnitude, which is what the code wants to do anyway.

I also removed the no longer valid comment about operating on arrays without units.

#### Checklist

- [x] Fully documented