### PR TITLE
Identify 'lv_' variables as vertical coordinates.

### DIFF
--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -77,7 +77,7 @@ coordinate_criteria = {
     },
     'regular_expression': {
         'time': r'time[0-9]*',
-        'vertical': (r'(bottom_top|sigma|h(ei)?ght|altitude|depth|isobaric|pres|'
+        'vertical': (r'(lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|isobaric|pres|'
                      r'isotherm)[a-z_]*[0-9]*'),
         'y': r'y',
         'lat': r'x?lat[a-z0-9]*',
@@ -191,7 +191,6 @@ class MetPyDataArrayAccessor:
         # Parse all the coordinates, attempting to identify x, y, vertical, time
         coord_lists = {'T': [], 'Z': [], 'Y': [], 'X': []}
         for coord_var in coords:
-
             # Identify the coordinate type using check_axis helper
             axes_to_check = {
                 'T': ('time',),


### PR DESCRIPTION
ncl_convert2nc starts its vertical coordinate variables with the
string "lv_". Added this to the set of regular expressions to match
in metpy.xarray.coordinate_criteria.

For example, when you download NARR grib files from https://nomads.ncdc.noaa.gov/data/narr/
and convert them from grib to netCDF, the 10-m zonal wind is stored in a variable called U_GRD_221_HTGL with a vertical coordinate lv_HTGL5.

Here are its attributes:
	int lv_HTGL5(lv_HTGL5) ;
		lv_HTGL5:long_name = "fixed height above ground" ;
		lv_HTGL5:units = "m" ;

Unfortunately, because lv_HTGL5 doesn't have units of pressure, nor the "positive" attribute indicating positive is "up".  metpy.parse_cf() doesn't recognize this as a vertical coordinate. It would be nice if ncl_convert2nc did this for you, but I think its development is over. 

Could we have metpy.parse_cf() recognize this prefix? i.e. "lv_"

Otherwise you get an Attribute error
AttributeError: vertical attribute is not available.

p.s. sorry about empty line in line 194. not needed. Couldn't figure out an easy way to remove. 

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Fully documented