### PR TITLE
Edits to MetPy; adding capitals, making website look more cohessive

### DIFF
--- a/src/metpy/calc/basic.py
+++ b/src/metpy/calc/basic.py
@@ -43,7 +43,7 @@ def wind_speed(u, v):
     Returns
     -------
     wind speed: `pint.Quantity`
-        The speed of the wind
+        Speed of the wind
 
     See Also
     --------
@@ -67,14 +67,14 @@ def wind_direction(u, v, convention='from'):
     v : `pint.Quantity`
         Wind component in the Y (North-South) direction
     convention : str
-        Convention to return direction. 'from' returns the direction the wind is coming from
-        (meteorological convention). 'to' returns the direction the wind is going towards
-        (oceanographic convention). Default is 'from'.
+        Convention to return direction; 'from' returns the direction the wind is coming from
+        (meteorological convention), 'to' returns the direction the wind is going towards
+        (oceanographic convention), default is 'from'.
 
     Returns
     -------
     direction: `pint.Quantity`
-        The direction of the wind in interval [0, 360] degrees, with 360 being North, with the
+        The direction of the wind in intervals [0, 360] degrees, with 360 being North,
         direction defined by the convention kwarg.
 
     See Also
@@ -117,9 +117,9 @@ def wind_components(speed, wind_direction):
     Parameters
     ----------
     speed : `pint.Quantity`
-        The wind speed (magnitude)
+        Wind speed (magnitude)
     wind_direction : `pint.Quantity`
-        The wind direction, specified as the direction from which the wind is
+        Wind direction, specified as the direction from which the wind is
         blowing (0-2 pi radians or 0-360 degrees), with 360 degrees being North.
 
     Returns
@@ -158,14 +158,14 @@ def windchill(temperature, speed, face_level_winds=False, mask_undefined=True):
     Specifically, these formulas assume that wind speed is measured at
     10m.  If, instead, the speeds are measured at face level, the winds
     need to be multiplied by a factor of 1.5 (this can be done by specifying
-    `face_level_winds` as `True`.)
+    `face_level_winds` as `True`).
 
     Parameters
     ----------
     temperature : `pint.Quantity`
-        The air temperature
+        Air temperature
     speed : `pint.Quantity`
-        The wind speed at 10m.  If instead the winds are at face level,
+        Wind speed at 10m. If instead the winds are at face level,
         `face_level_winds` should be set to `True` and the 1.5 multiplicative
         correction will be applied automatically.
     face_level_winds : bool, optional
@@ -181,7 +181,7 @@ def windchill(temperature, speed, face_level_winds=False, mask_undefined=True):
     Returns
     -------
     `pint.Quantity`
-        The corresponding Wind Chill Temperature Index value(s)
+        Corresponding Wind Chill Temperature Index value(s)
 
     See Also
     --------
@@ -231,7 +231,7 @@ def heat_index(temperature, relative_humidity, mask_undefined=True):
     Returns
     -------
     `pint.Quantity`
-        The corresponding Heat Index value(s)
+        Corresponding Heat Index value(s)
 
     Other Parameters
     ----------------
@@ -327,12 +327,12 @@ def apparent_temperature(temperature, relative_humidity, speed, face_level_winds
     Parameters
     ----------
     temperature : `pint.Quantity`
-        The air temperature
+        Air temperature
     relative_humidity : `pint.Quantity`
-        The relative humidity expressed as a unitless ratio in the range [0, 1].
+        Relative humidity expressed as a unitless ratio in the range [0, 1].
         Can also pass a percentage if proper units are attached.
     speed : `pint.Quantity`
-        The wind speed at 10m.  If instead the winds are at face level,
+        Wind speed at 10m.  If instead the winds are at face level,
         `face_level_winds` should be set to `True` and the 1.5 multiplicative
         correction will be applied automatically.
     face_level_winds : bool, optional
@@ -350,7 +350,7 @@ def apparent_temperature(temperature, relative_humidity, speed, face_level_winds
     Returns
     -------
     `pint.Quantity`
-        The corresponding apparent temperature value(s)
+        Corresponding apparent temperature value(s)
 
     See Also
     --------
@@ -409,7 +409,7 @@ def pressure_to_height_std(pressure):
     Returns
     -------
     `pint.Quantity`
-        The corresponding height value(s)
+        Corresponding height value(s)
 
     Notes
     -----
@@ -434,7 +434,8 @@ def height_to_geopotential(height):
     .. math:: \Phi = \frac{g R_e z}{R_e + z}
 
     (where :math:`\Phi` is geopotential, :math:`z` is height, :math:`R_e` is average Earth
-    radius, and :math:`g` is standard gravity.)
+    radius, and :math:`g` is standard gravity).
+
 
     Parameters
     ----------
@@ -444,7 +445,7 @@ def height_to_geopotential(height):
     Returns
     -------
     `pint.Quantity`
-        The corresponding geopotential value(s)
+        Corresponding geopotential value(s)
 
     Examples
     --------
@@ -468,7 +469,7 @@ def height_to_geopotential(height):
     centrifugal force and Earth's eccentricity.
 
     (Prior to MetPy v0.11, this formula instead calculated :math:`g(z)` from Newton's Law of
-    Gravitation assuming a spherical Earth and no centrifugal force effects.)
+    Gravitation assuming a spherical Earth and no centrifugal force effects).
 
     See Also
     --------
@@ -490,7 +491,8 @@ def geopotential_to_height(geopotential):
     .. math:: z = \frac{\Phi R_e}{gR_e - \Phi}
 
     (where :math:`\Phi` is geopotential, :math:`z` is height, :math:`R_e` is average Earth
-    radius, and :math:`g` is standard gravity.)
+    radius, and :math:`g` is standard gravity).
+
 
     Parameters
     ----------
@@ -500,7 +502,7 @@ def geopotential_to_height(geopotential):
     Returns
     -------
     `pint.Quantity`
-        The corresponding value(s) of height above sea level
+        Corresponding value(s) of height above sea level
 
     Examples
     --------
@@ -554,7 +556,7 @@ def height_to_pressure_std(height):
     Returns
     -------
     `pint.Quantity`
-        The corresponding pressure value(s)
+        Corresponding pressure value(s)
 
     Notes
     -----
@@ -580,7 +582,7 @@ def coriolis_parameter(latitude):
     Returns
     -------
     `pint.Quantity`
