### PR TITLE
fix docs

### DIFF
--- a/src/metpy/plots/declarative.py
+++ b/src/metpy/plots/declarative.py
@@ -1280,9 +1280,8 @@ class PlotObs(HasTraits):
       * fields
       * locations (optional)
       * time_range (optional)
-      * formatters (optional)
+      * formats (optional)
       * colors (optional)
-      * symbol_mapper (optional)
       * vector_field (optional)
       * vector_field_color (optional)
       * reduce_points (optional)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes

Realized that I did not properly change the list of attributes in the PlotObs class after changing the functionality from `formatters` and `symbol_mapper` to `formats`. This PR fixes only those documentation elements.

For some reason it also includes the changes in PR #1259 