### PR TITLE
Add arbitrary window smoother and refactor existing smoothers

### DIFF
--- a/docs/_templates/overrides/metpy.calc.rst
+++ b/docs/_templates/overrides/metpy.calc.rst
@@ -168,6 +168,17 @@ Standard Atmosphere
       height_to_pressure_std
       pressure_to_height_std
 
+Smoothing
+---------
+   .. autosummary::
+      :toctree: ./
+
+      smooth_gaussian
+      smooth_window
+      smooth_rectangular
+      smooth_circular
+      smooth_n_point
+
 Other
 -----
 
@@ -185,5 +196,4 @@ Other
       parse_angle
       reduce_point_density
       resample_nn_1d
-      smooth_gaussian
-      smooth_n_point
+

--- a/docs/gempak.rst
+++ b/docs/gempak.rst
@@ -758,19 +758,19 @@ blue is uncertain of parity, and white is unevaluated.
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">SM5S(S)</td>
-        <td class="tg-notimplemented">5-point smoother</td>
-        <td class="tg-notimplemented"><a href="https://github.com/Unidata/MetPy/issues/659">Issue #659</a></td>
+        <td class="tg-implemented">SM5S(S)</td>
+        <td class="tg-implemented">5-point smoother</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.smooth_n_point.html#metpy.calc.smooth_n_point">metpy.calc.smooth_n_point</a></td>
         <td></td>
-        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">SM9S(S)</td>
-        <td class="tg-notimplemented">9-point smoother</td>
-        <td class="tg-notimplemented"><a href="https://github.com/Unidata/MetPy/issues/659">Issue #659</a></td>
+        <td class="tg-implemented">SM9S(S)</td>
+        <td class="tg-implemented">9-point smoother</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.smooth_n_point.html#metpy.calc.smooth_n_point">metpy.calc.smooth_n_point</a></td>
         <td></td>
-        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>
@@ -1150,11 +1150,11 @@ blue is uncertain of parity, and white is unevaluated.
         <td></td>
       </tr>
       <tr>
-        <td class="tg-notimplemented">SM5V(V)</td>
-        <td class="tg-notimplemented">5-point smoother</td>
-        <td class="tg-notimplemented"><a href="https://github.com/Unidata/MetPy/issues/659">Issue #659</a></td>
+        <td class="tg-implemented">SM5V(V)</td>
+        <td class="tg-implemented">5-point smoother</td>
+        <td class="tg-implemented"><a href="api/generated/metpy.calc.smooth_n_point.html#metpy.calc.smooth_n_point">metpy.calc.smooth_n_point</a></td>
         <td></td>
-        <td></td>
+        <td class="tg-no">No</td>
         <td></td>
       </tr>
       <tr>

