### PR TITLE
Changed io metar default input year, month to None

### DIFF
--- a/src/metpy/io/metar.py
+++ b/src/metpy/io/metar.py
@@ -64,7 +64,7 @@ col_units = {'station_id': None,
 
 
 @exporter.export
-def parse_metar_to_dataframe(metar_text, year=datetime.now().year, month=datetime.now().month):
+def parse_metar_to_dataframe(metar_text, year=None, month=None):
     """Parse a single METAR report into a Pandas DataFrame.
 
     Takes a METAR string in a text form, and creates a `pandas.DataFrame` including the
@@ -119,6 +119,12 @@ def parse_metar_to_dataframe(metar_text, year=datetime.now().year, month=datetim
     and altimeter value, float
 
     """
+    # Defaults year, month to current date if none specified
+    if year is None or month is None:
+        now = datetime.now()
+        year = now.year if year is None else year
+        month = now.month if month is None else month
+
     # Use the named tuple parsing function to separate metar
     # Utilizes the station dictionary which contains elevation, latitude, and longitude
     metar_vars = parse_metar_to_named_tuple(metar_text, station_info, year, month)
@@ -181,8 +187,7 @@ def parse_metar_to_dataframe(metar_text, year=datetime.now().year, month=datetim
     return df
 
 
-def parse_metar_to_named_tuple(metar_text, station_metadata, year=datetime.now().year,
-                               month=datetime.now().month):
+def parse_metar_to_named_tuple(metar_text, station_metadata, year=None, month=None):
     """Parse a METAR report in text form into a list of named tuples.
 
     Parameters
@@ -429,7 +434,7 @@ def parse_metar_to_named_tuple(metar_text, station_metadata, year=datetime.now()
 
 
 @exporter.export
-def parse_metar_file(filename, year=datetime.now().year, month=datetime.now().month):
+def parse_metar_file(filename, year=None, month=None):
     """Parse a text file containing multiple METAR reports and/or text products.
 
     Parameters
@@ -478,6 +483,12 @@ def parse_metar_file(filename, year=datetime.now().year, month=datetime.now().mo
     and altimeter value, float
 
     """
+    # Defaults year, month to current date if none specified
+    if year is None or month is None:
+        now = datetime.now()
+        year = now.year if year is None else year
+        month = now.month if month is None else month
+
     # Function to merge METARs
     def merge(x, key='     '):
         tmp = []


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
Proposing the change to default `parse_metar_file()` and `parse_metar_to_dataframe()` year, month inputs to `None`. If `None` then code will check **once** for the current datetime and pass this to `year` and/or `month` if needed.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [ ] Closes #1327 