### PR TITLE
Updates continuous integration/testing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,29 @@
+name: Run tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Test with pytest
+      run: |
+        pytest


### PR DESCRIPTION
This is a full refactor of our CI setup to make a bunch of improvements. Some of the ideas were put in #1173.

Goals here:
- [ ] Implement some testing using GitHub Actions
- [ ] Implement doc builds (make it so we only linkcheck once)
- [ ] Pin dependency versions using various requirements files and have them updated by dependabot
- [ ] Test with minimum versions
- [ ] Test both PyPI and Conda
- [ ] Tests for pre-releases
- [ ] Tests for xarray, pint git master
- [ ] Factor out linting (maybe)
- [ ] Windows, Linux...macOS?
- [ ] Multiple platforms?

Some of these we have with the existing AppVeyor + Travis setup. I'm not against continuing with either/both of those (though AppVeyor limited at best since we only get 1 job at a time) where they make sense.

One open question is how many permutations do we want to run? We have access to at least 3 OSes (not to mention ppc64le and aarch64 if we want), currently 3 Python versions (plus pre-release), as well as some other sets of dependencies. 
