### PR TITLE
Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: "/ci"
+    schedule:
+      interval: daily
+      time: "23:00"
+      timezone: "America/Denver"
+
+    allow:
+      - dependency-type: all
+
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "Type: Maintenance"
+    commit-message:
+      prefix: "MNT:"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+    allow:
+      - dependency-type: all
+
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "Type: Maintenance"
+    commit-message:
+      prefix: "MNT:"
+      include: "scope"

--- a/src/metpy/plots/ctables.py
+++ b/src/metpy/plots/ctables.py
@@ -95,7 +95,7 @@ def read_colortable(fobj):
                 ret.append(mcolors.colorConverter.to_rgb(literal))
         return ret
     except (SyntaxError, ValueError):
-        raise RuntimeError('Malformed colortable.')
+        raise RuntimeError(f'Malformed colortable (bad line: {line})')
 
 
 def convert_gempak_table(infile, outfile):


### PR DESCRIPTION
#### Description Of Changes
Enables [Dependabot](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#pull-request-branch-nameseparator) to update our pinned dependencies (and versioned GitHub workflow actions). This is a first cut at it to see what happens with some of our versions that are on older versions. There are certainly some tweaks to make, but there's no way to test this without committing something.

I also found a commit lurking on my old branch for this that improves an error message from parsing colortables. In lieu of submitting a PR for that, I'm throwing it on here.