### PR TITLE
Added solar irradiance at orbit radius function

### DIFF
--- a/src/metpy/calc/basic.py
+++ b/src/metpy/calc/basic.py
@@ -587,6 +587,32 @@ def coriolis_parameter(latitude):
 
 @exporter.export
 @preprocess_xarray
+@check_units('[length]')  
+def earth_solar_irradiance_r(radius):
+    r"""Caclulates solar irradiance for arbitrary points in 
+    Earth's orbit.
+
+    Parameters
+    ----------
+    radius : `pint.Quantity`
+        Distance from the sun in meters
+
+    Returns
+    -------
+    `pint.Quantity`
+        The corresponding solar irradiance for the orbital radius
+
+    See Also
+    --------
+    earth_solar_irradiance
+
+    """
+    irradiance_at_r = mpconsts.L / (4 * np.pi * radius**2)
+    return irradiance_at_r * units('W / m^2')
+
+
+@exporter.export
+@preprocess_xarray
 @check_units('[pressure]', '[length]')
 def add_height_to_pressure(pressure, height):
     r"""Calculate the pressure at a certain height above another pressure level.

--- a/src/metpy/constants.py
+++ b/src/metpy/constants.py
@@ -14,7 +14,10 @@ earth_gravity            :math:`g`       g           :math:`\text{m s}^{-2}`    
 gravitational_constant   :math:`G`       G           :math:`\text{m}^{3} {kg}^{-1} {s}^{-2}` Gravitational constant
 earth_avg_angular_vel    :math:`\Omega`  omega       :math:`\text{rad s}^{-1}`               Avg. angular velocity of Earth
 earth_sfc_avg_dist_sun   :math:`d`       d           :math:`\text{m}`                        Avg. distance of the Earth from the Sun
+earth_sfc_ahel_dis_sun   :math:`d_a`     da          :math:`\text{m}`                        Aphelion dist. of Earth from the Sun
+earth_sfc_phel_dis_sun   :math:`d_p`     dp          :math:`\text{m}`                        Perihelion dist. of Earth from the Sun
 earth_solar_irradiance   :math:`S`       S           :math:`\text{W m}^{-2}`                 Avg. solar irradiance of Earth
+earth_solar_luminosity   :math:`L`       L           :math: `text{W}`                        Avg. luminosity of sun
 earth_max_declination    :math:`\delta`  delta       :math:`\text{degrees}`                  Max. solar declination angle of Earth
 earth_orbit_eccentricity :math:`e`                   :math:`\text{None}`                     Avg. eccentricity of Earth's orbit
 earth_mass               :math:`m_e`     me          :math:`\text{kg}`                       Total mass of the Earth (approx)
@@ -77,7 +80,10 @@ with exporter:
                                   .to('m^3 / kg / s^2'))
     omega = earth_avg_angular_vel = 2 * units.pi / units.sidereal_day
     d = earth_sfc_avg_dist_sun = 1.496e11 * units.m
+    d_a = earth_sfc_ahel_dis_sun = 1.520e11 * units.m
+    d_p = earth_sfc_phel_dis_sun = 1.471e11 * units.m
     S = earth_solar_irradiance = units.Quantity(1.368e3, 'W / m^2')
+    L = earth_solar_luminosity = units.Quantity(3.828e26, 'W')
     delta = earth_max_declination = 23.45 * units.deg
     earth_orbit_eccentricity = 0.0167
     earth_mass = me = 5.9722e24 * units.kg

--- a/tests/calc/test_basic.py
+++ b/tests/calc/test_basic.py
@@ -11,8 +11,8 @@ import xarray as xr
 from metpy.calc import (add_height_to_pressure, add_pressure_to_height,
                         altimeter_to_sea_level_pressure, altimeter_to_station_pressure,
                         apparent_temperature, coriolis_parameter, earth_solar_irradiance_r,
-                        geopotential_to_height, heat_index, height_to_geopotential, 
-                        height_to_pressure_std, pressure_to_height_std, sigma_to_pressure, 
+                        geopotential_to_height, heat_index, height_to_geopotential,
+                        height_to_pressure_std, pressure_to_height_std, sigma_to_pressure,
                         smooth_circular, smooth_gaussian, smooth_n_point, smooth_rectangular,
                         smooth_window, wind_components, wind_direction, wind_speed, windchill)
 from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal)
@@ -371,8 +371,8 @@ def test_earth_solar_irradiance_r():
     cor = earth_solar_irradiance_r(radius)
     values = np.array([1361.1277179, 1318.4840767, 1407.7862518]) * units('W / m^2')
     assert_almost_equal(cor, values, 7)
-    
-    
+
+
 def test_add_height_to_pressure():
     """Test the pressure at height above pressure calculation."""
     pressure = add_height_to_pressure(1000 * units.hPa, 877.17421094 * units.meter)

--- a/tests/calc/test_basic.py
+++ b/tests/calc/test_basic.py
@@ -10,11 +10,11 @@ import xarray as xr
 
 from metpy.calc import (add_height_to_pressure, add_pressure_to_height,
                         altimeter_to_sea_level_pressure, altimeter_to_station_pressure,
-                        apparent_temperature, coriolis_parameter, geopotential_to_height,
-                        heat_index, height_to_geopotential, height_to_pressure_std,
-                        pressure_to_height_std, sigma_to_pressure, smooth_circular,
-                        smooth_gaussian, smooth_n_point, smooth_rectangular, smooth_window,
-                        wind_components, wind_direction, wind_speed, windchill)
+                        apparent_temperature, coriolis_parameter, earth_solar_irradiance_r,
+                        geopotential_to_height, heat_index, height_to_geopotential, 
+                        height_to_pressure_std, pressure_to_height_std, sigma_to_pressure, 
+                        smooth_circular, smooth_gaussian, smooth_n_point, smooth_rectangular,
+                        smooth_window, wind_components, wind_direction, wind_speed, windchill)
 from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal)
 from metpy.units import units
 
@@ -365,6 +365,14 @@ def test_coriolis_force():
     assert_almost_equal(cor, values, 7)
 
 
+def test_earth_solar_irradiance_r():
+    """Test solar irradiance at radius calculation."""
+    radius = np.array([1.496e11, 1.520e11, 1.471e11]) * units.meter
+    cor = earth_solar_irradiance_r(radius)
+    values = np.array([1361.1277179, 1318.4840767, 1407.7862518]) * units('W / m^2')
+    assert_almost_equal(cor, values, 7)
+    
+    
 def test_add_height_to_pressure():
     """Test the pressure at height above pressure calculation."""
     pressure = add_height_to_pressure(1000 * units.hPa, 877.17421094 * units.meter)


### PR DESCRIPTION
#### Description Of Changes

Added the function and test for 'earth_solar_irradiance_r' to extend the 'earth_solar_irradiance' constant for those interested in orbital variations.

Added related constants 'earth_sfc_ahel_dis_sun' or 'd_a' and 'earth_sfc_phel_dis_sun' or 'd_p' for aphelion and perihelion distances from the sun, respectively.  These distances are reported in "Climatology, 4th Edition" (2018) by Rohli and Vega.

Added solar luminosity constant 'earth_solar_luminosity' or 'L' which is used in the solar irradiance calculation.  The value is the so called 'nominal solar luminosity' by International Astronomical Union Resolution B1.

#### Checklist
- [x] Tests added
- [x] Fully documented