### PR TITLE
fix ability to read file-like object METAR parse

### DIFF
--- a/src/metpy/io/_tools.py
+++ b/src/metpy/io/_tools.py
@@ -6,6 +6,7 @@
 import bz2
 from collections import namedtuple
 import gzip
+import io
 import logging
 from struct import Struct
 import zlib
@@ -21,14 +22,16 @@ def open_as_needed(filename, mode='rb'):
     """
     if hasattr(filename, 'read'):
         return filename
-
-    if filename.endswith('.bz2'):
-        return bz2.BZ2File(filename, mode)
-    elif filename.endswith('.gz'):
-        return gzip.GzipFile(filename, mode)
-    else:
-        kwargs = {'errors': 'surrogateescape'} if mode != 'rb' else {}
-        return open(filename, mode, **kwargs)
+    try:
+        if filename.endswith('.bz2'):
+            return bz2.BZ2File(filename, mode)
+        elif filename.endswith('.gz'):
+            return gzip.GzipFile(filename, mode)
+        else:
+            kwargs = {'errors': 'surrogateescape'} if mode != 'rb' else {}
+            return open(filename, mode, **kwargs)
+    except OSError:
+        return io.StringIO(filename)
 
 
 class NamedStruct(Struct):

--- a/tests/io/test_metar.py
+++ b/tests/io/test_metar.py
@@ -135,3 +135,23 @@ def test_parse_file_object():
     assert test.air_temperature.values == 21
     assert test.dew_point_temperature.values == 21
     assert test.altimeter.values == 30.03
+
+
+def test_parse_filelike():
+    """Test the parser with a file-like object."""
+    input_data = ('\x01\r\r\n101 \r\r\nSAUS70 KWBC 031200\r\r\nMETAR\r\r\nKI43 031155Z AUTO'
+        ' 00000KT 10SM -DZ OVC110 17/15 A2997 RMK AO2 LTG\r\r\n     DSNT '
+        'NW=\r\r\n\r\r\n\x03\x01\r\r\n945 \r\r\nSAUS70 KWBC 031200\r\r\n'
+        'METAR\r\r\nK27K 031155Z AUTO 00000KT 10SM BKN080 17/13 A2998 RMK AO1=\r\r\n'
+        'KEIK 031148Z AUTO 00000KT 3/4SM BR BKN002 OVC009 09/08 A3012 RMK\r\r\n     '
+        'AO2 T00880083=\r\r\nKVTP 031148Z AUTO 25006KT 230V290 10SM CLR 04/M08 A3029 RMK '
+        'AO2\r\r\n     TSNO=\r\r\n\r\r\n\x03\x01\r\r\n839 \r\r\nSAUS14 KAWN 031200\r\r\n'
+        'METAR KEIK 031148Z AUTO 00000KT 3/4SM BR BKN002 OVC009 09/08 A3012\r\r\n      '
+        'RMK AO2 T00880083=\r\r\nMETAR KVTP 031148Z AUTO 25006KT 230V290 10SM CLR 04/M08 '
+        'A3029 RMK AO2\r\r\n      TSNO=\r\r\n\r\r\n\x03\x01\r\r\n892 \r\r\nSAMX52 MMGL 031200'
+        '\r\r\nMETAR MMPN 031140Z 00000KT 3SM FU  SKC 16/10 A3019 RMK RTS=')
+    df = parse_metar_file(input_data)
+    test = df[df.station_id == 'KVTP']
+    assert test.air_temperature.values == 4
+    assert test.dew_point_temperature.values == -8
+    assert test.altimeter.values == 30.29


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
This PR fixes the ability to read a file-like object for METAR data. This came up as a result of trying to read a remote METAR file and not being able to push through a string of text as a file-like object. For example, this modest change will now allow for the ability to read from a remote meter file through using urlrequest.

#### Example
```python
from datetime import datetime

from metpy.io import metar

date = datetime(2020, 5, 3, 12)

# Download current data from http://bergeron.valpo.edu/current_surface_data
file = f'http://bergeron.valpo.edu/current_surface_data/{date:%Y%m%d%H}_sao.wmo'
data = requests.get(file)
df = metar.parse_metar_file(data.text, year=date.year, month=date.month)
```
#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Tests added
- [x] Fully documented