### PR TITLE
Improved data and colormap scaling for Level3File example.

### DIFF
--- a/examples/formats/NEXRAD_Level_3_File.py
+++ b/examples/formats/NEXRAD_Level_3_File.py
@@ -17,7 +17,9 @@ from metpy.plots import add_metpy_logo, add_timestamp, colortables
 ###########################################
 fig, axes = plt.subplots(1, 2, figsize=(15, 8))
 add_metpy_logo(fig, 190, 85, size='large')
-for v, ctable, ax in zip(('N0Q', 'N0U'), ('NWSReflectivity', 'NWSVelocity'), axes):
+ctables = (('NWSStormClearReflectivity', -20, 0.5),  # dBZ
+           ('NWS8bitVel', -100, 1.0))  # m/s
+for v, ctable, ax in zip(('N0Q', 'N0U'), ctables, axes):
     # Open the file
     name = get_test_data('nids/KOUN_SDUS54_{}TLX_201305202016'.format(v), as_file_obj=False)
     f = Level3File(name)
@@ -25,9 +27,8 @@ for v, ctable, ax in zip(('N0Q', 'N0U'), ('NWSReflectivity', 'NWSVelocity'), axe
     # Pull the data out of the file object
     datadict = f.sym_block[0][0]
 
-    # Turn into an array, then mask
-    data = np.ma.array(datadict['data'])
-    data[data == 0] = np.ma.masked
+    # Turn into an array using the scale specified by the file
+    data = f.map_data(datadict['data'])
 
     # Grab azimuths and calculate a range based on number of gates
     az = np.array(datadict['start_az'] + [datadict['end_az'][-1]])
@@ -38,7 +39,7 @@ for v, ctable, ax in zip(('N0Q', 'N0U'), ('NWSReflectivity', 'NWSVelocity'), axe
     ylocs = rng * np.cos(np.deg2rad(az[:, np.newaxis]))
 
     # Plot the data
-    norm, cmap = colortables.get_with_steps(ctable, 16, 16)
+    norm, cmap = colortables.get_with_steps(*ctable)
     ax.pcolormesh(xlocs, ylocs, data, norm=norm, cmap=cmap)
     ax.set_aspect('equal', 'datalim')
     ax.set_xlim(-40, 20)


### PR DESCRIPTION
#### Description Of Changes

* Use NWS 8-bit colormaps instead of 16-level colormaps.  16-level data will still render correctly, but now we can plot the full resolution from 8-bit data such as the files for this example.
* Convert the data array to dBZ or m/s using the scaling indicated in the file header.  Calling `colorbar` to add a scale bar will now draw a scale with meaningful physical units.  Changes to the data encoding will no longer affect our ability to plot colors correctly.
* This also fixes a bug where the example was rendering small positive velocities in green when they should in fact be red.

#### Checklist

- [x] PR does not change any files other than `examples/formats/NEXRAD_Level_3_File.py`
- [x] Ran the example and verified that the output plot has correct coloration

![corrected_level3_example](https://user-images.githubusercontent.com/606010/86496140-04900b80-bd4a-11ea-8854-69a6b1fd94b4.png)