### PR TITLE
Fix quantified/units-on-attribute mixtures in tests and derivative calculations for xarray 0.16.0

### DIFF
--- a/ci/Current.txt
+++ b/ci/Current.txt
@@ -2,7 +2,7 @@ matplotlib==3.2.1
 numpy==1.19.1
 scipy==1.5.2
 pint==0.14
-xarray==0.15.1
+xarray==0.16.0
 traitlets==4.3.3
 pooch==1.1.1
 pandas==1.0.5

--- a/src/metpy/calc/tools.py
+++ b/src/metpy/calc/tools.py
@@ -928,10 +928,7 @@ def xarray_derivative_wrap(func):
 
             # Calculate and return result as a DataArray
             result = func(f.metpy.unit_array, **new_kwargs)
-            return xr.DataArray(result.magnitude,
-                                coords=f.coords,
-                                dims=f.dims,
-                                attrs={'units': str(result.units)})
+            return xr.DataArray(result, coords=f.coords, dims=f.dims)
         else:
             # Error
             raise ValueError('Must specify either "x" or "delta" for value positions when "f" '
@@ -1218,11 +1215,7 @@ def laplacian(f, **kwargs):
     pos_kwarg, positions, axes = _process_gradient_args(f, kwargs)
     derivs = [second_derivative(f, axis=axis, **{pos_kwarg: positions[ind]})
               for ind, axis in enumerate(axes)]
-    laplac = sum(derivs)
-    if isinstance(derivs[0], xr.DataArray):
-        # Patch in the units that are dropped
-        laplac.attrs['units'] = derivs[0].attrs['units']
-    return laplac
+    return sum(derivs)
 
 
 def _broadcast_to_axis(arr, axis, ndim):

--- a/tests/calc/test_basic.py
+++ b/tests/calc/test_basic.py
@@ -696,10 +696,10 @@ def test_smooth_window_1d_dataarray():
     smoothed = smooth_window(temperature, window=np.ones(3) / 3, normalize_weights=False)
     truth = xr.DataArray(
         [37., 34.33333333, 31.66666667, 30.33333333, 27., 26., 24.66666667,
-         25.66666667, 27., 30.],
+         25.66666667, 27., 30.] * units.degF,
         dims=('time',),
-        coords={'time': pd.date_range('2020-01-01', periods=10, freq='H')},
-        attrs={'units': 'degF'})
+        coords={'time': pd.date_range('2020-01-01', periods=10, freq='H')}
+    )
     xr.testing.assert_allclose(smoothed, truth)
 
 

--- a/tests/calc/test_calc_tools.py
+++ b/tests/calc/test_calc_tools.py
@@ -1087,7 +1087,7 @@ def test_first_derivative_xarray_lonlat(test_da_lonlat):
     _, truth = xr.broadcast(test_da_lonlat, partial)
     truth.coords['crs'] = test_da_lonlat['crs']
     truth.attrs['units'] = 'kelvin / meter'
-    truth.metpy.quantify()
+    truth = truth.metpy.quantify()
 
     # Assert result matches expectation
     xr.testing.assert_allclose(deriv, truth)
@@ -1103,7 +1103,7 @@ def test_first_derivative_xarray_time_and_default_axis(test_da_xy):
     deriv = first_derivative(test_da_xy)
     truth = xr.full_like(test_da_xy, -0.000777000777)
     truth.attrs['units'] = 'kelvin / second'
-    truth.metpy.quantify()
+    truth = truth.metpy.quantify()
 
     xr.testing.assert_allclose(deriv, truth)
     assert deriv.metpy.units == truth.metpy.units
@@ -1123,7 +1123,7 @@ def test_first_derivative_xarray_time_subsecond_precision():
 
     truth = xr.full_like(test_da, 5.)
     truth.attrs['units'] = 'kelvin / second'
-    truth.metpy.quantify()
+    truth = truth.metpy.quantify()
 
     xr.testing.assert_allclose(deriv, truth)
     assert deriv.metpy.units == truth.metpy.units
