### PR TITLE
Change station_id and date_time variables to match declarative syntax

### DIFF
--- a/examples/plots/Station_Plot.py
+++ b/examples/plots/Station_Plot.py
@@ -106,6 +106,6 @@ stationplot.plot_barb(data['eastward_wind'].values, data['northward_wind'].value
 
 # Also plot the actual text of the station id. Instead of cardinal directions,
 # plot further out by specifying a location of 2 increments in x and 0 in y.
-stationplot.plot_text((2, 0), data['station_id'].values)
+stationplot.plot_text((2, 0), data['station'].values)
 
 plt.show()

--- a/tests/io/test_metar.py
+++ b/tests/io/test_metar.py
@@ -11,11 +11,11 @@ from metpy.cbook import get_test_data
 from metpy.io import parse_metar_file, parse_metar_to_dataframe
 
 
-def test_station_id_not_in_dictionary():
+def test_station_not_in_dictionary():
     """Test for when the METAR does not correspond to a station in the dictionary."""
     df = parse_metar_to_dataframe('METAR KLBG 261155Z AUTO 00000KT 10SM CLR 05/00 A3001 RMK '
                                   'AO2=')
-    assert df.station_id.values == 'KLBG'
+    assert df.station.values == 'KLBG'
     assert_almost_equal(df.latitude.values, np.nan)
     assert_almost_equal(df.longitude.values, np.nan)
     assert_almost_equal(df.elevation.values, np.nan)
@@ -39,7 +39,7 @@ def test_few_clouds_():
     assert df.cloud_coverage.values == 2
     assert_almost_equal(df.wind_direction.values, np.nan)
     assert_almost_equal(df.wind_speed.values, np.nan)
-    assert_almost_equal(df.date_time.values, np.nan)
+    assert_almost_equal(df.time.values, np.nan)
 
 
 def test_all_weather_given():
@@ -47,7 +47,7 @@ def test_all_weather_given():
     df = parse_metar_to_dataframe('METAR RJOI 261155Z 00000KT 4000 -SHRA BR VCSH BKN009 '
                                   'BKN015 OVC030 OVC040 22/21 A2987 RMK SHRAB35E44 SLP114 '
                                   'VCSH S-NW P0000 60021 70021 T02220206 10256 20211 55000=')
-    assert df.station_id.values == 'RJOI'
+    assert df.station.values == 'RJOI'
     assert_almost_equal(df.latitude.values, 34.14, decimal=2)
     assert_almost_equal(df.longitude.values, 132.22, decimal=2)
     assert df.current_wx1.values == '-SHRA'
@@ -89,11 +89,11 @@ def test_vertical_vis():
     assert df.low_cloud_type.values == 'VV'
 
 
-def test_date_time_given():
-    """Test for when date_time is given."""
+def test_time_given():
+    """Test for when time is given."""
     df = parse_metar_to_dataframe('K6B0 261200Z AUTO 00000KT 10SM CLR 20/M17 A3002 RMK AO2 '
                                   'T01990165=', year=2019, month=6)
-    assert_equal(df['date_time'][0], datetime(2019, 6, 26, 12))
+    assert_equal(df['time'][0], datetime(2019, 6, 26, 12))
     assert df.eastward_wind.values == 0
     assert df.northward_wind.values == 0
 
@@ -113,7 +113,7 @@ def test_parse_file():
     """Test the parser on an entire file."""
     input_file = get_test_data('metar_20190701_1200.txt', as_file_obj=False)
     df = parse_metar_file(input_file)
-    test = df[df.station_id == 'KVPZ']
+    test = df[df.station == 'KVPZ']
     assert test.air_temperature.values == 23
     assert test.air_pressure_at_sea_level.values == 1016.76
 
@@ -122,7 +122,7 @@ def test_parse_file_object():
     """Test the parser reading from a file-like object."""
     input_file = get_test_data('metar_20190701_1200.txt', mode='rt')
     df = parse_metar_file(input_file)
-    test = df[df.station_id == 'KOKC']
+    test = df[df.station == 'KOKC']
     assert test.air_temperature.values == 21
     assert test.dew_point_temperature.values == 21
     assert test.altimeter.values == 30.03


### PR DESCRIPTION
#### Description Of Changes
Changes variable names of parsed METARs to match variable names within the point observation declarative syntax. All instances of variable `date_time` are changed to `time` in addition to `station_id` changed to `station`. Changing the variable names will ensure the dataframe generated is compatible with the declarative plotting functions within MetPy. 
