### PR TITLE
Add percent sign and UDUNITS exponent syntax support via Pint's new preprocessor option

### DIFF
--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -16,6 +16,7 @@ units : :class:`pint.UnitRegistry`
 import functools
 from inspect import Parameter, signature
 import logging
+import re
 import warnings
 
 import numpy as np
@@ -27,7 +28,17 @@ log = logging.getLogger(__name__)
 UndefinedUnitError = pint.UndefinedUnitError
 DimensionalityError = pint.DimensionalityError
 
-units = pint.UnitRegistry(autoconvert_offset_to_baseunit=True)
+# Create registry, with preprocessors for UDUNITS-style powers (m2 s-2) and percent signs
+try:
+    units = pint.UnitRegistry(autoconvert_offset_to_baseunit=True,
+                              preprocessors=[functools.partial(
+                                             re.sub,
+                                             (r'(?<=[A-Za-z])(?![A-Za-z])(?<![0-9\-][eE])'
+                                              r'(?<![0-9\-])(?=[0-9\-])'),
+                                             '**'),
+                                             lambda string: string.replace('%', 'percent')])
+except TypeError:
+    units = pint.UnitRegistry(autoconvert_offset_to_baseunit=True)
 
 # Capture v0.10 NEP 18 warning on first creation
 with warnings.catch_warnings():

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 r"""Tests the operation of MetPy's unit support code."""
 
+from distutils.version import LooseVersion
 import sys
 
 import matplotlib.pyplot as plt
@@ -217,3 +218,17 @@ def test_assert_nan_checks_units():
     """Test that assert_nan properly checks units."""
     with pytest.raises(AssertionError):
         assert_nan(np.nan * units.m, units.second)
+
+
+@pytest.mark.skipif(LooseVersion(pint.__version__) < LooseVersion('0.10'),
+                    reason='Custom preprocessors only available in Pint 0.10')
+def test_percent_units():
+    """Test that percent sign units are properly parsed and interpreted."""
+    assert str(units('%').units) == 'percent'
+
+
+@pytest.mark.skipif(LooseVersion(pint.__version__) < LooseVersion('0.10'),
+                    reason='Custom preprocessors only available in Pint 0.10')
+def test_udunits_power_syntax():
+    """Test that UDUNITS style powers are properly parsed and interpreted."""
+    assert units('m2 s-2').units == units.m ** 2 / units.s ** 2


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes

Now that Pint v0.10 has been released, the string preprocessor option in https://github.com/hgrecco/pint/pull/911 is available. So, let's use it as discussed in #1134.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1134
- [x] Tests added