### PR TITLE
Adds function to get numeric wx code

### DIFF
--- a/src/metpy/plots/wx_symbols.py
+++ b/src/metpy/plots/wx_symbols.py
@@ -47,24 +47,18 @@ def wx_code_to_numeric(codes):
             if wxcode[0].startswith(('-', '+')):
                 options = [slice(None, 7), slice(None, 5), slice(1, 5), slice(None, 3),
                            slice(1, 3)]
-                for opt in options:
-                    try:
-                        wx_sym_list.append(wx_code_map[wxcode[opt]])
-                        break
-                    except KeyError:
-                        pass
-                else:
-                    wx_sym_list.append(0)
             else:
                 options = [slice(None, 6), slice(None, 4), slice(None, 2)]
-                for opt in options:
-                    try:
-                        wx_sym_list.append(wx_code_map[wxcode[opt]])
-                        break
-                    except KeyError:
-                        pass
-                else:
-                    wx_sym_list.append(0)
+
+            for opt in options:
+                try:
+                    wx_sym_list.append(wx_code_map[wxcode[opt]])
+                    break
+                except KeyError:
+                    pass
+            else:
+                wx_sym_list.append(0)
+
     return np.array(wx_sym_list)
 
 

--- a/src/metpy/plots/wx_symbols.py
+++ b/src/metpy/plots/wx_symbols.py
@@ -7,6 +7,7 @@ See WMO manual 485 Vol 1 for more info on the symbols.
 """
 
 import matplotlib.font_manager as fm
+import numpy as np
 from pkg_resources import resource_filename
 
 from ..package_tools import Exporter
@@ -16,6 +17,55 @@ exporter = Exporter(globals())
 # Create a matplotlib font object pointing to our weather symbol font
 wx_symbol_font = fm.FontProperties(fname=resource_filename('metpy.plots',
                                                            'fonts/wx_symbols.ttf'))
+
+
+@exporter.export
+def wx_code_to_numeric(codes):
+    """Determine the numeric weather symbol value from METAR code text.
+
+    A robust method to identifies the numeric value for plotting the correct symbol from a
+    decoded METAR current weather group. The METAR codes should be strings with no missing
+    values or NaN strings (empty strings are okay).
+
+    For example, if from a Pandas Dataframe sfc_df.wxcodes.fillna('')
+
+    Parameters
+    ----------
+    codes : Array like containing string values of METAR weather codes
+
+    Returns
+    -------
+    array of numeric codes of current weather symbols from the wx_code_map for use in
+    plotting.
+    """
+    wx_sym_list = []
+    for s in codes:
+        wxcode = s.split()[0] if ' ' in s else s
+        try:
+            wx_sym_list.append(wx_code_map[wxcode])
+        except KeyError:
+            if wxcode[0].startswith(('-', '+')):
+                options = [slice(None, 7), slice(None, 5), slice(1, 5), slice(None, 3),
+                           slice(1, 3)]
+                for opt in options:
+                    try:
+                        wx_sym_list.append(wx_code_map[wxcode[opt]])
+                        break
+                    except KeyError:
+                        pass
+                else:
+                    wx_sym_list.append(0)
+            else:
+                options = [slice(None, 6), slice(None, 4), slice(None, 2)]
+                for opt in options:
+                    try:
+                        wx_sym_list.append(wx_code_map[wxcode[opt]])
+                        break
+                    except KeyError:
+                        pass
+                else:
+                    wx_sym_list.append(0)
+    return np.array(wx_sym_list)
 
 
 class CodePointMapping(object):

--- a/tests/plots/test_wx_symbols.py
+++ b/tests/plots/test_wx_symbols.py
@@ -2,7 +2,10 @@
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Tests for the `wx_symbols` module."""
-from metpy.plots import current_weather
+import numpy as np
+
+from metpy.plots import current_weather, wx_code_to_numeric
+from metpy.testing import assert_array_equal
 
 
 def test_mapper():
@@ -22,3 +25,21 @@ def test_alt_char():
 def test_mapper_len():
     """Test getting the length of the mapper."""
     assert len(current_weather) == 100
+
+
+def test_wx_code_to_numeric():
+    """Test getting numeric weather codes from METAR."""
+    data = ['SN', '-RA', '-SHSN', '-SHRA', 'DZ', 'RA', 'SHSN', 'TSRA', '-FZRA', '-SN', '-TSRA',
+            '-RASN', '+SN', 'FG', '-SHRASN', '-DZ', 'SHRA', '-FZRASN', 'TSSN', 'MIBCFG',
+            '-RAPL', 'RAPL', 'TSSNPL', '-SNPL', '+RA', '-RASNPL', '-BLSN', '-SHSNIC', '+TSRA',
+            'TS', 'PL', 'SNPL', '-SHRAPL', '-SNSG', '-TSSN', 'SG', 'IC', 'FU', '+SNPL',
+            'TSSNPLGR', '-TSSNPLGR', '-SHSNSG', 'SHRAPL', '-TSRASN', 'FZRA', '-TSRAPL',
+            '-FZDZSN', '+TSSN', '-TSRASNPL', 'TSRAPL', 'RASN', '-SNIC', 'FZRAPL', '-FZRASNPL',
+            '+RAPL', '-RASGPL', '-TSSNPL', 'FZRASN', '+TSSNGR', 'TSPLGR', '', 'RA BR', '-TSSG',
+            '-TS', '-NA', 'NANA', '+NANA', 'NANANA', 'NANANANA']
+    true_codes = np.array([73, 61, 85, 80, 53, 63, 86, 95, 66, 71, 95, 68, 75, 45, 83, 51, 81,
+                           66, 95, 0, 79, 79, 95, 79, 65, 79, 36, 85, 97, 17, 79, 79, 80, 77,
+                           95, 77, 78, 4, 79, 95, 95, 85, 81, 95, 67, 95, 56, 97, 95, 95, 69,
+                           71, 79, 66, 79, 61, 95, 67, 97, 95, 0, 63, 17, 17, 0, 0, 0, 0, 0])
+    wx_codes = wx_code_to_numeric(data)
+    assert_array_equal(wx_codes, true_codes)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
This PR adds a function to robustly find an appropriate numeric weather code based on the first grouping of current WX METAR code (e.g., BR, RA, +RA, etc.) for plotting on a surface station plot.

May need to add a test or two to get coverage up. Open to changes in naming conventions.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Tests added
- [x] Fully documented