### PR TITLE
Update PlotObs for time and station dimension naming

### DIFF
--- a/src/metpy/plots/declarative.py
+++ b/src/metpy/plots/declarative.py
@@ -1410,14 +1410,21 @@ class PlotObs(HasTraits):
     @property
     def obsdata(self):
         """Return the internal cached data."""
-        time_vars = ['valid', 'time', 'valid_time']
-        stn_vars = ['station', 'stn']
+        time_vars = ['valid', 'time', 'valid_time', 'date_time', 'date']
+        stn_vars = ['station', 'stn', 'station_id', 'stid']
         if getattr(self, '_obsdata', None) is None:
-            for dim_name in list(self.data):
-                if dim_name in time_vars:
-                    dim_time = dim_name
-                elif dim_name in stn_vars:
-                    dim_stn = dim_name
+            dim_times = [time_var for time_var in time_vars if time_var in list(self.data)]
+            dim_stns = [stn_var for stn_var in stn_vars if stn_var in list(self.data)]
+            if not dim_times:
+                raise AttributeError('Time variable not found. Valid variable names are:'
+                                     f'{time_vars}')
+            else:
+                dim_time = dim_times[0]
+            if not dim_stns:
+                raise AttributeError('Station variable not found. Valid variable names are: '
+                                     f'{stn_vars}')
+            else:
+                dim_stn = dim_stns[0]
             if self.level is not None:
                 level_subset = self.data.pressure == self.level.m
                 self._obsdata = self.data[level_subset]
@@ -1467,7 +1474,7 @@ class PlotObs(HasTraits):
         lon, lat, data = self.plotdata
 
         # Use the cartopy map projection to transform station locations to the map and
-        # then refine the number of stations plotted by setting a 300km radius
+        # then refine the number of stations plotted by setting a radius
         if self.parent._proj_obj == ccrs.PlateCarree():
             scale = 1.
         else:

--- a/tests/plots/test_declarative.py
+++ b/tests/plots/test_declarative.py
@@ -558,6 +558,68 @@ def test_declarative_upa_obs():
     return pc.figure
 
 
+def test_attribute_error_time():
+    """Make sure we get a useful error when the time variable is not found."""
+    data = pd.read_csv(get_test_data('SFC_obs.csv', as_file_obj=False),
+                       infer_datetime_format=True, parse_dates=['valid'])
+    data.rename(columns={'valid': 'vtime'}, inplace=True)
+
+    obs = PlotObs()
+    obs.data = data
+    obs.time = datetime(1993, 3, 12, 12)
+    obs.level = None
+    obs.fields = ['tmpf']
+    obs.time_window = timedelta(minutes=15)
+
+    # Panel for plot with Map features
+    panel = MapPanel()
+    panel.layout = (1, 1, 1)
+    panel.projection = ccrs.PlateCarree()
+    panel.area = 'in'
+    panel.layers = ['states']
+    panel.plots = [obs]
+    panel.title = f'Surface Observations for {obs.time}'
+
+    # Bringing it all together
+    pc = PanelContainer()
+    pc.size = (10, 10)
+    pc.panels = [panel]
+
+    with pytest.raises(AttributeError):
+        pc.draw()
+
+
+def test_attribute_error_station():
+    """Make sure we get a useful error when the station variable is not found."""
+    data = pd.read_csv(get_test_data('SFC_obs.csv', as_file_obj=False),
+                       infer_datetime_format=True, parse_dates=['valid'])
+    data.rename(columns={'station': 'location'}, inplace=True)
+
+    obs = PlotObs()
+    obs.data = data
+    obs.time = datetime(1993, 3, 12, 12)
+    obs.level = None
+    obs.fields = ['tmpf']
+    obs.time_window = timedelta(minutes=15)
+
+    # Panel for plot with Map features
+    panel = MapPanel()
+    panel.layout = (1, 1, 1)
+    panel.projection = ccrs.PlateCarree()
+    panel.area = 'in'
+    panel.layers = ['states']
+    panel.plots = [obs]
+    panel.title = f'Surface Observations for {obs.time}'
+
+    # Bringing it all together
+    pc = PanelContainer()
+    pc.size = (10, 10)
+    pc.panels = [panel]
+
+    with pytest.raises(AttributeError):
+        pc.draw()
+
+
 def test_save():
     """Test that our saving function works."""
     pc = PanelContainer()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
In further testing of reading a data file of METAR with the new parser functionality, the naming convention used in that portion of the code was not captured in the declarative plotting code for the time dimension name and the station dimension name. I've added a few other options and made the loop-up more robust. In addition, I raise an `AttributeError` if one is not found in the set list. It is relatively easy to remedy if a data frame does not contain the right name by either re-naming a column or creating a new column with one of the names. With the latest additions we cover what I know to be the most common names from the available data sources. This could likely be made more robust in the future, but without a CF convention used for surface observation data, it will be a larger lift.

Added some tests to cover new functionality.