-        The corresponding coriolis force at each point
+        Corresponding coriolis force at each point
 
     """
     latitude = _check_radians(latitude, max_radians=np.pi / 2)
@@ -605,7 +607,7 @@ def add_height_to_pressure(pressure, height):
     Returns
     -------
     `pint.Quantity`
-        The corresponding pressure value for the height above the pressure level
+        Corresponding pressure value for the height above the pressure level
 
     See Also
     --------
@@ -654,22 +656,22 @@ def sigma_to_pressure(sigma, pressure_sfc, pressure_top):
     Parameters
     ----------
     sigma : ndarray
-        The sigma levels to be converted to pressure levels.
+        Sigma levels to be converted to pressure levels
 
     pressure_sfc : `pint.Quantity`
-        The surface pressure value.
+        Surface pressure value
 
     pressure_top : `pint.Quantity`
-        The pressure value at the top of the model domain.
+        Pressure value at the top of the model domain
 
     Returns
     -------
     `pint.Quantity`
-        The pressure values at the given sigma levels.
+        Pressure values at the given sigma levels
 
     Notes
     -----
-    Sigma definition adapted from [Philips1957]_.
+    Sigma definition adapted from [Philips1957]_:
 
     .. math:: p = \sigma * (p_{sfc} - p_{top}) + p_{top}
 
@@ -709,7 +711,7 @@ def smooth_gaussian(scalar_grid, n):
 
     Notes
     -----
-    This function is a close replication of the GEMPAK function GWFS,
+    This function is a close replication of the GEMPAK function ``GWFS``,
     but is not identical.  The following notes are incorporated from
     the GEMPAK source code:
 
@@ -717,9 +719,9 @@ def smooth_gaussian(scalar_grid, n):
     low-pass filter whose weights are determined by the normal
     (Gaussian) probability distribution function for two dimensions.
     The weight given to any grid point within the area covered by the
-    moving average for a target grid point is proportional to
+    moving average for a target grid point is proportional to:
 
-                    EXP [ -( D ** 2 ) ],
+    .. math:: e^{-D^2}
 
     where D is the distance from that point to the target point divided
     by the standard deviation of the normal distribution.  The value of
@@ -788,10 +790,10 @@ def smooth_window(scalar_grid, window, passes=1, normalize_weights=True):
     Parameters
     ----------
     scalar_grid : array-like
-        N-dimensional scalar grid to be smoothed.
+        N-dimensional scalar grid to be smoothed
 
     window : ndarray
-        The window to use in smoothing. Can have dimension less than or equal to N. If
+        Window to use in smoothing. Can have dimension less than or equal to N. If
         dimension less than N, the scalar grid will be smoothed along its trailing dimensions.
         Shape along each dimension must be odd.
 
@@ -806,7 +808,7 @@ def smooth_window(scalar_grid, window, passes=1, normalize_weights=True):
     Returns
     -------
     array-like
-        The filtered scalar grid.
+        The filtered scalar grid
 
     Notes
     -----
@@ -879,10 +881,10 @@ def smooth_rectangular(scalar_grid, size, passes=1):
     Parameters
     ----------
     scalar_grid : array-like
-        N-dimensional scalar grid to be smoothed.
+        N-dimensional scalar grid to be smoothed
 
     size : int or sequence of ints
-        Shape of rectangle along the trailing dimension(s) of the scalar grid.
+        Shape of rectangle along the trailing dimension(s) of the scalar grid
 
     passes : int
         The number of times to apply the filter to the grid. Defaults to 1.
@@ -890,7 +892,7 @@ def smooth_rectangular(scalar_grid, size, passes=1):
     Returns
     -------
     array-like
-        The filtered scalar grid.
+        The filtered scalar grid
 
     Notes
     -----
@@ -929,7 +931,7 @@ def smooth_circular(scalar_grid, radius, passes=1):
     Returns
     -------
     array-like
-        The filtered scalar grid.
+        The filtered scalar grid
 
     Notes
     -----
@@ -975,7 +977,7 @@ def smooth_n_point(scalar_grid, n=5, passes=1):
     Returns
     -------
     array-like or `pint.Quantity`
-        The filtered scalar grid.
+        The filtered scalar grid
 
     Notes
     -----
@@ -1030,14 +1032,15 @@ def altimeter_to_station_pressure(altimeter_value, height):
     altimeter_value : `pint.Quantity`
         The altimeter setting value as defined by the METAR or other observation,
         which can be measured in either inches of mercury (in. Hg) or millibars (mb)
+
     height: `pint.Quantity`
-        Elevation of the station measuring pressure.
+        Elevation of the station measuring pressure
 
     Returns
     -------
     `pint.Quantity`
-        The station pressure in hPa or in. Hg, which can be used to calculate sea-level
-        pressure
+        The station pressure in hPa or in. Hg. Can be used to calculate sea-level
+        pressure.
 
     See Also
     --------
@@ -1055,7 +1058,7 @@ def altimeter_to_station_pressure(altimeter_value, height):
      .. math::  F = \left [1 + \left(\frac{p_{0}^n a}{T_{0}} \right)
                    \frac{H_{b}}{p_{1}^n} \right ] ^ \frac{1}{n}
 
-    Where
+    Where,
 
     :math:`p_{0}` = standard sea-level pressure = 1013.25 mb
 
@@ -1066,11 +1069,10 @@ def altimeter_to_station_pressure(altimeter_value, height):
 
     :math:`t_{0}` = standard sea-level temperature 288 K
 
-    :math:`H_{b} =` station elevation in meters (elevation for which station
-      pressure is given)
+    :math:`H_{b} =` station elevation in meters (elevation for which station pressure is given)
 
-    :math:`n = \frac{a R_{d}}{g} = 0.190284` where :math:`R_{d}` is the gas
-      constant for dry air
+    :math:`n = \frac{a R_{d}}{g} = 0.190284` where :math:`R_{d}` is the gas constant for dry
+    air
 
     And solving for :math:`p_{mb}` results in the equation below, which is used to
     calculate station pressure :math:`(p_{mb})`
@@ -1099,7 +1101,7 @@ def altimeter_to_sea_level_pressure(altimeter_value, height, temperature):
     This function is useful for working with METARs since most provide
     altimeter values, but not sea-level pressure, which is often plotted
     on surface maps. The following definitions of altimeter setting, station pressure, and
-    sea-level pressure are taken from [Smithsonian1951]_
+    sea-level pressure are taken from [Smithsonian1951]_.
     Altimeter setting is the pressure value to which an aircraft altimeter scale
     is set so that it will indicate the altitude above mean sea-level of an aircraft
     on the ground at the location for which the value is determined. It assumes a standard
@@ -1115,9 +1117,11 @@ def altimeter_to_sea_level_pressure(altimeter_value, height, temperature):
     ----------
     altimeter_value : 'pint.Quantity'
         The altimeter setting value is defined by the METAR or other observation,
-        with units of inches of mercury (in Hg) or millibars (hPa)
+        with units of inches of mercury (in Hg) or millibars (hPa).
+
     height  : 'pint.Quantity'
         Elevation of the station measuring pressure. Often times measured in meters
+
     temperature : 'pint.Quantity'
         Temperature at the station
 
@@ -1125,7 +1129,7 @@ def altimeter_to_sea_level_pressure(altimeter_value, height, temperature):
     -------
     'pint.Quantity'
         The sea-level pressure in hPa and makes pressure values easier to compare
-        between different stations
+        between different stations.
 
     See Also
     --------
@@ -1133,7 +1137,7 @@ def altimeter_to_sea_level_pressure(altimeter_value, height, temperature):
 
     Notes
     -----
-    This function is implemented using the following equations from Wallace and Hobbs (1977)
+    This function is implemented using the following equations from Wallace and Hobbs (1977).
 
     Equation 2.29:
      .. math::
@@ -1167,15 +1171,15 @@ def _check_radians(value, max_radians=2 * np.pi):
     Parameters
     ----------
     value : `pint.Quantity`
-        The input value to check.
+        Input value to check
 
     max_radians : float
-        Maximum absolute value of radians before warning.
+        Maximum absolute value of radians before warning
 
     Returns
     -------
     `pint.Quantity`
-        The input value
+        Input value
 
     """
     try:

--- a/src/metpy/calc/cross_sections.py
+++ b/src/metpy/calc/cross_sections.py
@@ -69,7 +69,7 @@ def latitude_from_cross_section(cross):
     Parameters
     ----------
     cross : `xarray.DataArray`
-        The input DataArray of a cross-section from which to obtain latitudes.
+        The input DataArray of a cross-section from which to obtain latitudes
 
     Returns
     -------
@@ -97,7 +97,7 @@ def unit_vectors_from_cross_section(cross, index='index'):
     r"""Calculate the unit tanget and unit normal vectors from a cross-section.
 
     Given a path described parametrically by :math:`\vec{l}(i) = (x(i), y(i))`, we can find
-    the unit tangent vector by the formula
+    the unit tangent vector by the formula:
 
     .. math:: \vec{T}(i) =
         \frac{1}{\sqrt{\left( \frac{dx}{di} \right)^2 + \left( \frac{dy}{di} \right)^2}}
@@ -109,16 +109,17 @@ def unit_vectors_from_cross_section(cross, index='index'):
     Parameters
     ----------
     cross : `xarray.DataArray`
-        The input DataArray of a cross-section from which to obtain latitudes.
+        The input DataArray of a cross-section from which to obtain latitudes
+
     index : `str`, optional
         A string denoting the index coordinate of the cross section, defaults to 'index' as
-        set by `metpy.interpolate.cross_section`.
+        set by `metpy.interpolate.cross_section`
 
     Returns
     -------
     unit_tangent_vector, unit_normal_vector : tuple of `numpy.ndarray`
         Arrays describing the unit tangent and unit normal vectors (in x,y) for all points
-        along the cross section.
+        along the cross section
 
     """
     x, y = distances_from_cross_section(cross)
@@ -140,6 +141,7 @@ def cross_section_components(data_x, data_y, index='index'):
     data_x : `xarray.DataArray`
         The input DataArray of the x-component (in terms of data projection) of the vector
         field.
+
     data_y : `xarray.DataArray`
         The input DataArray of the y-component (in terms of data projection) of the vector
         field.
@@ -147,8 +149,7 @@ def cross_section_components(data_x, data_y, index='index'):
     Returns
     -------
     component_tangential, component_normal: tuple of `xarray.DataArray`
-        The components of the vector field in the tangential and normal directions,
-        respectively.
+        Components of the vector field in the tangential and normal directions, respectively
 
     See Also
     --------
@@ -186,7 +187,7 @@ def normal_component(data_x, data_y, index='index'):
     Returns
     -------
     component_normal: `xarray.DataArray`
-        The component of the vector field in the normal directions.
+        Component of the vector field in the normal directions
 
     See Also
     --------
@@ -219,15 +220,16 @@ def tangential_component(data_x, data_y, index='index'):
     ----------
     data_x : `xarray.DataArray`
         The input DataArray of the x-component (in terms of data projection) of the vector
-        field.
+        field
+
     data_y : `xarray.DataArray`
         The input DataArray of the y-component (in terms of data projection) of the vector
-        field.
+        field
 
     Returns
     -------
     component_tangential: `xarray.DataArray`
-        The component of the vector field in the tangential directions.
+        Component of the vector field in the tangential directions
 
     See Also
     --------
