### PR TITLE
Fix MetPyDatasetAccessor error in assign_latitude_longitude()

### DIFF
--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -727,7 +727,7 @@ class MetPyDatasetAccessor:
             return self._dataset
         else:
             latitude, longitude = _build_latitude_longitude(grid_prototype)
-            return self.assign_coords(latitude=latitude, longitude=longitude)
+            return self._dataset.assign_coords(latitude=latitude, longitude=longitude)
 
     def assign_y_x(self, force=False, tolerance=None):
         """Assign y and x dimension coordinates derived from 2D latitude and longitude.

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -852,6 +852,16 @@ def test_assign_latitude_longitude_force_existing_dataarray(
     np.testing.assert_array_almost_equal(test_coord_helper_da_latlon['longitude'].values,
                                          lon.values, 3)
 
+def test_assign_latitude_longitude_basic_dataset(test_coord_helper_da_yx,
+                                           test_coord_helper_da_latlon):
+    """Test assign_latitude_longitude in basic usage on Dataset"""
+    ds = test_coord_helper_da_yx.to_dataset(name='test').metpy.assign_latitude_longitude()
+    lat, lon = ds['test'].metpy.coordinates('latitude', 'longitude'(
+    np.testing.assert_array_almost_equal(test_coord_helper_da_latlon['latitude'].values,
+                                         lat.values, 3)
+    np.testing.assert_array_almost_equal(test_coord_helper_da_latlon['longitude'].values,
+                                         lon.values, 3)
+
 
 def test_assign_y_x_basic_dataarray(test_coord_helper_da_yx, test_coord_helper_da_latlon):
     """Test assign_y_x in basic usage on DataArray."""

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -855,7 +855,7 @@ def test_assign_latitude_longitude_force_existing_dataarray(
 
 def test_assign_latitude_longitude_basic_dataset(test_coord_helper_da_yx,
                                                  test_coord_helper_da_latlon):
-    """Test assign_latitude_longitude in basic usage on Dataset"""
+    """Test assign_latitude_longitude in basic usage on Dataset."""
     ds = test_coord_helper_da_yx.to_dataset(name='test').metpy.assign_latitude_longitude()
     lat, lon = ds['test'].metpy.coordinates('latitude', 'longitude')
     np.testing.assert_array_almost_equal(test_coord_helper_da_latlon['latitude'].values,

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -853,10 +853,10 @@ def test_assign_latitude_longitude_force_existing_dataarray(
                                          lon.values, 3)
 
 def test_assign_latitude_longitude_basic_dataset(test_coord_helper_da_yx,
-                                           test_coord_helper_da_latlon):
+                                                 test_coord_helper_da_latlon):
     """Test assign_latitude_longitude in basic usage on Dataset"""
     ds = test_coord_helper_da_yx.to_dataset(name='test').metpy.assign_latitude_longitude()
-    lat, lon = ds['test'].metpy.coordinates('latitude', 'longitude'(
+    lat, lon = ds['test'].metpy.coordinates('latitude', 'longitude')
     np.testing.assert_array_almost_equal(test_coord_helper_da_latlon['latitude'].values,
                                          lat.values, 3)
     np.testing.assert_array_almost_equal(test_coord_helper_da_latlon['longitude'].values,

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -852,6 +852,7 @@ def test_assign_latitude_longitude_force_existing_dataarray(
     np.testing.assert_array_almost_equal(test_coord_helper_da_latlon['longitude'].values,
                                          lon.values, 3)
 
+
 def test_assign_latitude_longitude_basic_dataset(test_coord_helper_da_yx,
                                                  test_coord_helper_da_latlon):
     """Test assign_latitude_longitude in basic usage on Dataset"""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes

Added the actual dataset to the call to xr.assign_coords() in assign_latitude_longitude() for the DatasetAccessor to resolve MetPyDatasetAccessor error. Relevant dialogue can be found in #1090. 

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #xxxx
- [x] Tests added
- [ ] Fully documented