### PR TITLE
Plotting fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ dist: xenial
 
 addons:
   artifacts:
-    target_paths: /
+    target_paths: /wheelhouse
+    working_dir: $WHEELDIR
     paths:
       - $(find $WHEELDIR -newer $WHEELDIR/download_marker -name *.whl | tr [:space:] :)
   apt:

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ where = src
 [options.extras_require]
 dev = ipython[all]>=3.1
 doc = sphinx>=2.1; sphinx-gallery>=0.4; doc8; m2r; netCDF4
-examples = cartopy>=0.13.1; matplotlib>=2.2.0; pyproj>=1.9.4,!=2.0.0
+examples = cartopy>=0.15.0; matplotlib>=2.2.0; pyproj>=1.9.4,!=2.0.0
 test = pytest>=2.4; pytest-mpl; pytest-flake8; cartopy>=0.16.0; flake8>3.2.0; flake8-builtins!=1.4.0; flake8-comprehensions; flake8-copyright; flake8-docstrings; flake8-import-order; flake8-mutable; flake8-pep3101; flake8-print; flake8-quotes; flake8-rst-docstrings; pep8-naming; netCDF4; pyproj>=1.9.4,!=2.0.0
 
 [build_sphinx]

--- a/src/metpy/plots/declarative.py
+++ b/src/metpy/plots/declarative.py
@@ -568,7 +568,7 @@ class PanelContainer(HasTraits):
     def show(self):
         """Show the constructed graphic on the screen."""
         self.draw()
-        self.figure.show()
+        plt.show()
 
 
 @exporter.export

--- a/src/metpy/plots/station_plot.py
+++ b/src/metpy/plots/station_plot.py
@@ -5,7 +5,6 @@
 
 from enum import Enum
 
-import matplotlib
 import numpy as np
 
 from .wx_symbols import (current_weather, high_clouds, low_clouds, mid_clouds,
@@ -276,20 +275,7 @@ class StationPlot(object):
         if self.barbs:
             self.barbs.remove()
 
-        # Handle transforming our center points. CartoPy doesn't like 1D barbs
-        # TODO: This can be removed for cartopy > 0.14.3
-        if hasattr(self.ax, 'projection') and 'transform' in kwargs:
-            trans = kwargs['transform']
-            try:
-                kwargs['transform'] = trans._as_mpl_transform(self.ax)
-            except AttributeError:
-                pass
-            u, v = self.ax.projection.transform_vectors(trans, self.x, self.y, u, v)
-
-            # Since we've re-implemented CartoPy's barbs, we need to skip calling it here
-            self.barbs = matplotlib.axes.Axes.barbs(self.ax, self.x, self.y, u, v, **defaults)
-        else:
-            self.barbs = self.ax.barbs(self.x, self.y, u, v, **defaults)
+        self.barbs = self.ax.barbs(self.x, self.y, u, v, **defaults)
 
     def plot_arrow(self, u, v, **kwargs):
         r"""At the center of the station model plot wind arrows.
@@ -328,21 +314,7 @@ class StationPlot(object):
         if self.arrows:
             self.arrows.remove()
 
-        # Handle transforming our center points. CartoPy doesn't like 1D arrows
-        # TODO: This can be removed for cartopy > 0.14.3
-        if hasattr(self.ax, 'projection') and 'transform' in kwargs:
-            trans = kwargs['transform']
-            try:
-                kwargs['transform'] = trans._as_mpl_transform(self.ax)
-            except AttributeError:
-                pass
-            u, v = self.ax.projection.transform_vectors(trans, self.x, self.y, u, v)
-
-            # Since we've re-implemented CartoPy's arrows, we need to skip calling it here
-            self.arrows = matplotlib.axes.Axes.quiver(self.ax, self.x, self.y, u, v,
-                                                      **defaults)
-        else:
-            self.arrows = self.ax.quiver(self.x, self.y, u, v, **defaults)
+        self.arrows = self.ax.quiver(self.x, self.y, u, v, **defaults)
 
     @staticmethod
     def _plotting_units(u, v, plotting_units):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
- Fix declarative `show()` implementation: we were trying to avoid `pyplot.show()`, but `figure.show()` is insufficient. Also, we use `pyplot` all over the place now, so no need (#1207)
- Remove outdated CartoPy work-around code in `StationPlot`. This was for CartoPy <= 0.14.3. CartoPy 0.15.0 is almost 3 years old now. (#1229)
#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1207 
- [x] Closes #1229