@@ -257,7 +259,7 @@ def absolute_momentum(u, v, index='index'):
     r"""Calculate cross-sectional absolute momentum (also called pseudoangular momentum).
 
     As given in [Schultz1999]_, absolute momentum (also called pseudoangular momentum) is
-    given by
+    given by:
 
     .. math:: M = v + fx
 
@@ -279,7 +281,7 @@ def absolute_momentum(u, v, index='index'):
     Returns
     -------
     absolute_momentum: `xarray.DataArray`
-        The absolute momentum
+        Absolute momentum
 
     Notes
     -----

--- a/src/metpy/calc/indices.py
+++ b/src/metpy/calc/indices.py
@@ -24,23 +24,26 @@ def precipitable_water(pressure, dewpoint, *, bottom=None, top=None):
 
     .. math::  -\frac{1}{\rho_l g} \int\limits_{p_\text{bottom}}^{p_\text{top}} r dp
 
-    from [Salby1996]_, p. 28.
+    from [Salby1996]_, p. 28
 
     Parameters
     ----------
     pressure : `pint.Quantity`
         Atmospheric pressure profile
+
     dewpoint : `pint.Quantity`
         Atmospheric dewpoint profile
+
     bottom: `pint.Quantity`, optional
         Bottom of the layer, specified in pressure. Defaults to None (highest pressure).
+
     top: `pint.Quantity`, optional
-        The top of the layer, specified in pressure. Defaults to None (lowest pressure).
+        Top of the layer, specified in pressure. Defaults to None (lowest pressure).
 
     Returns
     -------
     `pint.Quantity`
-        The precipitable water in the layer
+        Precipitable water in the layer
 
     Examples
     --------
@@ -89,18 +92,22 @@ def mean_pressure_weighted(pressure, *args, height=None, bottom=None, depth=None
     ----------
     pressure : `pint.Quantity`
         Atmospheric pressure profile
+
     args : `pint.Quantity`
-        Parameters for which the pressure-weighted mean is to be calculated.
+        Parameters for which the pressure-weighted mean is to be calculated
+
     height : `pint.Quantity`, optional
         Heights from sounding. Standard atmosphere heights assumed (if needed)
         if no heights are given.
+
     bottom: `pint.Quantity`, optional
         The bottom of the layer in either the provided height coordinate
         or in pressure. Don't provide in meters AGL unless the provided
         height coordinate is meters AGL. Default is the first observation,
         assumed to be the surface.
+
     depth: `pint.Quantity`, optional
-        The depth of the layer in meters or hPa.
+        Depth of the layer in meters or hPa
 
     Returns
     -------
@@ -142,10 +149,13 @@ def bunkers_storm_motion(pressure, u, v, height):
     ----------
     pressure : `pint.Quantity`
         Pressure from sounding
+
     u : `pint.Quantity`
         U component of the wind
+
     v : `pint.Quantity`
         V component of the wind
+
     height : `pint.Quantity`
         Height from sounding
 
@@ -153,8 +163,10 @@ def bunkers_storm_motion(pressure, u, v, height):
     -------
     right_mover: `pint.Quantity`
         U and v component of Bunkers RM storm motion
+
     left_mover: `pint.Quantity`
         U and v component of Bunkers LM storm motion
+
     wind_mean: `pint.Quantity`
         U and v component of sfc-6km mean flow
 
@@ -208,14 +220,19 @@ def bulk_shear(pressure, u, v, height=None, bottom=None, depth=None):
     ----------
     pressure : `pint.Quantity`
         Atmospheric pressure profile
+
     u : `pint.Quantity`
-        U-component of wind.
+        U-component of wind
+
     v : `pint.Quantity`
-        V-component of wind.
+        V-component of wind
+
     height : `pint.Quantity`, optional
         Heights from sounding
+
     depth: `pint.Quantity`, optional
         The depth of the layer in meters or hPa. Defaults to 100 hPa.
+
     bottom: `pint.Quantity`, optional
         The bottom of the layer in height or pressure coordinates.
         If using a height, it must be in the same coordinates as the given
@@ -225,9 +242,9 @@ def bulk_shear(pressure, u, v, height=None, bottom=None, depth=None):
     Returns
     -------
     u_shr: `pint.Quantity`
-        u-component of layer bulk shear
+        U-component of layer bulk shear
     v_shr: `pint.Quantity`
-        v-component of layer bulk shear
+        V-component of layer bulk shear
 
     Notes
     -----
@@ -267,15 +284,17 @@ def supercell_composite(mucape, effective_storm_helicity, effective_shear):
     ----------
     mucape : `pint.Quantity`
         Most-unstable CAPE
+
     effective_storm_helicity : `pint.Quantity`
         Effective-layer storm-relative helicity
+
     effective_shear : `pint.Quantity`
         Effective bulk shear
 
     Returns
     -------
     `pint.Quantity`
-        supercell composite
+        Supercell composite
 
     """
     effective_shear = np.clip(np.atleast_1d(effective_shear), None, 20 * units('m/s'))
