### PR TITLE
add exception catch

### DIFF
--- a/src/metpy/io/metar.py
+++ b/src/metpy/io/metar.py
@@ -254,7 +254,7 @@ def parse_metar_to_named_tuple(metar_text, station_metadata, year=datetime.now()
         hour = int(day_time_utc[2:4])
         minute = int(day_time_utc[4:7])
         date_time = datetime(year, month, day, hour, minute)
-    except AttributeError:
+    except (AttributeError, ValueError):
         date_time = np.nan
 
     # Set the wind values

--- a/tests/io/test_metar.py
+++ b/tests/io/test_metar.py
@@ -33,12 +33,13 @@ def test_broken_clouds():
 
 def test_few_clouds_():
     """Test for skycover when there are few clouds."""
-    df = parse_metar_to_dataframe('METAR KMKE 261155Z AUTO /////KT 10SM FEW100 05/00 A3001 '
+    df = parse_metar_to_dataframe('METAR KMKE 266155Z AUTO /////KT 10SM FEW100 05/00 A3001 '
                                   'RMK AO2=')
     assert df.low_cloud_type.values == 'FEW'
     assert df.cloud_coverage.values == 2
     assert_almost_equal(df.wind_direction.values, np.nan)
     assert_almost_equal(df.wind_speed.values, np.nan)
+    assert_almost_equal(df.date_time.values, np.nan)
 
 
 def test_all_weather_given():


### PR DESCRIPTION
In testing the new metar parsing capabilities with the SAO WMO files that come across the LDM I ran across a problem when the date/time field was incorrect in the metar. An example is `266170`, which threw a `ValueError` from the datetime function when the hour fell outside of the range `0..23`. I was able to add another error to the try/except around determining date time and was successful in reading in a full file containing over 9000 observations.

Modified one test to cover this issue.