### PR TITLE
Still further updates to pint master branch compatibility

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,16 +3,21 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Configure pytest for metpy."""
 
+import os
+
 import matplotlib
 import matplotlib.pyplot
 import numpy
 import pandas
-import pint
 import pytest
 import scipy
 import xarray
 
 import metpy.calc
+
+# Need to disable fallback before importing pint
+os.environ['PINT_ARRAY_PROTOCOL_FALLBACK'] = '0'
+import pint  # noqa: I100, E402
 
 
 def pytest_report_header(config, startdir):

--- a/src/metpy/__init__.py
+++ b/src/metpy/__init__.py
@@ -4,6 +4,7 @@
 """Tools for reading, calculating, and plotting with weather data."""
 
 # What do we want to pull into the top-level namespace?
+import os
 import sys
 import warnings
 
@@ -28,6 +29,7 @@ if sys.version_info < (3,):
 
 # Must occur before below imports
 warnings.filterwarnings('ignore', 'numpy.dtype size changed')
+os.environ['PINT_ARRAY_PROTOCOL_FALLBACK'] = '0'
 
 from ._version import get_version  # noqa: E402
 from .xarray import *  # noqa: F401, F403

--- a/src/metpy/calc/basic.py
+++ b/src/metpy/calc/basic.py
@@ -685,7 +685,7 @@ def sigma_to_pressure(sigma, psfc, ptop):
 
 @exporter.export
 @preprocess_xarray
-@units.wraps('=A', ('=A',))
+@units.wraps('=A', ('=A', None))
 def smooth_gaussian(scalar_grid, n):
     """Filter with normal distribution of weights.
 
@@ -778,7 +778,7 @@ def smooth_gaussian(scalar_grid, n):
 
 @exporter.export
 @preprocess_xarray
-@units.wraps('=A', ('=A',))
+@units.wraps('=A', ('=A', None, None))
 def smooth_n_point(scalar_grid, n=5, passes=1):
     """Filter with normal distribution of weights.
 

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -2410,7 +2410,7 @@ def wet_bulb_temperature(pressure, temperature, dewpoint):
         lcl_pressure, lcl_temperature = lcl(press, temp, dewp)
         moist_adiabat_temperatures = moist_lapse(concatenate([lcl_pressure, press]),
                                                  lcl_temperature)
-        ret[...] = moist_adiabat_temperatures[-1]
+        ret[...] = moist_adiabat_temperatures[-1].magnitude
 
     # If we started with a scalar, return a scalar
     if it.operands[3].size == 1:

--- a/src/metpy/calc/tools.py
+++ b/src/metpy/calc/tools.py
@@ -92,7 +92,7 @@ def nearest_intersection_idx(a, b):
 
 @exporter.export
 @preprocess_xarray
-@units.wraps(('=A', '=B'), ('=A', '=B', '=B'))
+@units.wraps(('=A', '=B'), ('=A', '=B', '=B', None, None))
 def find_intersections(x, a, b, direction='all', log_x=False):
     """Calculate the best estimate of intersection.
 

--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -29,6 +29,11 @@ DimensionalityError = pint.DimensionalityError
 
 units = pint.UnitRegistry(autoconvert_offset_to_baseunit=True)
 
+# Capture v0.10 NEP 18 warning on first creation
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    units.Quantity([])
+
 # For pint 0.6, this is the best way to define a dimensionless unit. See pint #185
 units.define(pint.unit.UnitDefinition('percent', '%', (),
              pint.converters.ScaleConverter(0.01)))


### PR DESCRIPTION
#### Description Of Changes

In what is becoming a recurring pattern (#1144, #1250), MetPy has conflicts with the current state of Pint's master branch! This PR

- cleans up missing `None`s for non-unit arguments with `@units.wraps` (without this, pytest will not run due to an `ImportError`)
- fixes `wet_bulb_temperature` to not assume unit is stripped
- sets `PINT_ARRAY_PROTOCOL_FALLBACK` environment variable to '0' to disable Pint's problematic `__array_struct__` and `__array_interface__` fallback (xref https://github.com/hgrecco/pint/issues/924)
- creates a dummy array Quantity within a warning filter context to bypass Pint's NEP 18 warning

This is likely needed ASAP, since [Pint v0.10 is expected out soon](https://github.com/hgrecco/pint/issues/955)

#### Checklist
- [x] Fully documented