### PR TITLE
Update xarray time derivative for subsecond precision

### DIFF
--- a/src/metpy/calc/tools.py
+++ b/src/metpy/calc/tools.py
@@ -866,8 +866,8 @@ def xarray_derivative_wrap(func):
             new_kwargs = {'axis': f.get_axis_num(axis)}
 
             if check_axis(f[axis], 'time'):
-                # Time coordinate, need to convert to seconds from datetimes
-                new_kwargs['x'] = f[axis].metpy.as_timestamp().metpy.unit_array
+                # Time coordinate, need to get time deltas
+                new_kwargs['delta'] = f[axis].metpy.time_deltas
             elif check_axis(f[axis], 'lon'):
                 # Longitude coordinate, need to get grid deltas
                 new_kwargs['delta'], _ = grid_deltas_from_dataarray(f)

--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -22,9 +22,11 @@ import logging
 import re
 import warnings
 
+import numpy as np
 import xarray as xr
 
 from ._vendor.xarray import either_dict_or_kwargs, expanded_indexer, is_dict_like
+from .deprecation import metpyDeprecation
 from .units import DimensionalityError, UndefinedUnitError, units
 
 __all__ = []
@@ -319,16 +321,31 @@ class MetPyDataArrayAccessor(object):
         return True
 
     def as_timestamp(self):
-        """Return the data as unix timestamp (for easier time derivatives)."""
+        """Return the data as unix timestamp (for easier time derivatives).
+
+        Notes
+        -----
+        This function has been deprecated and will be removed in v1.0. For the purposes of
+        time derivatives, use ``time_deltas`` instead, which allows sub-second precision.
+
+        """
+        warnings.warn('This function has been deprecated and will be removed in v1.0. Use '
+                      'time_deltas instead.', metpyDeprecation)
         attrs = {key: self._data_array.attrs[key] for key in
                  {'standard_name', 'long_name', 'axis', '_metpy_axis'}
                  & set(self._data_array.attrs)}
         attrs['units'] = 'seconds'
-        return xr.DataArray(self._data_array.values.astype('datetime64[s]').astype('int'),
+        return xr.DataArray(self._data_array.values.astype('datetime64[s]').astype('int64'),
                             name=self._data_array.name,
                             coords=self._data_array.coords,
                             dims=self._data_array.dims,
                             attrs=attrs)
+
+    @property
+    def time_deltas(self):
+        """Return the time difference of the data in seconds (to microsecond precision)."""
+        return (np.diff(self._data_array.values).astype('timedelta64[us]').astype('int64')
+                / 1e6 * units.s)
 
     def find_axis_name(self, axis):
         """Return the name of the axis corresponding to the given identifier.

--- a/tests/calc/test_calc_tools.py
+++ b/tests/calc/test_calc_tools.py
@@ -1022,6 +1022,25 @@ def test_first_derivative_xarray_time_and_default_axis(test_da_xy):
     assert deriv.metpy.units == truth.metpy.units
 
 
+def test_first_derivative_xarray_time_subsecond_precision():
+    """Test time derivative with an xarray.DataArray where subsecond precision is needed."""
+    test_da = xr.DataArray([299.5, 300, 300.5],
+                           dims='time',
+                           coords={'time': np.array(['2019-01-01T00:00:00.0',
+                                                     '2019-01-01T00:00:00.1',
+                                                     '2019-01-01T00:00:00.2'],
+                                                    dtype='datetime64[ms]')},
+                           attrs={'units': 'kelvin'})
+
+    deriv = first_derivative(test_da)
+
+    truth = xr.full_like(test_da, 5.)
+    truth.attrs['units'] = 'kelvin / second'
+
+    xr.testing.assert_allclose(deriv, truth)
+    assert deriv.metpy.units == truth.metpy.units
+
+
 def test_second_derivative_xarray_lonlat(test_da_lonlat):
     """Test second derivative with an xarray.DataArray on a lonlat grid."""
     deriv = second_derivative(test_da_lonlat, axis='lat')

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 MetPy Developers.
+# Copyright (c) 2018,2019 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Test the operation of MetPy's XArray accessors."""
@@ -11,7 +11,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from metpy.testing import assert_almost_equal, assert_array_equal, get_test_data
+from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal,
+                           check_and_silence_deprecation, get_test_data)
 from metpy.units import units
 from metpy.xarray import check_axis, check_matching_coordinates, preprocess_xarray
 
@@ -454,6 +455,7 @@ def test_check_matching_coordinates(test_ds_generic):
         add(test_ds_generic['test'], other)
 
 
+@check_and_silence_deprecation
 def test_as_timestamp(test_var):
     """Test the as_timestamp method for a time DataArray."""
     time = test_var.metpy.time
@@ -464,6 +466,14 @@ def test_as_timestamp(test_var):
                          attrs={'long_name': 'forecast time', '_metpy_axis': 'T',
                                 'units': 'seconds'})
     assert truth.identical(time.metpy.as_timestamp())
+
+
+def test_time_deltas():
+    """Test the time_deltas attribute."""
+    ds = xr.open_dataset(get_test_data('irma_gfs_example.nc', as_file_obj=False))
+    time = ds['time1']
+    truth = 3 * np.ones(8) * units.hr
+    assert_array_almost_equal(time.metpy.time_deltas, truth)
 
 
 def test_find_axis_name_integer(test_var):


### PR DESCRIPTION
#### Description Of Changes

In working with some high-temporal-resolution data with MetPy and xarray, I realized that the xarray time derivative only allows precision to the nearest second, since I had implemented it via conversion to a Unix timestamp in #899. Oops!

This PR modifies this to use `np.timedelta64[us]` to permit microsecond precision instead, which should be fine enough for any meteorological application I can think of, but also coarse enough to fit climatological timescales in 64 bits (if I'm interpreting https://docs.scipy.org/doc/numpy/reference/arrays.datetime.html#datetime-units correctly).

Since `DataArray.metpy.as_timestamp()` was previously documented in the public API in #1175, I also deprecated it instead of removing it in favor of `DataArray.metpy.time_deltas`.

Also, should this be a property or method on the accessor?

#### Checklist

- [x] Tests added
- [x] Fully documented