### PR TITLE
Modify xarray coordinate identification from CF axis to generic labels, permitting latitude/longitude identification

### DIFF
--- a/src/metpy/calc/cross_sections.py
+++ b/src/metpy/calc/cross_sections.py
@@ -33,7 +33,7 @@ def distances_from_cross_section(cross):
         A tuple of the x and y distances as DataArrays
 
     """
-    if check_axis(cross.metpy.x, 'lon') and check_axis(cross.metpy.y, 'lat'):
+    if check_axis(cross.metpy.x, 'longitude') and check_axis(cross.metpy.y, 'latitude'):
         # Use pyproj to obtain x and y distances
         from pyproj import Geod
 
@@ -79,7 +79,7 @@ def latitude_from_cross_section(cross):
 
     """
     y = cross.metpy.y
-    if check_axis(y, 'lat'):
+    if check_axis(y, 'latitude'):
         return y
     else:
         import cartopy.crs as ccrs

--- a/src/metpy/calc/tools.py
+++ b/src/metpy/calc/tools.py
@@ -852,10 +852,10 @@ def xarray_derivative_wrap(func):
             if check_axis(f[axis], 'time'):
                 # Time coordinate, need to get time deltas
                 new_kwargs['delta'] = f[axis].metpy.time_deltas
-            elif check_axis(f[axis], 'lon'):
+            elif check_axis(f[axis], 'longitude'):
                 # Longitude coordinate, need to get grid deltas
                 new_kwargs['delta'], _ = grid_deltas_from_dataarray(f)
-            elif check_axis(f[axis], 'lat'):
+            elif check_axis(f[axis], 'latitude'):
                 # Latitude coordinate, need to get grid deltas
                 _, new_kwargs['delta'] = grid_deltas_from_dataarray(f)
             else:

--- a/src/metpy/interpolate/slices.py
+++ b/src/metpy/interpolate/slices.py
@@ -166,7 +166,7 @@ def cross_section(data, start, end, steps=100, interp_type='linear'):
         points_cross = geodesic(crs_data, start, end, steps)
 
         # Patch points_cross to match given longitude range, whether [0, 360) or (-180,  180]
-        if check_axis(x, 'lon') and (x > 180).any():
+        if check_axis(x, 'longitude') and (x > 180).any():
             points_cross[points_cross[:, 0] < 0, 0] += 360.
 
         # Return the interpolated data

--- a/tutorials/xarray_tutorial.py
+++ b/tutorials/xarray_tutorial.py
@@ -94,17 +94,26 @@ data['temperature'].metpy.convert_units('degC')
 # coordinate type directly. There are two ways to do this:
 #
 # 1. Use the ``data_var.metpy.coordinates`` method
-# 2. Use the ``data_var.metpy.x``, ``data_var.metpy.y``, ``data_var.metpy.vertical``,
-#    ``data_var.metpy.time`` properties
+# 2. Use the ``data_var.metpy.x``, ``data_var.metpy.y``, ``data_var.metpy.longitude``,
+#    ``data_var.metpy.latitude``, ``data_var.metpy.vertical``,  ``data_var.metpy.time``
+#    properties
 #
 # The valid coordinate types are:
 #
 # - x
 # - y
+# - longitude
+# - latitude
 # - vertical
 # - time
 #
-# (Both approaches and all four types are shown below)
+# (Both approaches are shown below)
+#
+# The ``x``, ``y``, ``vertical``, and ``time`` coordinates cannot be multidimensional,
+# however, the ``longitude`` and ``latitude`` coordinates can (which is often the case for
+# gridded weather data in its native projection). Note that for gridded data on an
+# equirectangular projection, such as the GFS data in this example, ``x`` and ``longitude``
+# will be identical (as will ``y`` and ``latitude``).
 
 # Get multiple coordinates (for example, in just the x and y direction)
 x, y = data['temperature'].metpy.coordinates('x', 'y')
@@ -302,13 +311,13 @@ plt.show()
 #
 # Manually assign the coordinates using the ``assign_coordinates()`` method on your DataArray,
 # or by specifying the ``coordinates`` argument to the ``parse_cf()`` method on your Dataset,
-# to map the ``T`` (time), ``Z`` (vertical), ``Y``, and ``X`` axes (as applicable to your
-# data) to the corresponding coordinates.
+# to map the ``time``, ``vertical``, ``y``, ``latitude``, ``x``, and ``longitude`` axes (as
+# applicable to your data) to the corresponding coordinates.
 #
 # ::
 #
-#     data['Temperature'].assign_coordinates({'T': 'time', 'Z': 'isobaric',
-#                                             'Y': 'y', 'X': 'x'})
+#     data['Temperature'].assign_coordinates({'time': 'time', 'vertical': 'isobaric',
+#                                             'y': 'y', 'x': 'x'})
 #     x = data['Temperature'].metpy.x
 #
 # or
@@ -316,8 +325,8 @@ plt.show()
 # ::
 #
 #     temperature = data.metpy.parse_cf('Temperature',
-#                                       coordinates={'T': 'time', 'Z': 'isobaric',
-#                                                    'Y': 'y', 'X': 'x'})
+#                                       coordinates={'time': 'time', 'vertical': 'isobaric',
+#                                                    'y': 'y', 'x': 'x'})
 #     x = temperature.metpy.x
 #
 # **Axis Unavailable**


### PR DESCRIPTION
#### Description Of Changes

To resolve #1090, this commit changes the CF-axis-based labeling of coordinate identification ('T', 'Z', 'Y', 'X'), to a more general labeling system (currently with labels 'time', 'vertical', 'y', 'latitude', 'x', and 'longitude'). This also permits the needed changes of #1090, which are adding lat/lon coordinate identification and setting the stage for x/y to be 1D only. Also, explicit tests are added for the following cases in regards to coordinate identification:

- 1D latitude/longitude (which should also be assigned as y/x)
- 2D latitude/longitude with existing 1D y/x coords
- 2D latitude/longitude without 1D y/x coords (which assigns to y/x as well as deprecated behavior)

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1090
- [x] Tests added
- [x] Fully documented