### PR TITLE
adds function to lookup and add station lat/lon to dataframe

### DIFF
--- a/src/metpy/io/station_data.py
+++ b/src/metpy/io/station_data.py
@@ -4,6 +4,7 @@
 """Pull out station metadata."""
 from collections import namedtuple
 
+import numpy as np
 import pandas as pd
 
 from ..cbook import get_test_data
@@ -138,3 +139,36 @@ class StationLookup:
 
 with exporter:
     station_info = StationLookup()
+
+
+@exporter.export
+def add_station_lat_lon(df, stn_var):
+    """Lookup station information to add the station latitude and longitude to the DataFrame.
+
+    This function will add two columns to the DataFrame ('latitude' and 'longitude') after
+    looking up all unique station identifiers available in the DataFrame.
+
+    Parameters
+    ----------
+    df : `pandas.DataFrame`
+        The DataFrame that contains the station observations
+    stn_var : str
+        The string of the variable name that represents the station in the DataFrame. Common
+        examples are 'station', 'stid', and 'station_id'
+
+    Returns
+    -------
+    `pandas.DataFrame` that contains original Dataframe now with the latitude and longitude
+    values for each location found in `station_info`.
+    """
+    df['latitude'] = None
+    df['longitude'] = None
+    for stn in df[stn_var].unique():
+        try:
+            info = station_info[stn]
+            df.loc[df[stn_var] == stn, 'latitude'] = info.latitude
+            df.loc[df[stn_var] == stn, 'longitude'] = info.longitude
+        except AttributeError:
+            df.loc[df[stn_var] == stn, 'latitude'] = np.nan
+            df.loc[df[stn_var] == stn, 'longitude'] = np.nan
+    return df

--- a/src/metpy/io/station_data.py
+++ b/src/metpy/io/station_data.py
@@ -168,7 +168,7 @@ def add_station_lat_lon(df, stn_var):
             info = station_info[stn]
             df.loc[df[stn_var] == stn, 'latitude'] = info.latitude
             df.loc[df[stn_var] == stn, 'longitude'] = info.longitude
-        except AttributeError:
+        except KeyError:
             df.loc[df[stn_var] == stn, 'latitude'] = np.nan
             df.loc[df[stn_var] == stn, 'longitude'] = np.nan
     return df

--- a/tests/io/test_station_data.py
+++ b/tests/io/test_station_data.py
@@ -1,7 +1,8 @@
-# Copyright (c) 2008,2015,2016,2017,2018,2019,2020 MetPy Developers.
+# Copyright (c) 2020 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Test station data information."""
+import numpy as np
 from numpy.testing import assert_almost_equal
 import pandas as pd
 
@@ -10,7 +11,7 @@ from metpy.io import add_station_lat_lon
 
 def test_add_lat_lon_station_data():
     """Test for when the METAR does not correspond to a station in the dictionary."""
-    df = pd.DataFrame({'station': ['KOUN', 'KVPZ', 'KDEN']})
+    df = pd.DataFrame({'station': ['KOUN', 'KVPZ', 'KDEN', 'KAAA']})
 
     df = add_station_lat_lon(df, 'station')
     assert_almost_equal(df.loc[df.station == 'KOUN'].latitude.values, 35.25)
@@ -19,3 +20,5 @@ def test_add_lat_lon_station_data():
     assert_almost_equal(df.loc[df.station == 'KVPZ'].longitude.values, -87)
     assert_almost_equal(df.loc[df.station == 'KDEN'].latitude.values, 39.85)
     assert_almost_equal(df.loc[df.station == 'KDEN'].longitude.values, -104.65)
+    assert_almost_equal(df.loc[df.station == 'PAAA'].longitude.values, np.nan)
+    assert_almost_equal(df.loc[df.station == 'PAAA'].longitude.values, np.nan)

--- a/tests/io/test_station_data.py
+++ b/tests/io/test_station_data.py
@@ -11,14 +11,14 @@ from metpy.io import add_station_lat_lon
 
 def test_add_lat_lon_station_data():
     """Test for when the METAR does not correspond to a station in the dictionary."""
-    df = pd.DataFrame({'station': ['KOUN', 'KVPZ', 'KDEN', 'KAAA']})
+    df = pd.DataFrame({'station': ['KOUN', 'KVPZ', 'KDEN', 'PAAA']})
 
     df = add_station_lat_lon(df, 'station')
-    assert_almost_equal(df.loc[df.station == 'KOUN'].latitude.values, 35.25)
-    assert_almost_equal(df.loc[df.station == 'KOUN'].longitude.values, -97.47)
-    assert_almost_equal(df.loc[df.station == 'KVPZ'].latitude.values, 41.45)
-    assert_almost_equal(df.loc[df.station == 'KVPZ'].longitude.values, -87)
-    assert_almost_equal(df.loc[df.station == 'KDEN'].latitude.values, 39.85)
-    assert_almost_equal(df.loc[df.station == 'KDEN'].longitude.values, -104.65)
-    assert_almost_equal(df.loc[df.station == 'PAAA'].longitude.values, np.nan)
-    assert_almost_equal(df.loc[df.station == 'PAAA'].longitude.values, np.nan)
+    assert_almost_equal(df.loc[df.station == 'KOUN'].latitude.values[0], 35.25)
+    assert_almost_equal(df.loc[df.station == 'KOUN'].longitude.values[0], -97.47)
+    assert_almost_equal(df.loc[df.station == 'KVPZ'].latitude.values[0], 41.45)
+    assert_almost_equal(df.loc[df.station == 'KVPZ'].longitude.values[0], -87)
+    assert_almost_equal(df.loc[df.station == 'KDEN'].latitude.values[0], 39.85)
+    assert_almost_equal(df.loc[df.station == 'KDEN'].longitude.values[0], -104.65)
+    assert_almost_equal(df.loc[df.station == 'PAAA'].latitude.values[0], np.nan)
+    assert_almost_equal(df.loc[df.station == 'PAAA'].longitude.values[0], np.nan)

--- a/tests/io/test_station_data.py
+++ b/tests/io/test_station_data.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2008,2015,2016,2017,2018,2019,2020 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Test station data information."""
+from numpy.testing import assert_almost_equal
+import pandas as pd
+
+from metpy.io import add_station_lat_lon
+
+
+def test_add_lat_lon_station_data():
+    """Test for when the METAR does not correspond to a station in the dictionary."""
+    df = pd.DataFrame({'station': ['KOUN', 'KVPZ', 'KDEN']})
+
+    df = add_station_lat_lon(df, 'station')
+    assert_almost_equal(df.loc[df.station == 'KOUN'].latitude.values, 35.25)
+    assert_almost_equal(df.loc[df.station == 'KOUN'].longitude.values, -97.47)
+    assert_almost_equal(df.loc[df.station == 'KVPZ'].latitude.values, 41.45)
+    assert_almost_equal(df.loc[df.station == 'KVPZ'].longitude.values, -87)
+    assert_almost_equal(df.loc[df.station == 'KDEN'].latitude.values, 39.85)
+    assert_almost_equal(df.loc[df.station == 'KDEN'].longitude.values, -104.65)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
This PR adds a simple function to use the `station_info` to add latitude and longitude values to a `pandas.DataFrame`, which will add plotting. This is useful for data obtained from sources that do not send lat/lon information with observations.
#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Tests added
- [x] Fully documented