### PR TITLE
 Fix masked array issue in equivalent potential temperature

### DIFF
--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -988,7 +988,7 @@ def equivalent_potential_temperature(pressure, temperature, dewpoint):
     th_l = t * (1000 / (p - e)) ** mpconsts.kappa * (t / t_l) ** (0.28 * r)
     th_e = th_l * np.exp((3036. / t_l - 1.78) * r * (1 + 0.448 * r))
 
-    return th_e * units.kelvin
+    return units.Quantity(th_e, units.kelvin)
 
 
 @exporter.export
@@ -1055,7 +1055,7 @@ def saturation_equivalent_potential_temperature(pressure, temperature):
     th_l = t * (1000 / (p - e)) ** mpconsts.kappa
     th_es = th_l * np.exp((3036. / t - 1.78) * r * (1 + 0.448 * r))
 
-    return th_es * units.kelvin
+    return units.Quantity(th_es, units.kelvin)
 
 
 @exporter.export

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -476,6 +476,24 @@ def test_equivalent_potential_temperature():
     assert_almost_equal(ept, 311.18586467284007 * units.kelvin, 3)
 
 
+def test_equivalent_potential_temperature_masked():
+    """Test equivalent potential temperature calculation with masked arrays."""
+    p = 1000 * units.mbar
+    t = units.Quantity(np.ma.array([293., 294., 295.]), units.kelvin)
+    td = units.Quantity(
+        np.ma.array([280., 281., 282.], mask=[False, True, False]),
+        units.kelvin
+    )
+    ept = equivalent_potential_temperature(p, t, td)
+    expected = units.Quantity(
+        np.ma.array([311.18586, 313.51781, 315.93971], mask=[False, True, False]),
+        units.kelvin
+    )
+    assert isinstance(ept, units.Quantity)
+    assert isinstance(ept.m, np.ma.MaskedArray)
+    assert_array_almost_equal(ept, expected, 3)
+
+
 def test_saturation_equivalent_potential_temperature():
     """Test saturation equivalent potential temperature calculation."""
     p = 700 * units.mbar
@@ -484,6 +502,20 @@ def test_saturation_equivalent_potential_temperature():
     # 299.096584 comes from equivalent_potential_temperature(p,t,t)
     # where dewpoint and temperature are equal, which means saturations.
     assert_almost_equal(s_ept, 299.096584 * units.kelvin, 3)
+
+
+def test_saturation_equivalent_potential_temperature_masked():
+    """Test saturation equivalent potential temperature calculation with masked arrays."""
+    p = 1000 * units.mbar
+    t = units.Quantity(np.ma.array([293., 294., 295.]), units.kelvin)
+    s_ept = saturation_equivalent_potential_temperature(p, t)
+    expected = units.Quantity(
+        np.ma.array([335.02750, 338.95813, 343.08740]),
+        units.kelvin
+    )
+    assert isinstance(s_ept, units.Quantity)
+    assert isinstance(s_ept.m, np.ma.MaskedArray)
+    assert_array_almost_equal(s_ept, expected, 3)
 
 
 def test_virtual_temperature():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes

Fixes the equivalent potential temperature issue noted in #1364 with masked arrays by not reconstructing quantity with multiplication (instead, reconstructing directly).

Tagging this for 1.0 (and basing on master branch), but should probably get cherry-picked for 0.12.2 as well?

Replaces https://github.com/Unidata/MetPy/pull/1373 due to needing to recreate my MetPy fork.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1364
- [x] Tests added