### PR TITLE
Fix masked arrays breaking wind_direction #1390

### DIFF
--- a/src/metpy/calc/basic.py
+++ b/src/metpy/calc/basic.py
@@ -98,7 +98,9 @@ def wind_direction(u, v, convention='from'):
     elif convention not in ('to', 'from'):
         raise ValueError('Invalid kwarg for "convention". Valid options are "from" or "to".')
 
-    wdir[wdir <= 0] += 360. * units.deg
+    mask = wdir <= 0
+    if np.any(mask):
+        wdir[mask] += 360. * units.deg
     # avoid unintended modification of `pint.Quantity` by direct use of magnitude
     calm_mask = (np.asarray(u.magnitude) == 0.) & (np.asarray(v.magnitude) == 0.)
     # np.any check required for legacy numpy which treats 0-d False boolean index as zero

--- a/tests/calc/test_basic.py
+++ b/tests/calc/test_basic.py
@@ -80,6 +80,23 @@ def test_direction():
     assert_array_almost_equal(true_dir, direc, 4)
 
 
+def test_direction_masked():
+    """Test calculating wind direction from masked wind components."""
+    mask = np.array([True, False, True, False])
+    u = np.array([4., 2., 0., 0.])
+    v = np.array([0., 2., 4., 0.])
+
+    u_masked = units.Quantity(np.ma.array(u, mask=mask), units('m/s'))
+    v_masked = units.Quantity(np.ma.array(v, mask=mask), units('m/s'))
+
+    direc = wind_direction(u_masked, v_masked)
+
+    true_dir = np.array([270., 225., 180., 0.])
+    true_dir_masked = units.Quantity(np.ma.array(true_dir, mask=mask), units.deg)
+
+    assert_array_almost_equal(true_dir_masked, direc, 4)
+
+
 def test_direction_with_north_and_calm():
     """Test how wind direction handles northerly and calm winds."""
     u = np.array([0., -0., 0.]) * units('m/s')


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes

Modify the `wind_direction` function so that masked arrays are supported when identifying directions <= 0.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [X] Closes #1390 
- [X] Tests added