### PR TITLE
Add warning to xarray tutorial to avoid Quantity-in-xarray in pre-1.0 MetPy

### DIFF
--- a/tutorials/xarray_tutorial.py
+++ b/tutorials/xarray_tutorial.py
@@ -78,11 +78,23 @@ data = data.rename({
 # -----
 #
 # MetPy's DataArray accessor has a ``unit_array`` property to obtain a ``pint.Quantity`` array
-# of just the data from the DataArray (metadata is removed) and a ``convert_units`` method to
-# convert the the data from one unit to another (keeping it as a DataArray). For now, we'll
-# just use ``convert_units`` to convert our temperature to ``degC``.
+# of just the data from the DataArray (metadata other than units is removed) and a
+# ``convert_units`` method to convert the the data from one unit to another (keeping it as a
+# DataArray). For now, we'll just use ``convert_units`` to convert our temperature to
+# ``degC``.
 
 data['temperature'].metpy.convert_units('degC')
+
+#########################################################################
+# WARNING: Versions of MetPy prior to 1.0 (including 0.12) require units to be in the
+# attributes of your xarray DataArray. If you attempt to use a DataArray containing a
+# ``pint.Quantity`` instead, incorrect results are likely to occur, since these earlier
+# versions of MetPy will ignore the ``pint.Quantity`` and still just rely upon the units
+# attribute. See `GitHub Issue #1358 <https://github.com/Unidata/MetPy/issues/1358>`_ for more
+# details.
+#
+# Note that this changes in newer versions of MetPy as of 1.0, when Quantities-in-xarray
+# became the default behavior.
 
 #########################################################################
 # Coordinates


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes

As suggested in #1358, this adds documentation regarding the requirement in pre-1.0 MetPy that units be in the attributes of your xarray object, and that `pint.Quantity` inside xarray will behave poorly.

I've made this to the 0.12.x branch, but I'm not sure if that's the best place to go for doc updates for 0.12 or not.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1358 
- [x] Fully documented