@@ -313,17 +332,20 @@ def significant_tornado(sbcape, surface_based_lcl_height, storm_helicity_1km, sh
     ----------
     sbcape : `pint.Quantity`
         Surface-based CAPE
+
     surface_based_lcl_height : `pint.Quantity`
         Surface-based lifted condensation level
+
     storm_helicity_1km : `pint.Quantity`
         Surface-1km storm-relative helicity
+
     shear_6km : `pint.Quantity`
         Surface-6km bulk shear
 
     Returns
     -------
     `pint.Quantity`
-        significant tornado parameter
+        Significant tornado parameter
 
     """
     surface_based_lcl_height = np.clip(np.atleast_1d(surface_based_lcl_height),
@@ -357,22 +379,27 @@ def critical_angle(pressure, u, v, height, u_storm, v_storm):
     Parameters
     ----------
     pressure : `pint.Quantity`
-        Pressures from sounding.
+        Pressures from sounding
+
     u : `pint.Quantity`
-        U-component of sounding winds.
+        U-component of sounding winds
+
     v : `pint.Quantity`
-        V-component of sounding winds.
+        V-component of sounding winds
+
     height : `pint.Quantity`
-        Heights from sounding.
+        Heights from sounding
+
     u_storm : `pint.Quantity`
-        U-component of storm motion.
+        U-component of storm motion
+
     v_storm : `pint.Quantity`
-        V-component of storm motion.
+        V-component of storm motion
 
     Returns
     -------
     `pint.Quantity`
-        critical angle in degrees
+        Critical angle in degrees
 
     Notes
     -----

--- a/src/metpy/calc/kinematics.py
+++ b/src/metpy/calc/kinematics.py
@@ -309,7 +309,7 @@ def frontogenesis(potential_temperature, u, v, dx=None, dy=None, x_dim=-1, y_dim
     r"""Calculate the 2D kinematic frontogenesis of a temperature field.
 
     The implementation is a form of the Petterssen Frontogenesis and uses the formula
-    outlined in [Bluestein1993]_ pg.248-253.
+    outlined in [Bluestein1993]_ pg.248-253
 
     .. math:: F=\frac{1}{2}\left|\nabla \theta\right|[D cos(2\beta)-\delta]
 
@@ -470,7 +470,7 @@ def ageostrophic_wind(height, u, v, dx=None, dy=None, latitude=None, x_dim=-1, y
     Returns
     -------
     A 2-item tuple of arrays
-        A tuple of the u-component and v-component of the ageostrophic wind.
+        A tuple of the u-component and v-component of the ageostrophic wind
 
     """
     u_geostrophic, v_geostrophic = geostrophic_wind(
@@ -534,7 +534,7 @@ def storm_relative_helicity(height, u, v, depth, *, bottom=0 * units.m,
     # Partially adapted from similar SharpPy code
     r"""Calculate storm relative helicity.
 
-    Calculates storm relatively helicity following [Markowski2010]_ 230-231.
+    Calculates storm relatively helicity following [Markowski2010]_ pg.230-231
 
     .. math:: \int\limits_0^d (\bar v - c) \cdot \bar\omega_{h} \,dz
 
@@ -546,28 +546,36 @@ def storm_relative_helicity(height, u, v, depth, *, bottom=0 * units.m,
     Parameters
     ----------
     u : array-like
-        u component winds
+        U component winds
+
     v : array-like
-        v component winds
+        V component winds
+
     height : array-like
-        atmospheric height, will be converted to AGL
+        Atmospheric height, will be converted to AGL
+
     depth : number
-        depth of the layer
+        Depth of the layer
+
     bottom : number
-        height of layer bottom AGL (default is surface)
+        Height of layer bottom AGL (default is surface)
+
     storm_u : number
-        u component of storm motion (default is 0 m/s)
+        U component of storm motion (default is 0 m/s)
+
     storm_v : number
-        v component of storm motion (default is 0 m/s)
+        V component of storm motion (default is 0 m/s)
 
     Returns
     -------
     `pint.Quantity`
-        positive storm-relative helicity
+        Positive storm-relative helicity
+
     `pint.Quantity`
-        negative storm-relative helicity
+        Negative storm-relative helicity
+
     `pint.Quantity`
-        total storm-relative helicity
+        Total storm-relative helicity
 
     Notes
     -----
@@ -667,7 +675,7 @@ def potential_vorticity_baroclinic(
               - \frac{\partial v}{\partial p}\frac{\partial \theta}{\partial x}
               + \frac{\partial \theta}{\partial p}(\zeta + f) \right)
 
-    This formula is based on equation 4.5.93 [Bluestein1993]_.
+    This formula is based on equation 4.5.93 [Bluestein1993]_
 
     Parameters
     ----------
@@ -880,7 +888,7 @@ def inertial_advective_wind(
     -----
     Many forms of the inertial advective wind assume the advecting and advected
     wind to both be the geostrophic wind. To do so, pass the x and y components
-    of the geostrophic with for u and u_geostrophic/v and v_geostrophic.
+    of the geostrophic wind for u and u_geostrophic/v and v_geostrophic.
 
     """
     f = coriolis_parameter(latitude)
@@ -927,7 +935,7 @@ def q_vector(
     .. math:: \left( \nabla_p^2 + \frac{f_0^2}{\sigma} \frac{\partial^2}{\partial p^2}
                   \right) \omega =
               - 2 \nabla_p \cdot \vec{Q} -
-                  \frac{R}{\sigma p} \beta \frac{\partial T}{\partial x}.
+                  \frac{R}{\sigma p} \beta \frac{\partial T}{\partial x}
 
     Parameters
     ----------

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -35,14 +35,15 @@ def relative_humidity_from_dewpoint(temperature, dewpoint):
     Parameters
     ----------
     temperature : `pint.Quantity`
-        air temperature
+        Air temperature
+
     dewpoint : `pint.Quantity`
-        dewpoint temperature
+        Dewpoint temperature
 
     Returns
     -------
     `pint.Quantity`
-        relative humidity
+        Relative humidity
 
     See Also
     --------
@@ -63,14 +64,15 @@ def exner_function(pressure, reference_pressure=mpconsts.P0):
     .. math:: \Pi = \left( \frac{p}{p_0} \right)^\kappa
 
     This can be used to calculate potential temperature from temperature (and visa-versa),
-    since
+    since:
 
     .. math:: \Pi = \frac{T}{\theta}
 
     Parameters
     ----------
     pressure : `pint.Quantity`
-        total atmospheric pressure
+        Total atmospheric pressure
+
     reference_pressure : `pint.Quantity`, optional
         The reference pressure against which to calculate the Exner function, defaults to
         metpy.constants.P0
@@ -78,7 +80,7 @@ def exner_function(pressure, reference_pressure=mpconsts.P0):
     Returns
     -------
     `pint.Quantity`
-        The value of the Exner function at the given pressure
+        Value of the Exner function at the given pressure
 
     See Also
     --------
@@ -101,15 +103,15 @@ def potential_temperature(pressure, temperature):
     Parameters
     ----------
     pressure : `pint.Quantity`
-        total atmospheric pressure
+        Total atmospheric pressure
+
     temperature : `pint.Quantity`
-        air temperature
+        Air temperature
 
     Returns
     -------
     `pint.Quantity`
-        The potential temperature corresponding to the temperature and
-        pressure.
+        Potential temperature corresponding to the temperature and pressure
 
     See Also
     --------
@@ -146,14 +148,15 @@ def temperature_from_potential_temperature(pressure, potential_temperature):
     Parameters
     ----------
     pressure : `pint.Quantity`
-        total atmospheric pressure
+        Total atmospheric pressure
+
     potential_temperature : `pint.Quantity`
-        potential temperature
+        Potential temperature
 
     Returns
     -------
     `pint.Quantity`
-        The temperature corresponding to the potential temperature and pressure.
+        Temperature corresponding to the potential temperature and pressure
 
     See Also
     --------
@@ -188,23 +191,25 @@ def temperature_from_potential_temperature(pressure, potential_temperature):
 def dry_lapse(pressure, temperature, reference_pressure=None, vertical_dim=0):
     r"""Calculate the temperature at a level assuming only dry processes.
 
-    This function lifts a parcel starting at `temperature`, conserving
-    potential temperature. The starting pressure can be given by `reference_pressure`.
+    This function lifts a parcel starting at ``temperature``, conserving
+    potential temperature. The starting pressure can be given by ``reference_pressure``.
 
     Parameters
     ----------
     pressure : `pint.Quantity`
-        The atmospheric pressure level(s) of interest
+        Atmospheric pressure level(s) of interest
+
     temperature : `pint.Quantity`
-        The starting temperature
+        Starting temperature
+
     reference_pressure : `pint.Quantity`, optional
-        The reference pressure. If not given, it defaults to the first element of the
+        Reference pressure; if not given, it defaults to the first element of the
         pressure array.
 
     Returns
     -------
     `pint.Quantity`
-       The resulting parcel temperature at levels given by `pressure`
+       The parcel's resulting temperature at levels given by ``pressure``
 
     See Also
     --------
@@ -239,11 +244,13 @@ def moist_lapse(pressure, temperature, reference_pressure=None):
     Parameters
     ----------
     pressure : `pint.Quantity`
-        The atmospheric pressure level(s) of interest
+        Atmospheric pressure level(s) of interest
+
     temperature : `pint.Quantity`
-        The starting temperature
+        Starting temperature
+
     reference_pressure : `pint.Quantity`, optional
-        The reference pressure. If not given, it defaults to the first element of the
+        Reference pressure; if not given, it defaults to the first element of the
         pressure array.
 
     Returns
@@ -330,23 +337,27 @@ def lcl(pressure, temperature, dewpoint, max_iters=50, eps=1e-5):
     Parameters
     ----------
     pressure : `pint.Quantity`
-        The starting atmospheric pressure
+        Starting atmospheric pressure
+
     temperature : `pint.Quantity`
-        The starting temperature
+        Starting temperature
+
     dewpoint : `pint.Quantity`
-        The starting dewpoint
+        Starting dewpoint
 
     Returns
     -------
     `pint.Quantity`
-        The LCL pressure
+        LCL pressure
+
     `pint.Quantity`
-        The LCL temperature
+        LCL temperature
 
     Other Parameters
     ----------------
     max_iters : int, optional
         The maximum number of iterations to use in calculation, defaults to 50.
+
     eps : float, optional
         The desired relative error in the calculated value, defaults to 1e-5.
 
@@ -401,30 +412,36 @@ def lfc(pressure, temperature, dewpoint, parcel_temperature_profile=None, dewpoi
     Parameters
     ----------
     pressure : `pint.Quantity`
-        The atmospheric pressure
+        Atmospheric pressure
+
     temperature : `pint.Quantity`
-        The temperature at the levels given by `pressure`
+        Temperature at the levels given by `pressure`
+
     dewpoint : `pint.Quantity`
-        The dewpoint at the levels given by `pressure`
+        Dewpoint at the levels given by `pressure`
+
     parcel_temperature_profile: `pint.Quantity`, optional
-        The parcel temperature profile from which to calculate the LFC. Defaults to the
+        The parcel's temperature profile from which to calculate the LFC. Defaults to the
         surface parcel profile.
+
     dewpoint_start: `pint.Quantity`, optional
-        The dewpoint of the parcel for which to calculate the LFC. Defaults to the surface
+        Dewpoint of the parcel for which to calculate the LFC. Defaults to the surface
         dewpoint.
+
     which: str, optional
-        Pick which LFC to return. Options are 'top', 'bottom', 'wide', 'most_cape', and 'all'.
-        'top' returns the lowest-pressure LFC, default.
-        'bottom' returns the highest-pressure LFC.
-        'wide' returns the LFC whose corresponding EL is farthest away.
+        Pick which LFC to return. Options are 'top', 'bottom', 'wide', 'most_cape', and 'all';
+        'top' returns the lowest-pressure LFC (default),
+        'bottom' returns the highest-pressure LFC,
+        'wide' returns the LFC whose corresponding EL is farthest away,
         'most_cape' returns the LFC that results in the most CAPE in the profile.
 
     Returns
     -------
     `pint.Quantity`
-        The LFC pressure, or array of same if which='all'
+        LFC pressure, or array of same if which='all'
+
     `pint.Quantity`
-        The LFC temperature, or array of same if which='all'
+        LFC temperature, or array of same if which='all'
 
     See Also
     --------
@@ -579,14 +596,18 @@ def el(pressure, temperature, dewpoint, parcel_temperature_profile=None, which='
     Parameters
     ----------
     pressure : `pint.Quantity`
-        The atmospheric pressure profile
+        Atmospheric pressure profile
+
     temperature : `pint.Quantity`
-        The temperature at the levels given by `pressure`
+        Temperature at the levels given by `pressure`
+
     dewpoint : `pint.Quantity`
-        The dewpoint at the levels given by `pressure`
+        Dewpoint at the levels given by `pressure`
+
     parcel_temperature_profile: `pint.Quantity`, optional
-        The parcel temperature profile from which to calculate the EL. Defaults to the
+        The parcel's temperature profile from which to calculate the EL. Defaults to the
         surface parcel profile.
+
     which: str, optional
         Pick which LFC to return. Options are 'top', 'bottom', 'wide', 'most_cape', and 'all'.
         'top' returns the lowest-pressure EL, default.
@@ -597,9 +618,10 @@ def el(pressure, temperature, dewpoint, parcel_temperature_profile=None, which='
     Returns
     -------
     `pint.Quantity`
-        The EL pressure, or array of same if which='all'
+        EL pressure, or array of same if which='all'
+
     `pint.Quantity`
-        The EL temperature, or array of same if which='all'
+        EL temperature, or array of same if which='all'
 
     See Also
     --------
@@ -650,17 +672,19 @@ def parcel_profile(pressure, temperature, dewpoint):
     Parameters
     ----------
     pressure : `pint.Quantity`
-        The atmospheric pressure level(s) of interest. This array must be from
+        Atmospheric pressure level(s) of interest. This array must be from
         high to low pressure.
+
     temperature : `pint.Quantity`
-        The starting temperature
+        Starting temperature
+
     dewpoint : `pint.Quantity`
-        The starting dewpoint
+        Starting dewpoint
 
     Returns
     -------
     `pint.Quantity`
-        The parcel temperatures at the specified pressure levels.
+        The parcel's temperatures at the specified pressure levels
 
     See Also
     --------
@@ -689,26 +713,31 @@ def parcel_profile_with_lcl(pressure, temperature, dewpoint):
     Parameters
     ----------
     pressure : `pint.Quantity`
-        The atmospheric pressure level(s) of interest. This array must be from
+        Atmospheric pressure level(s) of interest. This array must be from
         high to low pressure.
+
     temperature : `pint.Quantity`
-        The atmospheric temperature at the levels in `pressure`. The first entry should be at
+        Atmospheric temperature at the levels in `pressure`. The first entry should be at
         the same level as the first `pressure` data point.
+
     dewpoint : `pint.Quantity`
-        The atmospheric dewpoint at the levels in `pressure`. The first entry should be at
+        Atmospheric dewpoint at the levels in `pressure`. The first entry should be at
         the same level as the first `pressure` data point.
 
     Returns
     -------
     pressure : `pint.Quantity`
         The parcel profile pressures, which includes the specified levels and the LCL
+
     ambient_temperature : `pint.Quantity`
-        The atmospheric temperature values, including the value interpolated to the LCL level
+        Atmospheric temperature values, including the value interpolated to the LCL level
+
     ambient_dew_point : `pint.Quantity`
-        The atmospheric dewpoint values, including the value interpolated to the LCL level
+        Atmospheric dewpoint values, including the value interpolated to the LCL level
+
     profile_temperature : `pint.Quantity`
         The parcel profile temperatures at all of the levels in the returned pressures array,
-        including the LCL.
+        including the LCL
 
     See Also
     --------
@@ -847,21 +876,21 @@ def _insert_lcl_level(pressure, temperature, lcl_pressure):
 def vapor_pressure(pressure, mixing_ratio):
     r"""Calculate water vapor (partial) pressure.
 
-    Given total `pressure` and water vapor `mixing_ratio`, calculates the
+    Given total ``pressure`` and water vapor ``mixing_ratio``, calculates the
     partial pressure of water vapor.
 
     Parameters
     ----------
     pressure : `pint.Quantity`
-        total atmospheric pressure
+        Total atmospheric pressure
+
     mixing_ratio : `pint.Quantity`
-        dimensionless mass mixing ratio
+        Dimensionless mass mixing ratio
 
     Returns
     -------
     `pint.Quantity`
-        The ambient water vapor (partial) pressure in the same units as
-        `pressure`.
+        Ambient water vapor (partial) pressure in the same units as ``pressure``
 
     Notes
     -----
@@ -887,12 +916,12 @@ def saturation_vapor_pressure(temperature):
     Parameters
     ----------
     temperature : `pint.Quantity`
-        air temperature
+        Air temperature
 
     Returns
     -------
     `pint.Quantity`
-        The saturation water vapor (partial) pressure
+        Saturation water vapor (partial) pressure
 
     See Also
     --------
@@ -923,14 +952,15 @@ def dewpoint_from_relative_humidity(temperature, relative_humidity):
     Parameters
     ----------
     temperature : `pint.Quantity`
-        air temperature
+        Air temperature
+
     relative_humidity : `pint.Quantity`
-        relative humidity expressed as a ratio in the range 0 < relative_humidity <= 1
+        Relative humidity expressed as a ratio in the range 0 < relative_humidity <= 1
 
     Returns
     -------
     `pint.Quantity`
-        The dewpoint temperature
+        Dewpoint temperature
 
     See Also
     --------
@@ -956,7 +986,7 @@ def dewpoint(vapor_pressure):
     Returns
     -------
     `pint.Quantity`
-        dewpoint temperature
+        Dewpoint temperature
 
     See Also
     --------
@@ -989,8 +1019,10 @@ def mixing_ratio(partial_press, total_press, molecular_weight_ratio=mpconsts.eps
     ----------
     partial_press : `pint.Quantity`
         Partial pressure of the constituent gas
+
     total_press : `pint.Quantity`
         Total air pressure
+
     molecular_weight_ratio : `pint.Quantity` or float, optional
         The ratio of the molecular weight of the constituent gas to that assumed
         for air. Defaults to the ratio for water vapor to dry air
@@ -1029,6 +1061,7 @@ def saturation_mixing_ratio(total_press, temperature):
     ----------
     total_press: `pint.Quantity`
         Total atmospheric pressure
+
     temperature: `pint.Quantity`
         Air temperature
 
@@ -1078,15 +1111,17 @@ def equivalent_potential_temperature(pressure, temperature, dewpoint):
     ----------
     pressure: `pint.Quantity`
         Total atmospheric pressure
+
     temperature: `pint.Quantity`
         Temperature of parcel
+
     dewpoint: `pint.Quantity`
         Dewpoint of parcel
 
     Returns
     -------
     `pint.Quantity`
-        The equivalent potential temperature of the parcel
+        Equivalent potential temperature of the parcel
 
     Notes
     -----
@@ -1116,11 +1151,11 @@ def saturation_equivalent_potential_temperature(pressure, temperature):
     equivalent potential temperature, and assumes a saturated process.
 
     First, because we assume a saturated process, the temperature at the LCL is
-    equivalent to the current temperature. Therefore the following equation
+    equivalent to the current temperature. Therefore the following equation.
 
     .. math:: T_{L}=\frac{1}{\frac{1}{T_{D}-56}+\frac{ln(T_{K}/T_{D})}{800}}+56
 
-    reduces to
+    reduces to:
 
     .. math:: T_{L} = T_{K}
 
@@ -1129,11 +1164,11 @@ def saturation_equivalent_potential_temperature(pressure, temperature):
     .. math:: \theta_{DL}=T_{K}\left(\frac{1000}{p-e}\right)^k
               \left(\frac{T_{K}}{T_{L}}\right)^{.28r}
 
-    However, because
+    However, because:
 
     .. math:: T_{L} = T_{K}
 
-    it follows that
+    it follows that:
 
     .. math:: \theta_{DL}=T_{K}\left(\frac{1000}{p-e}\right)^k
 
@@ -1146,13 +1181,14 @@ def saturation_equivalent_potential_temperature(pressure, temperature):
     ----------
     pressure: `pint.Quantity`
         Total atmospheric pressure
+
     temperature: `pint.Quantity`
         Temperature of parcel
 
     Returns
     -------
     `pint.Quantity`
-        The saturation equivalent potential temperature of the parcel
+        Saturation equivalent potential temperature of the parcel
 
     Notes
     -----
@@ -1184,18 +1220,20 @@ def virtual_temperature(temperature, mixing_ratio, molecular_weight_ratio=mpcons
     Parameters
     ----------
     temperature: `pint.Quantity`
-        air temperature
+        Air temperature
+
     mixing_ratio : `pint.Quantity`
-        dimensionless mass mixing ratio
+        Mass mixing ratio (dimensionless)
+
     molecular_weight_ratio : `pint.Quantity` or float, optional
         The ratio of the molecular weight of the constituent gas to that assumed
         for air. Defaults to the ratio for water vapor to dry air.
-        (:math:`\epsilon\approx0.622`).
+        (:math:`\epsilon\approx0.622`)
 
     Returns
     -------
     `pint.Quantity`
-        The corresponding virtual temperature of the parcel
+        Corresponding virtual temperature of the parcel
 
     Notes
     -----
@@ -1223,19 +1261,22 @@ def virtual_potential_temperature(pressure, temperature, mixing_ratio,
     ----------
     pressure: `pint.Quantity`
         Total atmospheric pressure
+
     temperature: `pint.Quantity`
-        air temperature
+        Air temperature
+
     mixing_ratio : `pint.Quantity`
-        dimensionless mass mixing ratio
+        Dimensionless mass mixing ratio
+
     molecular_weight_ratio : `pint.Quantity` or float, optional
         The ratio of the molecular weight of the constituent gas to that assumed
         for air. Defaults to the ratio for water vapor to dry air.
-        (:math:`\epsilon\approx0.622`).
+        (:math:`\epsilon\approx0.622`)
 
     Returns
     -------
     `pint.Quantity`
-        The corresponding virtual potential temperature of the parcel
+        Corresponding virtual potential temperature of the parcel
 
     Notes
     -----
@@ -1262,19 +1303,22 @@ def density(pressure, temperature, mixing_ratio, molecular_weight_ratio=mpconsts
     ----------
     pressure: `pint.Quantity`
         Total atmospheric pressure
+
     temperature: `pint.Quantity`
-        air temperature
+        Air temperature
+
     mixing_ratio : `pint.Quantity`
-        dimensionless mass mixing ratio
+        Mass mixing ratio (dimensionless)
+
     molecular_weight_ratio : `pint.Quantity` or float, optional
         The ratio of the molecular weight of the constituent gas to that assumed
         for air. Defaults to the ratio for water vapor to dry air.
-        (:math:`\epsilon\approx0.622`).
+        (:math:`\epsilon\approx0.622`)
 
     Returns
     -------
     `pint.Quantity`
-        The corresponding density of the parcel
+        Corresponding density of the parcel
 
     Notes
     -----
@@ -1302,8 +1346,10 @@ def relative_humidity_wet_psychrometric(pressure, dry_bulb_temperature, wet_bulb
     ----------
     pressure: `pint.Quantity`
         Total atmospheric pressure
+
     dry_bulb_temperature: `pint.Quantity`
         Dry bulb temperature
+
     wet_bulb_temperature: `pint.Quantity`
         Wet bulb temperature
 
@@ -1314,9 +1360,9 @@ def relative_humidity_wet_psychrometric(pressure, dry_bulb_temperature, wet_bulb
 
     Notes
     -----
-    .. math:: relative_humidity = \frac{e}{e_s}
+    .. math:: RH = \frac{e}{e_s}
 
-    * :math:`relative_humidity` is relative humidity as a unitless ratio
+    * :math:`RH` is relative humidity as a unitless ratio
     * :math:`e` is vapor pressure from the wet psychrometric calculation
     * :math:`e_s` is the saturation vapor pressure
 
@@ -1347,10 +1393,13 @@ def psychrometric_vapor_pressure_wet(pressure, dry_bulb_temperature, wet_bulb_te
     ----------
     pressure: `pint.Quantity`
         Total atmospheric pressure
+
     dry_bulb_temperature: `pint.Quantity`
         Dry bulb temperature
+
     wet_bulb_temperature: `pint.Quantity`
         Wet bulb temperature
+
     psychrometer_coefficient: `pint.Quantity`, optional
         Psychrometer coefficient. Defaults to 6.21e-4 K^-1.
 
@@ -1396,8 +1445,10 @@ def mixing_ratio_from_relative_humidity(pressure, temperature, relative_humidity
     ----------
     pressure: `pint.Quantity`
         Total atmospheric pressure
+
     temperature: `pint.Quantity`
         Air temperature
+
     relative_humidity: array_like
         The relative humidity expressed as a unitless ratio in the range [0, 1]. Can also pass
         a percentage if proper units are attached.
@@ -1405,7 +1456,7 @@ def mixing_ratio_from_relative_humidity(pressure, temperature, relative_humidity
     Returns
     -------
     `pint.Quantity`
-        Dimensionless mixing ratio
+        Mixing ratio (dimensionless)
 
     Notes
     -----
@@ -1439,8 +1490,10 @@ def relative_humidity_from_mixing_ratio(pressure, temperature, mixing_ratio):
     ----------
     pressure: `pint.Quantity`
         Total atmospheric pressure
+
     temperature: `pint.Quantity`
         Air temperature
+
     mixing_ratio: `pint.Quantity`
         Dimensionless mass mixing ratio
 
@@ -1513,7 +1566,7 @@ def specific_humidity_from_mixing_ratio(mixing_ratio):
     Parameters
     ----------
     mixing_ratio: `pint.Quantity`
-        mixing ratio
+        Mixing ratio
 
     Returns
     -------
@@ -1554,8 +1607,10 @@ def relative_humidity_from_specific_humidity(pressure, temperature, specific_hum
     ----------
     pressure: `pint.Quantity`
         Total atmospheric pressure
+
     temperature: `pint.Quantity`
         Air temperature
+
     specific_humidity: `pint.Quantity`
         Specific humidity of air
 
@@ -1598,17 +1653,22 @@ def cape_cin(pressure, temperature, dewpoint, parcel_profile, which_lfc='bottom'
     Parameters
     ----------
     pressure : `pint.Quantity`
-        The atmospheric pressure level(s) of interest, in order from highest to
-        lowest pressure.
+        Atmospheric pressure level(s) of interest, in order from highest to
+        lowest pressure
+
     temperature : `pint.Quantity`
-        The atmospheric temperature corresponding to pressure.
+        Atmospheric temperature corresponding to pressure
+
     dewpoint : `pint.Quantity`
-        The atmospheric dewpoint corresponding to pressure.
+        Atmospheric dewpoint corresponding to pressure
+
     parcel_profile : `pint.Quantity`
-        The temperature profile of the parcel.
+        Temperature profile of the parcel
+
     which_lfc : str
         Choose which LFC to integrate from. Valid options are 'top', 'bottom', 'wide',
         and 'most_cape'. Default is 'bottom'.
+
     which_el : str
         Choose which EL to integrate to. Valid options are 'top', 'bottom', 'wide',
         and 'most_cape'. Default is 'top'.
@@ -1616,9 +1676,10 @@ def cape_cin(pressure, temperature, dewpoint, parcel_profile, which_lfc='bottom'
     Returns
     -------
     `pint.Quantity`
-        Convective Available Potential Energy (CAPE).
+        Convective Available Potential Energy (CAPE)
+
     `pint.Quantity`
-        Convective INhibition (CIN).
+        Convective Inhibition (CIN)
 
     Notes
     -----
@@ -1629,16 +1690,16 @@ def cape_cin(pressure, temperature, dewpoint, parcel_profile, which_lfc='bottom'
     .. math:: \text{CIN} = -R_d \int_{SFC}^{LFC} (T_{parcel} - T_{env}) d\text{ln}(p)
 
 
-    * :math:`CAPE` Convective available potential energy
-    * :math:`CIN` Convective inhibition
-    * :math:`LFC` Pressure of the level of free convection
-    * :math:`EL` Pressure of the equilibrium level
-    * :math:`SFC` Level of the surface or beginning of parcel path
-    * :math:`R_d` Gas constant
-    * :math:`g` Gravitational acceleration
-    * :math:`T_{parcel}` Parcel temperature
-    * :math:`T_{env}` Environment temperature
-    * :math:`p` Atmospheric pressure
+    * :math:`CAPE` is convective available potential energy
+    * :math:`CIN` is convective inhibition
+    * :math:`LFC` is pressure of the level of free convection
+    * :math:`EL` is pressure of the equilibrium level
+    * :math:`SFC` is the level of the surface or beginning of parcel path
+    * :math:`R_d` is the gas constant
+    * :math:`g` is gravitational acceleration
+    * :math:`T_{parcel}` is the parcel temperature
+    * :math:`T_{env}` is environment temperature
+    * :math:`p` is atmospheric pressure
 
     Only functions on 1D profiles (not higher-dimension vertical cross sections or grids).
     Since this function returns scalar values when given a profile, this will return Pint
@@ -1709,16 +1770,17 @@ def _find_append_zero_crossings(x, y):
     Parameters
     ----------
     x : `pint.Quantity`
-        x values of data
+        X values of data
+
     y : `pint.Quantity`
-        y values of data
+        Y values of data
 
     Returns
     -------
     x : `pint.Quantity`
-        x values of data
+        X values of data
     y : `pint.Quantity`
-        y values of data
+        Y values of data
 
     """
     crossings = find_intersections(x[1:], y[1:], y.units * np.zeros_like(y[1:]), log_x=True)
@@ -1752,15 +1814,20 @@ def most_unstable_parcel(pressure, temperature, dewpoint, height=None,
     ----------
     pressure: `pint.Quantity`
         Atmospheric pressure profile
+
     temperature: `pint.Quantity`
         Atmospheric temperature profile
+
     dewpoint: `pint.Quantity`
         Atmospheric dewpoint profile
+
     height: `pint.Quantity`, optional
         Atmospheric height profile. Standard atmosphere assumed when None (the default).
+
     bottom: `pint.Quantity`, optional
         Bottom of the layer to consider for the calculation in pressure or height.
         Defaults to using the bottom pressure or height.
+
     depth: `pint.Quantity`, optional
         Depth of the layer to consider for the calculation in pressure or height. Defaults
         to 300 hPa.
@@ -1768,7 +1835,8 @@ def most_unstable_parcel(pressure, temperature, dewpoint, height=None,
     Returns
     -------
     `pint.Quantity`
-        Pressure, temperature, and dewpoint of most unstable parcel in the profile.
+        Pressure, temperature, and dewpoint of most unstable parcel in the profile
+
     integer
         Index of the most unstable parcel in the given profile
 
@@ -1803,24 +1871,31 @@ def isentropic_interpolation(levels, pressure, temperature, *args, vertical_dim=
     ----------
     levels : array
         One-dimensional array of desired potential temperature surfaces
+
     pressure : array
         One-dimensional array of pressure levels
+
     temperature : array
         Array of temperature
     vertical_dim : int, optional
         The axis corresponding to the vertical in the temperature array, defaults to 0.
+
     temperature_out : bool, optional
         If true, will calculate temperature and output as the last item in the output list.
         Defaults to False.
+
     max_iters : int, optional
-        The maximum number of iterations to use in calculation, defaults to 50.
+        Maximum number of iterations to use in calculation, defaults to 50.
+
     eps : float, optional
         The desired absolute error in the calculated value, defaults to 1e-6.
+
     bottom_up_search : bool, optional
         Controls whether to search for levels bottom-up, or top-down. Defaults to
         True, which is bottom-up search.
+
     args : array, optional
-        Any additional variables will be interpolated to each isentropic level.
+        Any additional variables will be interpolated to each isentropic level
 
     Returns
     -------
@@ -2070,17 +2145,20 @@ def surface_based_cape_cin(pressure, temperature, dewpoint):
     pressure : `pint.Quantity`
         Atmospheric pressure profile. The first entry should be the starting
         (surface) observation, with the array going from high to low pressure.
+
     temperature : `pint.Quantity`
-        Temperature profile corresponding to the `pressure` profile.
+        Temperature profile corresponding to the `pressure` profile
+
     dewpoint : `pint.Quantity`
-        Dewpoint profile corresponding to the `pressure` profile.
+        Dewpoint profile corresponding to the `pressure` profile
 
     Returns
     -------
     `pint.Quantity`
-        Surface based Convective Available Potential Energy (CAPE).
+        Surface based Convective Available Potential Energy (CAPE)
+
     `pint.Quantity`
-        Surface based Convective INhibition (CIN).
+        Surface based Convective Inhibition (CIN)
 
     See Also
     --------
@@ -2114,19 +2192,23 @@ def most_unstable_cape_cin(pressure, temperature, dewpoint, **kwargs):
     ----------
     pressure : `pint.Quantity`
         Pressure profile
+
     temperature : `pint.Quantity`
         Temperature profile
+
     dewpoint : `pint.Quantity`
         Dew point profile
+
     kwargs
         Additional keyword arguments to pass to `most_unstable_parcel`
 
     Returns
     -------
     `pint.Quantity`
-        Most unstable Convective Available Potential Energy (CAPE).
+        Most unstable Convective Available Potential Energy (CAPE)
+
     `pint.Quantity`
-        Most unstable Convective INhibition (CIN).
+        Most unstable Convective Inhibition (CIN)
 
     See Also
     --------
@@ -2164,19 +2246,22 @@ def mixed_layer_cape_cin(pressure, temperature, dewpoint, **kwargs):
     ----------
     pressure : `pint.Quantity`
         Pressure profile
+
     temperature : `pint.Quantity`
         Temperature profile
+
     dewpoint : `pint.Quantity`
         Dewpoint profile
+
     kwargs
         Additional keyword arguments to pass to `mixed_parcel`
 
     Returns
     -------
     `pint.Quantity`
-        Mixed-layer Convective Available Potential Energy (CAPE).
+        Mixed-layer Convective Available Potential Energy (CAPE)
     `pint.Quantity`
-        Mixed-layer Convective INhibition (CIN).
+        Mixed-layer Convective INhibition (CIN)
 
     See Also
     --------
@@ -2219,31 +2304,39 @@ def mixed_parcel(pressure, temperature, dewpoint, parcel_start_pressure=None,
     ----------
     pressure : `pint.Quantity`
         Atmospheric pressure profile
+
     temperature : `pint.Quantity`
         Atmospheric temperature profile
+
     dewpoint : `pint.Quantity`
         Atmospheric dewpoint profile
+
     parcel_start_pressure : `pint.Quantity`, optional
         Pressure at which the mixed parcel should begin (default None)
+
     height: `pint.Quantity`, optional
         Atmospheric heights corresponding to the given pressures (default None)
+
     bottom : `pint.Quantity`, optional
         The bottom of the layer as a pressure or height above the surface pressure
         (default None)
+
     depth : `pint.Quantity`, optional
         The thickness of the layer as a pressure or height above the bottom of the layer
         (default 100 hPa)
+
     interpolate : bool, optional
         Interpolate the top and bottom points if they are not in the given data
 
     Returns
     -------
     `pint.Quantity`
-        The pressure of the mixed parcel
+        Pressure of the mixed parcel
     `pint.Quantity`
-        The temperature of the mixed parcel
+        Temperature of the mixed parcel
+
     `pint.Quantity`
-        The dewpoint of the mixed parcel
+        Dewpoint of the mixed parcel
 
     Notes
     -----
@@ -2293,23 +2386,28 @@ def mixed_layer(pressure, *args, height=None, bottom=None, depth=100 * units.hPa
     ----------
     pressure : array-like
         Atmospheric pressure profile
+
     datavar : array-like
         Atmospheric variable measured at the given pressures
+
     height: array-like, optional
         Atmospheric heights corresponding to the given pressures (default None)
+
     bottom : `pint.Quantity`, optional
         The bottom of the layer as a pressure or height above the surface pressure
         (default None)
+
     depth : `pint.Quantity`, optional
         The thickness of the layer as a pressure or height above the bottom of the layer
         (default 100 hPa)
+
     interpolate : bool, optional
         Interpolate the top and bottom points if they are not in the given data (default True)
 
     Returns
     -------
     `pint.Quantity`
-        The mixed value of the data variable.
+        The mixed value of the data variable
 
     Notes
     -----
@@ -2351,13 +2449,14 @@ def dry_static_energy(height, temperature):
     ----------
     height : `pint.Quantity`
         Atmospheric height
+
     temperature : `pint.Quantity`
         Air temperature
 
     Returns
     -------
     `pint.Quantity`
-        The dry static energy
+        Dry static energy
 
     See Also
     --------
@@ -2391,15 +2490,17 @@ def moist_static_energy(height, temperature, specific_humidity):
     ----------
     height : `pint.Quantity`
         Atmospheric height
+
     temperature : `pint.Quantity`
         Air temperature
+
     specific_humidity : `pint.Quantity`
         Atmospheric specific humidity
 
     Returns
     -------
     `pint.Quantity`
-        The moist static energy
+        Moist static energy
 
     """
     return (dry_static_energy(height, temperature)
@@ -2414,31 +2515,34 @@ def thickness_hydrostatic(pressure, temperature, mixing_ratio=None,
     r"""Calculate the thickness of a layer via the hypsometric equation.
 
     This thickness calculation uses the pressure and temperature profiles (and optionally
-    mixing ratio) via the hypsometric equation with virtual temperature adjustment
+    mixing ratio) via the hypsometric equation with virtual temperature adjustment.
 
     .. math:: Z_2 - Z_1 = -\frac{R_d}{g} \int_{p_1}^{p_2} T_v d\ln p,
 
-    which is based off of Equation 3.24 in [Hobbs2006]_.
+    Which is based off of Equation 3.24 in [Hobbs2006]_.
 
-    This assumes a hydrostatic atmosphere.
-
-    Layer bottom and depth specified in pressure.
+    This assumes a hydrostatic atmosphere. Layer bottom and depth specified in pressure.
 
     Parameters
     ----------
     pressure : `pint.Quantity`
         Atmospheric pressure profile
+
     temperature : `pint.Quantity`
         Atmospheric temperature profile
+
     mixing_ratio : `pint.Quantity`, optional
         Profile of dimensionless mass mixing ratio. If none is given, virtual temperature
         is simply set to be the given temperature.
+
     molecular_weight_ratio : `pint.Quantity` or float, optional
         The ratio of the molecular weight of the constituent gas to that assumed
         for air. Defaults to the ratio for water vapor to dry air.
-        (:math:`\epsilon\approx0.622`).
+        (:math:`\epsilon\approx0.622`)
+
     bottom : `pint.Quantity`, optional
         The bottom of the layer in pressure. Defaults to the first observation.
+
     depth : `pint.Quantity`, optional
         The depth of the layer in hPa. Defaults to the full profile if bottom is not given,
         and 100 hPa if bottom is given.
@@ -2446,7 +2550,7 @@ def thickness_hydrostatic(pressure, temperature, mixing_ratio=None,
     Returns
     -------
     `pint.Quantity`
-        The thickness of the layer in meters.
+        The thickness of the layer in meters
 
     See Also
     --------
@@ -2491,7 +2595,7 @@ def thickness_hydrostatic_from_relative_humidity(pressure, temperature, relative
 
     Similar to ``thickness_hydrostatic``, this thickness calculation uses the pressure,
     temperature, and relative humidity profiles via the hypsometric equation with virtual
-    temperature adjustment.
+    temperature adjustment
 
     .. math:: Z_2 - Z_1 = -\frac{R_d}{g} \int_{p_1}^{p_2} T_v d\ln p,
 
@@ -2506,14 +2610,18 @@ def thickness_hydrostatic_from_relative_humidity(pressure, temperature, relative
     ----------
     pressure : `pint.Quantity`
         Atmospheric pressure profile
+
     temperature : `pint.Quantity`
         Atmospheric temperature profile
+
     relative_humidity : `pint.Quantity`
         Atmospheric relative humidity profile. The relative humidity is expressed as a
         unitless ratio in the range [0, 1]. Can also pass a percentage if proper units are
         attached.
+
     bottom : `pint.Quantity`, optional
         The bottom of the layer in pressure. Defaults to the first observation.
+
     depth : `pint.Quantity`, optional
         The depth of the layer in hPa. Defaults to the full profile if bottom is not given,
         and 100 hPa if bottom is given.
@@ -2521,7 +2629,7 @@ def thickness_hydrostatic_from_relative_humidity(pressure, temperature, relative
     Returns
     -------
     `pint.Quantity`
-        The thickness of the layer in meters.
+        The thickness of the layer in meters
 
     See Also
     --------
@@ -2559,8 +2667,10 @@ def brunt_vaisala_frequency_squared(height, potential_temperature, vertical_dim=
     ----------
     height : `xarray.DataArray` or `pint.Quantity`
         Atmospheric (geopotential) height
+
     potential_temperature : `xarray.DataArray` or `pint.Quantity`
         Atmospheric potential temperature
+
     vertical_dim : int, optional
         The axis corresponding to vertical in the potential temperature array, defaults to 0,
         unless `height` and `potential_temperature` given as `xarray.DataArray`, in which case
@@ -2609,8 +2719,10 @@ def brunt_vaisala_frequency(height, potential_temperature, vertical_dim=0):
     ----------
     height : `xarray.DataArray` or `pint.Quantity`
         Atmospheric (geopotential) height
+
     potential_temperature : `xarray.DataArray` or `pint.Quantity`
         Atmospheric potential temperature
+
     vertical_dim : int, optional
         The axis corresponding to vertical in the potential temperature array, defaults to 0,
         unless `height` and `potential_temperature` given as `xarray.DataArray`, in which case
@@ -2653,8 +2765,10 @@ def brunt_vaisala_period(height, potential_temperature, vertical_dim=0):
     ----------
     height : `xarray.DataArray` or `pint.Quantity`
         Atmospheric (geopotential) height
+
     potential_temperature : `xarray.DataArray` or `pint.Quantity`
         Atmospheric potential temperature
+
     vertical_dim : int, optional
         The axis corresponding to vertical in the potential temperature array, defaults to 0,
         unless `height` and `potential_temperature` given as `xarray.DataArray`, in which case
@@ -2697,8 +2811,10 @@ def wet_bulb_temperature(pressure, temperature, dewpoint):
     ----------
     pressure : `pint.Quantity`
         Initial atmospheric pressure
+
     temperature : `pint.Quantity`
         Initial atmospheric temperature
+
     dewpoint : `pint.Quantity`
         Initial atmospheric dewpoint
 
@@ -2757,8 +2873,10 @@ def static_stability(pressure, temperature, vertical_dim=0):
     ----------
     pressure : `pint.Quantity`
         Profile of atmospheric pressure
+
     temperature : `pint.Quantity`
         Profile of temperature
+
     vertical_dim : int, optional
         The axis corresponding to vertical in the pressure and temperature arrays, defaults
         to 0.
@@ -2766,7 +2884,7 @@ def static_stability(pressure, temperature, vertical_dim=0):
     Returns
     -------
     `pint.Quantity`
-        The profile of static stability.
+        The profile of static stability
 
     """
     theta = potential_temperature(pressure, temperature)
@@ -2791,8 +2909,10 @@ def dewpoint_from_specific_humidity(pressure, temperature, specific_humidity):
     ----------
     pressure: `pint.Quantity`
         Total atmospheric pressure
+
     temperature: `pint.Quantity`
         Air temperature
+
     specific_humidity: `pint.Quantity`
         Specific humidity of air
 
@@ -2833,12 +2953,15 @@ def vertical_velocity_pressure(w, pressure, temperature, mixing_ratio=0):
     ----------
     w: `pint.Quantity`
         Vertical velocity in terms of height
+
     pressure: `pint.Quantity`
         Total atmospheric pressure
+
     temperature: `pint.Quantity`
         Air temperature
+
     mixing_ratio: `pint.Quantity`, optional
-        Mixing_ratio ratio of air
+        Mixing ratio of air
 
     Returns
     -------
@@ -2882,10 +3005,13 @@ def vertical_velocity(omega, pressure, temperature, mixing_ratio=0):
     ----------
     omega: `pint.Quantity`
         Vertical velocity in terms of pressure
+
     pressure: `pint.Quantity`
         Total atmospheric pressure
+
     temperature: `pint.Quantity`
         Air temperature
+
     mixing_ratio: `pint.Quantity`, optional
         Mixing ratio of air
 
@@ -2912,10 +3038,10 @@ def specific_humidity_from_dewpoint(pressure, dewpoint):
     Parameters
     ----------
     dewpoint: `pint.Quantity`
-        dewpoint temperature
+        Dewpoint temperature
 
     pressure: `pint.Quantity`
-        pressure
+        Pressure
 
     Returns
     -------
@@ -2939,9 +3065,11 @@ def lifted_index(pressure, temperature, parcel_profile):
 
     Lifted index formula derived from [Galway1956]_ and referenced by [DoswellSchultz2006]_:
     LI = T500 - Tp500
+
     where:
-    T500 is the measured temperature at 500 hPa.
-    Tp500 is the temperature of the lifted parcel at 500 hPa.
+
+    T500 is the measured temperature at 500 hPa
+    Tp500 is the temperature of the lifted parcel at 500 hPa
 
     Calculation of the lifted index is defined as the temperature difference between the
     observed 500 hPa temperature and the temperature of a parcel lifted from the
@@ -2950,17 +3078,19 @@ def lifted_index(pressure, temperature, parcel_profile):
     Parameters
     ----------
     pressure : `pint.Quantity`
-        The atmospheric pressure level(s) of interest, in order from highest to
-        lowest pressure.
+        Atmospheric pressure level(s) of interest, in order from highest to
+        lowest pressure
+
     temperature : `pint.Quantity`
-        The atmospheric temperature corresponding to pressure.
+        Atmospheric temperature corresponding to pressure
+
     parcel_profile : `pint.Quantity`
-        The temperature profile of the parcel.
+        Temperature profile of the parcel
 
     Returns
     -------
     `pint.Quantity`
-        Lifted Index.
+        Lifted Index
 
     """
     # find the index for the 500 hPa pressure level.
@@ -2994,12 +3124,16 @@ def gradient_richardson_number(height, potential_temperature, u, v, vertical_dim
     ----------
     height : `pint.Quantity`
         Atmospheric height
+
     potential_temperature : `pint.Quantity`
         Atmospheric potential temperature
+
     u : `pint.Quantity`
-        x component of the wind
+        X component of the wind
+
     v : `pint.Quantity`
         y component of the wind
+
     vertical_dim : int, optional
         The axis corresponding to vertical, defaults to 0. Automatically determined from
         xarray DataArray arguments.

--- a/src/metpy/calc/tools.py
+++ b/src/metpy/calc/tools.py
@@ -195,7 +195,7 @@ def _next_non_masked_element(a, idx):
     a : array-like
         1-dimensional array of numeric values
     idx : integer
-        index of requested element
+        Index of requested element
 
     Returns
     -------
@@ -220,12 +220,12 @@ def _delete_masked_points(*arrs):
     Parameters
     ----------
     arrs : one or more array-like
-        source arrays
+        Source arrays
 
     Returns
     -------
     arrs : one or more array-like
-        arrays with masked elements removed
+        Arrays with masked elements removed
 
     """
     if any(hasattr(a, 'mask') for a in arrs):
@@ -333,7 +333,7 @@ def _get_bound_pressure_height(pressure, bound, height=None, interpolate=True):
     Returns
     -------
     `pint.Quantity`
-        The bound pressure and height.
+        The bound pressure and height
 
     """
     # avoid circular import if basic.py ever imports something from tools.py
@@ -434,11 +434,11 @@ def get_layer_heights(height, depth, *args, bottom=None, interpolate=True, with_
     height : array-like
         Atmospheric height
     depth : `pint.Quantity`
-        The thickness of the layer
+        Thickness of the layer
     args : array-like
         Atmospheric variable(s) measured at the given pressures
     bottom : `pint.Quantity`, optional
-        The bottom of the layer
+        Bottom of the layer
     interpolate : bool, optional
         Interpolate the top and bottom points if they are not in the given data. Defaults
         to True.
@@ -449,7 +449,7 @@ def get_layer_heights(height, depth, *args, bottom=None, interpolate=True, with_
     Returns
     -------
     `pint.Quantity, pint.Quantity`
-        The height and data variables of the layer
+        Height and data variables of the layer
 
     Notes
     -----
@@ -538,10 +538,10 @@ def get_layer(pressure, *args, height=None, bottom=None, depth=100 * units.hPa,
         Atmospheric heights corresponding to the given pressures. Defaults to using
         heights calculated from ``pressure`` assuming a standard atmosphere [NOAA1976]_.
     bottom : `pint.Quantity`, optional
-        The bottom of the layer as a pressure or height above the surface pressure. Defaults
+        Bottom of the layer as a pressure or height above the surface pressure. Defaults
         to the highest pressure or lowest height given.
     depth : `pint.Quantity`, optional
-        The thickness of the layer as a pressure or height above the bottom of the layer.
+        Thickness of the layer as a pressure or height above the bottom of the layer.
         Defaults to 100 hPa.
     interpolate : bool, optional
         Interpolate the top and bottom points if they are not in the given data. Defaults
@@ -642,7 +642,7 @@ def find_bounding_indices(arr, values, axis, from_below=True):
         One or more values to search for in `arr`
 
     axis : int
-        The dimension of `arr` along which to search.
+        Dimension of `arr` along which to search
 
     from_below : bool, optional
         Whether to search from "below" (i.e. low indices to high indices). If `False`,
@@ -749,7 +749,7 @@ def _less_or_close(a, value, **kwargs):
     Returns
     -------
     array-like
-        Boolean array where values are less than or nearly equal to value.
+        Boolean array where values are less than or nearly equal to value
 
     """
     return (a < value) | np.isclose(a, value, **kwargs)
@@ -771,10 +771,11 @@ def lat_lon_grid_deltas(longitude, latitude, x_dim=-1, y_dim=-2, geod=None):
     Parameters
     ----------
     longitude : array_like
-        array of longitudes defining the grid. If not a `pint.Quantity`, assumed to be in
+        Array of longitudes defining the grid. If not a `pint.Quantity`, assumed to be in
         degrees.
+
     latitude : array_like
-        array of latitudes defining the grid. If not a `pint.Quantity`, assumed to be in
+        Array of latitudes defining the grid. If not a `pint.Quantity`, assumed to be in
         degrees.
     x_dim: int
         axis number for the x dimension, defaults to -1.
@@ -787,7 +788,7 @@ def lat_lon_grid_deltas(longitude, latitude, x_dim=-1, y_dim=-2, geod=None):
     Returns
     -------
     dx, dy:
-        at least two dimensional arrays of signed deltas between grid points in the x and y
+        At least two dimensional arrays of signed deltas between grid points in the x and y
         direction
 
     Notes
@@ -955,7 +956,7 @@ def first_derivative(f, axis=None, x=None, delta=None):
         to 0. For reference, the current standard axis types are 'time', 'vertical', 'y', and
         'x'.
     x : array-like, optional
-        The coordinate values corresponding to the grid points in `f`.
+        The coordinate values corresponding to the grid points in `f`
     delta : array-like, optional
         Spacing between the grid points in `f`. Should be one item less than the size
         of `f` along `axis`.
@@ -963,7 +964,7 @@ def first_derivative(f, axis=None, x=None, delta=None):
     Returns
     -------
     array-like
-        The first derivative calculated along the selected axis.
+        The first derivative calculated along the selected axis
 
     See Also
     --------
@@ -1027,7 +1028,7 @@ def second_derivative(f, axis=None, x=None, delta=None):
     `delta` are given, `f` will be converted to a `pint.Quantity` and the derivative returned
     as a `pint.Quantity`, otherwise, if neither `x` nor `delta` are given, the attached
     coordinate information belonging to `axis` will be used and the derivative will be returned
-    as an `xarray.DataArray`.
+    as an `xarray.DataArray`
 
     This uses 3 points to calculate the derivative, using forward or backward at the edges of
     the grid as appropriate, and centered elsewhere. The irregular spacing is handled
@@ -1045,7 +1046,7 @@ def second_derivative(f, axis=None, x=None, delta=None):
         to 0. For reference, the current standard axis types are 'time', 'vertical', 'y', and
         'x'.
     x : array-like, optional
-        The coordinate values corresponding to the grid points in `f`.
+        The coordinate values corresponding to the grid points in `f`
     delta : array-like, optional
         Spacing between the grid points in `f`. There should be one item less than the size
         of `f` along `axis`.
@@ -1053,7 +1054,7 @@ def second_derivative(f, axis=None, x=None, delta=None):
     Returns
     -------
     array-like
-        The second derivative calculated along the selected axis.
+        The second derivative calculated along the selected axis
 
     See Also
     --------
@@ -1284,12 +1285,12 @@ def parse_angle(input_dir):
     """Calculate the meteorological angle from directional text.
 
     Works for abbrieviations or whole words (E -> 90 | South -> 180)
-    and also is able to parse 22.5 degreee angles such as ESE/East South East
+    and also is able to parse 22.5 degreee angles such as ESE/East South East.
 
     Parameters
     ----------
     input_dir : string or array-like
-        Directional text such as west, [south-west, ne], etc
+        Directional text such as west, [south-west, ne], etc.
 
     Returns
     -------
@@ -1345,7 +1346,7 @@ def angle_to_direction(input_angle, full=False, level=3):
     Parameters
     ----------
     input_angle : numeric or array-like numeric
-        Angles such as 0, 25, 45, 360, 410, etc
+        Angles such as 0, 25, 45, 360, 410, etc.
     full : boolean
         True returns full text (South), False returns abbrieviated text (S)
     level : int
@@ -1443,8 +1444,8 @@ def _unabbrieviate_direction(abb_dir_str):
 def _remove_nans(*variables):
     """Remove NaNs from arrays that cause issues with calculations.
 
-    Takes a variable number of arguments
-    Returns masked arrays in the same order as provided
+    Takes a variable number of arguments and returns masked arrays in the same
+    order as provided.
     """
     mask = None
     for v in variables:


### PR DESCRIPTION
I have made a plethora of changes with the goal of making the calc functions look more cohesive on the MetPy Unidata website.

Some particular conflicts that need to be reviewed are:

smooth_guassian - I made a change to the equation EXP[-D^2], it looks funky on the website so I modified the code. I may be wrong so I want to double check that I did it correctly or it could have been right in the first place, not sure.

gradient_richardson_number - this function is included in my fork but is not on the MetPy page, so I am not sure if it is supposed to be there or not. 

friction_velocity - this function is on the MetPy page but I am unable to find it on my forked version

relative_humidity_wet_psychrometric - I changed the 'relative humidity' wording to RH because it looked funky, once again I am not sure if it looks like that on purpose so I wanted to double check

cape_cin - in the notes section, I went ahead and added "is" to all of the variables, just want to make sure that is something that should be changed

Those are functions I wanted to point out specifically but after all of these changes are reviewed if there is anything else I can change/do I am happy to help!