### PR TITLE
Fix _check_argument_units for pint __eq__ returning duck array

### DIFF
--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -182,7 +182,7 @@ def _check_argument_units(args, defaults, dimensionality):
 
         if arg in defaults:
             check = val == defaults[arg]
-            if check:
+            if np.all(check):
                 continue
 
         # See if the value passed in is appropriate


### PR DESCRIPTION
Just a tiny quick fix for https://github.com/hgrecco/pint/pull/1123, which currently breaks a couple tests with Pint master. No tests or documentation needed to be modified.