--- a/examples/calculations/Smoothing.py
+++ b/examples/calculations/Smoothing.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2015-2018 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Smoothing
+=========
+
+Using MetPy's smoothing functions.
+
+This example demonstrates the various ways that MetPy's smoothing function
+can be utilized. While this example utilizes basic NumPy arrays, these
+functions all work equally well with Pint Quantities or xarray DataArrays.
+"""
+
+from itertools import product
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import metpy.calc as mpcalc
+
+###########################################
+# Start with a base pattern with random noise
+np.random.seed(61461542)
+size = 128
+x, y = np.mgrid[:size, :size]
+distance = np.sqrt((x - size / 2) ** 2 + (y - size / 2) ** 2)
+raw_data = np.random.random((size, size)) * 0.3 + distance / distance.max() * 0.7
+
+fig, ax = plt.subplots(1, 1, figsize=(4, 4))
+ax.set_title('Raw Data')
+ax.imshow(raw_data, vmin=0, vmax=1)
+ax.axis('off')
+plt.show()
+
+###########################################
+# Now, create a grid showing different smoothing options
+fig, ax = plt.subplots(3, 3, figsize=(12, 12))
+for i, j in product(range(3), range(3)):
+    ax[i, j].axis('off')
+
+# Gaussian Smoother
+ax[0, 0].imshow(mpcalc.smooth_gaussian(raw_data, 3), vmin=0, vmax=1)
+ax[0, 0].set_title('Gaussian - Low Degree')
+
+ax[0, 1].imshow(mpcalc.smooth_gaussian(raw_data, 8), vmin=0, vmax=1)
+ax[0, 1].set_title('Gaussian - High Degree')
+
+# Rectangular Smoother
+ax[0, 2].imshow(mpcalc.smooth_rectangular(raw_data, (3, 7), 2), vmin=0, vmax=1)
+ax[0, 2].set_title('Rectangular - 3x7 Window\n2 Passes')
+
+# 5-point smoother
+ax[1, 0].imshow(mpcalc.smooth_n_point(raw_data, 5, 1), vmin=0, vmax=1)
+ax[1, 0].set_title('5-Point - 1 Pass')
+
+ax[1, 1].imshow(mpcalc.smooth_n_point(raw_data, 5, 4), vmin=0, vmax=1)
+ax[1, 1].set_title('5-Point - 4 Passes')
+
+# Circular Smoother
+ax[1, 2].imshow(mpcalc.smooth_circular(raw_data, 2, 2), vmin=0, vmax=1)
+ax[1, 2].set_title('Circular - Radius 2\n2 Passes')
+
+# 9-point smoother
+ax[2, 0].imshow(mpcalc.smooth_n_point(raw_data, 9, 1), vmin=0, vmax=1)
+ax[2, 0].set_title('9-Point - 1 Pass')
+
+ax[2, 1].imshow(mpcalc.smooth_n_point(raw_data, 9, 4), vmin=0, vmax=1)
+ax[2, 1].set_title('9-Point - 4 Passes')
+
+# Arbitrary Window Smoother
+ax[2, 2].imshow(mpcalc.smooth_window(raw_data, np.diag(np.ones(5)), 2), vmin=0, vmax=1)
+ax[2, 2].set_title('Custom Window (Diagonal) \n2 Passes')
+
+plt.show()

--- a/src/metpy/calc/tools.py
+++ b/src/metpy/calc/tools.py
@@ -5,6 +5,7 @@
 import functools
 from inspect import signature
 from operator import itemgetter
+import warnings
 
 import numpy as np
 from numpy.core.numeric import normalize_axis_index

--- a/src/metpy/calc/tools.py
+++ b/src/metpy/calc/tools.py
@@ -1503,15 +1503,20 @@ def wrap_output_like(**wrap_kwargs):
         attrs) of other object
         - If shapes do not match, this will error
         - If input is a Quantity, use magnitude and add unit as attribute (rather than xarray
-            wrapping Quantity, at least for now)
+        wrapping Quantity, at least for now)
 
-    The behavior of this decorator is flexible. Use the following keyword arguments to control
-    the mapping behavior:
+    The behavior of this decorator is flexible. Use the optional keyword arguments to control
+    the mapping behavior.
 
-    - `argument`: specify the name of a single argument from the function signature from which
+    Parameters
+    ----------
+    argument : str
+        specify the name of a single argument from the function signature from which
         to take the other data object
-    - `other`: specify the other data object directly
-    - `match_unit`: if True and other data object has units, convert output to those units
+    other : `numpy.ndarray` or `pint.Quantity` or `xarray.DataArray`
+        specify the other data object directly
+    match_unit : bool
+        if True and other data object has units, convert output to those units
         (defaults to False)
 
     Notes

--- a/src/metpy/calc/tools.py
+++ b/src/metpy/calc/tools.py
@@ -1483,12 +1483,15 @@ def wrap_output_like(**wrap_kwargs):
     supports:
 
     - As input (output from wrapped function):
-        - ``pint.Quantity``
-        - ``xarray.DataArray``
-        - any type wrappable by ``pint.Quantity``
+
+        * ``pint.Quantity``
+        * ``xarray.DataArray``
+        * any type wrappable by ``pint.Quantity``
+
     - As matched output (final returned value):
-        - ``pint.Quantity``
-        - ``xarray.DataArray``
+
+        * ``pint.Quantity``
+        * ``xarray.DataArray``
 
     (if matched output is not one of these types, we instead treat the match as if it was a
     dimenionless Quantity.)
@@ -1496,15 +1499,18 @@ def wrap_output_like(**wrap_kwargs):
     This wrapping/conversion follows the following rules:
 
     - If match_unit is False, for output of Quantity or DataArary respectively,
-        - ndarray becomes dimensionless Quantity or unitless DataArray with matching coords
-        - Quantity is unchanged or becomes DataArray with input units and output coords
-        - DataArray is converted to Quantity by accessor or is unchanged
+
+        * ndarray becomes dimensionless Quantity or unitless DataArray with matching coords
+        * Quantity is unchanged or becomes DataArray with input units and output coords
+        * DataArray is converted to Quantity by accessor or is unchanged
+
     - If match_unit is True, for output of Quantity or DataArary respectively, with a given
       unit,
-        - ndarray becomes Quantity or DataArray (with matching coords) with output unit
-        - Quantity is converted to output unit, then returned or converted to DataArray with
+
+        * ndarray becomes Quantity or DataArray (with matching coords) with output unit
+        * Quantity is converted to output unit, then returned or converted to DataArray with
           matching coords
-        - DataArray is has units converted via the accessor, then converted to Quantity via
+        * DataArray is has units converted via the accessor, then converted to Quantity via
           the accessor or returned
 
     The output to match can be specified two ways:

--- a/tests/calc/test_calc_tools.py
+++ b/tests/calc/test_calc_tools.py
@@ -19,9 +19,10 @@ from metpy.calc import (angle_to_direction, find_bounding_indices, find_intersec
                         reduce_point_density, resample_nn_1d, second_derivative)
 from metpy.calc.tools import (_delete_masked_points, _get_bound_pressure_height,
                               _greater_or_close, _less_or_close, _next_non_masked_element,
-                              _remove_nans, BASE_DEGREE_MULTIPLIER, DIR_STRS, UND)
+                              _remove_nans, BASE_DEGREE_MULTIPLIER, DIR_STRS, UND,
+                              wrap_output_like)
 from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal)
-from metpy.units import units
+from metpy.units import DimensionalityError, units
 
 
 FULL_CIRCLE_DEGREES = np.arange(0, 360, BASE_DEGREE_MULTIPLIER.m) * units.degree
@@ -1260,3 +1261,226 @@ def test_remove_nans():
     y_expected = np.array([0, 1, 3, 4])
     assert_array_almost_equal(x_expected, x_test, 0)
     assert_almost_equal(y_expected, y_test, 0)
+
+
+@pytest.mark.parametrize('test, other, match_unit, expected', [
+    (np.arange(4), np.ones(3), False, np.arange(4)),
+    (np.arange(4), np.ones(3), True, np.arange(4)),
+    (np.arange(4), [0] * units.m, False, np.arange(4) * units('dimensionless')),
+    (np.arange(4), [0] * units.m, True, np.arange(4) * units.m),
+    (
+        np.arange(4),
+        xr.DataArray(
+            np.zeros(4),
+            dims=('x',),
+            coords={'x': np.linspace(0, 1, 4)},
+            attrs={'units': 'meter', 'description': 'Just some zeros'}
+        ),
+        False,
+        xr.DataArray(
+            np.arange(4),
+            dims=('x',),
+            coords={'x': np.linspace(0, 1, 4)}
+        )
+    ),
+    (
+        np.arange(4),
+        xr.DataArray(
+            np.zeros(4),
+            dims=('x',),
+            coords={'x': np.linspace(0, 1, 4)},
+            attrs={'units': 'meter', 'description': 'Just some zeros'}
+        ),
+        True,
+        xr.DataArray(
+            np.arange(4),
+            dims=('x',),
+            coords={'x': np.linspace(0, 1, 4)},
+            attrs={'units': 'meter'}
+        )
+    ),
+    ([2, 4, 8] * units.kg, np.ones(3), False, np.array([2, 4, 8])),
+    ([2, 4, 8] * units.kg, np.ones(3), True, np.array([2, 4, 8])),
+    ([2, 4, 8] * units.kg, [0] * units.m, False, [2, 4, 8] * units.kg),
+    ([2, 4, 8] * units.kg, [0] * units.g, True, [2000, 4000, 8000] * units.g),
+    (
+        [2, 4, 8] * units.kg,
+        xr.DataArray(
+            np.zeros(3),
+            dims=('x',),
+            coords={'x': np.linspace(0, 1, 3)},
+            attrs={'units': 'meter'}
+        ),
+        False,
+        xr.DataArray(
+            [2, 4, 8],
+            dims=('x',),
+            coords={'x': np.linspace(0, 1, 3)},
+            attrs={'units': 'kilogram'}
+        )
+    ),
+    (
+        [2, 4, 8] * units.kg,
+        xr.DataArray(
+            np.zeros(3),
+            dims=('x',),
+            coords={'x': np.linspace(0, 1, 3)},
+            attrs={'units': 'gram'}
+        ),
+        True,
+        xr.DataArray(
+            [2000, 4000, 8000],
+            dims=('x',),
+            coords={'x': np.linspace(0, 1, 3)},
+            attrs={'units': 'gram'}
+        )
+    ),
+    (
+        xr.DataArray(
+            np.linspace(0, 1, 5),
+            attrs={'units': 'meter', 'description': 'A range of values'}
+        ),
+        np.arange(4, dtype=np.float64),
+        False,
+        np.linspace(0, 1, 5)
+    ),
+    (
+        xr.DataArray(
+            np.linspace(0, 1, 5),
+            attrs={'units': 'meter', 'description': 'A range of values'}
+        ),
+        np.arange(4, dtype=np.float64),
+        True,
+        np.linspace(0, 1, 5)
+    ),
+    (
+        xr.DataArray(
+            np.linspace(0, 1, 5),
+            attrs={'units': 'meter', 'description': 'A range of values'}
+        ),
+        [0] * units.kg,
+        False,
+        np.linspace(0, 1, 5) * units.m
+    ),
+    (
+        xr.DataArray(
+            np.linspace(0, 1, 5),
+            attrs={'units': 'meter', 'description': 'A range of values'}
+        ),
+        [0] * units.cm,
+        True,
+        np.linspace(0, 100, 5) * units.cm
+    ),
+    (
+        xr.DataArray(
+            np.linspace(0, 1, 5),
+            attrs={'units': 'meter', 'description': 'A range of values'}
+        ),
+        xr.DataArray(
+            np.zeros(3),
+            dims=('x',),
+            coords={'x': np.linspace(0, 1, 3)},
+            attrs={'units': 'kilogram', 'description': 'Alternative data'}
+        ),
+        False,
+        xr.DataArray(
+            np.linspace(0, 1, 5),
+            attrs={'units': 'meter', 'description': 'A range of values'}
+        )
+    ),
+    (
+        xr.DataArray(
+            np.linspace(0, 1, 5),
+            attrs={'units': 'meter', 'description': 'A range of values'}
+        ),
+        xr.DataArray(
+            np.zeros(3),
+            dims=('x',),
+            coords={'x': np.linspace(0, 1, 3)},
+            attrs={'units': 'centimeter', 'description': 'Alternative data'}
+        ),
+        True,
+        xr.DataArray(
+            np.linspace(0, 100, 5),
+            attrs={'units': 'centimeter', 'description': 'A range of values'}
+        )
+    ),
+])
+def test_wrap_output_like_with_other_kwarg(test, other, match_unit, expected):
+    """Test the wrap output like decorator when using the output kwarg."""
+    @wrap_output_like(other=other, match_unit=match_unit)
+    def almost_identity(arg):
+        return arg
+
+    result = almost_identity(test)
+
+    if hasattr(expected, 'units'):
+        assert expected.units == result.units
+    if isinstance(expected, xr.DataArray):
+        xr.testing.assert_identical(result, expected)
+    else:
+        assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize('test, other', [
+    ([2, 4, 8] * units.kg, [0] * units.m),
+    (
+        [2, 4, 8] * units.kg,
+        xr.DataArray(
+            np.zeros(3),
+            dims=('x',),
+            coords={'x': np.linspace(0, 1, 3)},
+            attrs={'units': 'meter'}
+        )
+    ),
+    (
+        xr.DataArray(
+            np.linspace(0, 1, 5),
+            attrs={'units': 'meter'}
+        ),
+        [0] * units.kg
+    ),
+    (
+        xr.DataArray(
+            np.linspace(0, 1, 5),
+            attrs={'units': 'meter'}
+        ),
+        xr.DataArray(
+            np.zeros(3),
+            dims=('x',),
+            coords={'x': np.linspace(0, 1, 3)},
+            attrs={'units': 'kilogram'}
+        )
+    )
+])
+def test_wrap_output_like_with_other_kwarg_raising_dimensionality_error(test, other):
+    """Test the wrap output like decorator when when a dimensionality error is raised."""
+    @wrap_output_like(other=other, match_unit=True)
+    def almost_identity(arg):
+        return arg
+
+    with pytest.raises(DimensionalityError):
+        almost_identity(test)
+
+
+def test_wrap_output_like_with_argument_kwarg():
+    """Test the wrap output like decorator with signature recognition."""
+    @wrap_output_like(argument='a')
+    def double(a):
+        return units.Quantity(2) * a.metpy.unit_array
+
+    test = xr.DataArray([1, 3, 5, 7], attrs={'units': 'm'})
+    expected = xr.DataArray([2, 6, 10, 14], attrs={'units': 'meter'})
+
+    xr.testing.assert_identical(double(test), expected)
+
+
+def test_wrap_output_like_without_control_kwarg():
+    """Test that the wrap output like decorator fails when not provided a control param."""
+    @wrap_output_like()
+    def func(arg):
+        return np.array(arg)
+
+    with pytest.raises(ValueError) as exc:
+        func(0)
+        assert 'Must specify keyword' in str(exc)

--- a/tests/calc/test_calc_tools.py
+++ b/tests/calc/test_calc_tools.py
@@ -1264,8 +1264,8 @@ def test_remove_nans():
 
 
 @pytest.mark.parametrize('test, other, match_unit, expected', [
-    (np.arange(4), np.ones(3), False, np.arange(4)),
-    (np.arange(4), np.ones(3), True, np.arange(4)),
+    (np.arange(4), np.arange(4), False, np.arange(4) * units('dimensionless')),
+    (np.arange(4), np.arange(4), True, np.arange(4) * units('dimensionless')),
     (np.arange(4), [0] * units.m, False, np.arange(4) * units('dimensionless')),
     (np.arange(4), [0] * units.m, True, np.arange(4) * units.m),
     (
@@ -1280,7 +1280,8 @@ def test_remove_nans():
         xr.DataArray(
             np.arange(4),
             dims=('x',),
-            coords={'x': np.linspace(0, 1, 4)}
+            coords={'x': np.linspace(0, 1, 4)},
+            attrs={'units': ''}
         )
     ),
     (
@@ -1299,8 +1300,6 @@ def test_remove_nans():
             attrs={'units': 'meter'}
         )
     ),
-    ([2, 4, 8] * units.kg, np.ones(3), False, np.array([2, 4, 8])),
-    ([2, 4, 8] * units.kg, np.ones(3), True, np.array([2, 4, 8])),
     ([2, 4, 8] * units.kg, [0] * units.m, False, [2, 4, 8] * units.kg),
     ([2, 4, 8] * units.kg, [0] * units.g, True, [2000, 4000, 8000] * units.g),
     (
@@ -1342,16 +1341,7 @@ def test_remove_nans():
         ),
         np.arange(4, dtype=np.float64),
         False,
-        np.linspace(0, 1, 5)
-    ),
-    (
-        xr.DataArray(
-            np.linspace(0, 1, 5),
-            attrs={'units': 'meter', 'description': 'A range of values'}
-        ),
-        np.arange(4, dtype=np.float64),
-        True,
-        np.linspace(0, 1, 5)
+        units.Quantity(np.linspace(0, 1, 5), 'meter')
     ),
     (
         xr.DataArray(
@@ -1451,6 +1441,13 @@ def test_wrap_output_like_with_other_kwarg(test, other, match_unit, expected):
             coords={'x': np.linspace(0, 1, 3)},
             attrs={'units': 'kilogram'}
         )
+    ),
+    (
+        xr.DataArray(
+            np.linspace(0, 1, 5),
+            attrs={'units': 'meter', 'description': 'A range of values'}
+        ),
+        np.arange(4, dtype=np.float64)
     )
 ])
 def test_wrap_output_like_with_other_kwarg_raising_dimensionality_error(test, other):

--- a/tutorials/xarray_tutorial.py
+++ b/tutorials/xarray_tutorial.py
@@ -196,6 +196,12 @@ print(v_geo)
 #     - ``normal_component``
 #     - ``tangential_component``
 #     - ``absolute_momentum``
+# - Smoothing functions
+#     - ``smooth_gaussian``
+#     - ``smooth_n_point``
+#     - ``smooth_window``
+#     - ``smooth_rectangular``
+#     - ``smooth_circular``
 #
 # More details can be found by looking at the documentation for the specific function of
 # interest.


### PR DESCRIPTION
#### Description Of Changes

~~I've had a good part of this sitting in my repo for a while, and I've neglected to do anything with it since I don't have tests yet. While I *still* don't have tests yet, #1221 gave me the idea of going back to it and put it up as a PR to get any early feedback on it, since it does strip and reattach units in the smoother. Plus, this may motivate me to finally put together the tests.~~

This PR adds an arbitrary window smoother that utilizes a weighted sum over offset array subsets. Convenience methods for rectangular and circular windows are also added, along with refactoring the n-point smoother to use the new window smoother (which allows more flexible dimensionality). In an attempt to be compatible with base ndarrays, pint Quantities, and xarray DataArrays, there is also a array wrapping decorator added, which may be able to be generalized to other functions for makeshift xarray support.

#### Checklist

- [x] Closes #665
- [x] Tests added
  - [x] `smooth_window`
  - [x] `smooth_circular`
  - [x] `smooth_rectangular`
  - [x] `wrap_data_like`
- [x] Fully documented
  - [x] Functions documented
  - [x] Example(s) added