@@ -1141,7 +1141,7 @@ def test_second_derivative_xarray_lonlat(test_da_lonlat):
     _, truth = xr.broadcast(test_da_lonlat, partial)
     truth.coords['crs'] = test_da_lonlat['crs']
     truth.attrs['units'] = 'kelvin / meter^2'
-    truth.metpy.quantify()
+    truth = truth.metpy.quantify()
 
     xr.testing.assert_allclose(deriv, truth)
     assert deriv.metpy.units == truth.metpy.units
@@ -1156,11 +1156,11 @@ def test_gradient_xarray(test_da_xy):
 
     truth_x = xr.full_like(test_da_xy, -6.993007e-07)
     truth_x.attrs['units'] = 'kelvin / meter'
-    truth_x.metpy.quantify()
+    truth_x = truth_x.metpy.quantify()
 
     truth_y = xr.full_like(test_da_xy, -2.797203e-06)
     truth_y.attrs['units'] = 'kelvin / meter'
-    truth_y.metpy.quantify()
+    truth_y = truth_y.metpy.quantify()
 
     partial = xr.DataArray(
         np.array([0.04129204, 0.03330003, 0.02264402]),
@@ -1169,7 +1169,7 @@ def test_gradient_xarray(test_da_xy):
     _, truth_p = xr.broadcast(test_da_xy, partial)
     truth_p.coords['crs'] = test_da_xy['crs']
     truth_p.attrs['units'] = 'kelvin / hectopascal'
-    truth_p.metpy.quantify()
+    truth_p = truth_p.metpy.quantify()
 
     # Assert results match expectations
     xr.testing.assert_allclose(deriv_x, truth_x)
@@ -1195,11 +1195,11 @@ def test_gradient_xarray_implicit_axes(test_da_xy):
 
     truth_x = xr.full_like(data, -6.993007e-07)
     truth_x.attrs['units'] = 'kelvin / meter'
-    truth_x.metpy.quantify()
+    truth_x = truth_x.metpy.quantify()
 
     truth_y = xr.full_like(data, -2.797203e-06)
     truth_y.attrs['units'] = 'kelvin / meter'
-    truth_y.metpy.quantify()
+    truth_y = truth_y.metpy.quantify()
 
     xr.testing.assert_allclose(deriv_x, truth_x)
     assert deriv_x.metpy.units == truth_x.metpy.units
@@ -1253,7 +1253,7 @@ def test_laplacian_xarray_lonlat(test_da_lonlat):
     _, truth = xr.broadcast(test_da_lonlat, partial)
     truth.coords['crs'] = test_da_lonlat['crs']
     truth.attrs['units'] = 'kelvin / meter^2'
-    truth.metpy.quantify()
+    truth = truth.metpy.quantify()
 
     xr.testing.assert_allclose(laplac, truth)
     assert laplac.metpy.units == truth.metpy.units

--- a/tests/interpolate/test_slices.py
+++ b/tests/interpolate/test_slices.py
@@ -197,8 +197,8 @@ def test_cross_section_dataset_and_nearest_interp(test_ds_lonlat):
     data_cross = cross_section(test_ds_lonlat, start, end, steps=7, interp_type='nearest')
     nearest_values = test_ds_lonlat.isel(lat=xr.DataArray([0, 1, 2, 3, 3, 4, 5], dims='index'),
                                          lon=xr.DataArray(range(7), dims='index'))
-    truth_temp = nearest_values['temperature'].values
-    truth_rh = nearest_values['relative_humidity'].values
+    truth_temp = nearest_values['temperature'].metpy.unit_array
+    truth_rh = nearest_values['relative_humidity'].metpy.unit_array
     truth_values_lon = np.array([255.5, 258.20305939, 261.06299342, 264.10041516,
                                  267.3372208, 270.7961498, 274.5])
     truth_values_lat = np.array([30.5, 33.02800969, 35.49306226, 37.88512911, 40.19271688,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes

Fix some mixing of quantified and units-on-attribute DataArrays which breaks `xr.testing.assert_allclose` in xarray 0.16.0. This allows us to bump the current CI build to xarray 0.16.0.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1419
- [x] Tests ~~added~~ updated