### PR TITLE
Test maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@ MetPy
 [![Gitter](https://badges.gitter.im/Unidata/MetPy.svg)](https://gitter.im/Unidata/MetPy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=round-square)](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github)
 
-[![Latest Docs](https://img.shields.io/badge/docs-stable-brightgreen.svg)](http://unidata.github.io/MetPy)
+[![Latest Docs](https://github.com/Unidata/MetPy/workflows/Build%20Docs/badge.svg)](http://unidata.github.io/MetPy)
 [![PyPI Package](https://img.shields.io/pypi/v/metpy.svg)](https://pypi.python.org/pypi/MetPy/)
 [![Conda Package](https://anaconda.org/conda-forge/metpy/badges/version.svg)](https://anaconda.org/conda-forge/metpy)
 
 [![PyPI Downloads](https://img.shields.io/pypi/dm/metpy.svg)](https://pypi.python.org/pypi/MetPy/)
 [![Conda Downloads](https://anaconda.org/conda-forge/metpy/badges/downloads.svg)](https://anaconda.org/conda-forge/metpy)
 
-[![CI](https://github.com/Unidata/MetPy/workflows/CI/badge.svg)](https://github.com/Unidata/MetPy/actions?query=workflow%3ACI)
+[![PyPI Tests](https://github.com/Unidata/MetPy/workflows/PyPI%20Tests/badge.svg)](https://github.com/Unidata/MetPy/actions?query=workflow%3A%22PyPI+Tests%22)
+[![Conda Tests](https://github.com/Unidata/MetPy/workflows/Conda%20Tests/badge.svg)](https://github.com/Unidata/MetPy/actions?query=workflow%3A%22Conda+Tests%22)
 [![Travis Build Status](https://travis-ci.com/Unidata/MetPy.svg?branch=master)](https://travis-ci.com/Unidata/MetPy)
 [![Code Coverage Status](https://codecov.io/github/Unidata/MetPy/coverage.svg?branch=master)](https://codecov.io/github/Unidata/MetPy?branch=master)
 

--- a/src/metpy/calc/basic.py
+++ b/src/metpy/calc/basic.py
@@ -294,8 +294,9 @@ def heat_index(temperature, relative_humidity, mask_undefined=True):
            & (temperature <= 112. * units.degF))
     if np.any(sel):
         rh15adj = ((13. - relative_humidity[sel] * 100.) / 4.
-                   * ((17. * units.delta_degF - np.abs(delta[sel] - 95. * units.delta_degF))
-                      / 17. * units.delta_degF) ** 0.5)
+                   * np.sqrt((17. * units.delta_degF
+                              - np.abs(delta[sel] - 95. * units.delta_degF))
+                             / 17. * units.delta_degF))
         hi[sel] = hi[sel] - rh15adj
 
     # Adjustment for RH > 85% and 80F <= T <= 87F

--- a/src/metpy/calc/basic.py
+++ b/src/metpy/calc/basic.py
@@ -293,17 +293,18 @@ def heat_index(temperature, relative_humidity, mask_undefined=True):
     sel = ((relative_humidity <= 13. * units.percent) & (temperature >= 80. * units.degF)
            & (temperature <= 112. * units.degF))
     if np.any(sel):
-        rh15adj = ((13. - relative_humidity * 100.) / 4.
-                   * ((17. * units.delta_degF - np.abs(delta - 95. * units.delta_degF))
+        rh15adj = ((13. - relative_humidity[sel] * 100.) / 4.
+                   * ((17. * units.delta_degF - np.abs(delta[sel] - 95. * units.delta_degF))
                       / 17. * units.delta_degF) ** 0.5)
-        hi[sel] = hi[sel] - rh15adj[sel]
+        hi[sel] = hi[sel] - rh15adj
 
     # Adjustment for RH > 85% and 80F <= T <= 87F
     sel = ((relative_humidity > 85. * units.percent) & (temperature >= 80. * units.degF)
            & (temperature <= 87. * units.degF))
     if np.any(sel):
-        rh85adj = 0.02 * (relative_humidity * 100. - 85.) * (87. * units.delta_degF - delta)
-        hi[sel] = hi[sel] + rh85adj[sel]
+        rh85adj = 0.02 * (relative_humidity[sel] * 100. - 85.) * (87. * units.delta_degF
+                                                                  - delta[sel])
+        hi[sel] = hi[sel] + rh85adj
 
     # See if we need to mask any undefined values
     if mask_undefined:

--- a/src/metpy/calc/basic.py
+++ b/src/metpy/calc/basic.py
@@ -1181,7 +1181,7 @@ def _check_radians(value, max_radians=2 * np.pi):
         value = value.to('radians').m
     except AttributeError:
         pass
-    if np.greater(np.nanmax(np.abs(value)), max_radians):
+    if np.any(np.greater(np.abs(value), max_radians)):
         warnings.warn('Input over {} radians. '
-                      'Ensure proper units are given.'.format(max_radians))
+                      'Ensure proper units are given.'.format(np.nanmax(max_radians)))
     return value

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -980,15 +980,12 @@ def equivalent_potential_temperature(pressure, temperature, dewpoint):
     """
     t = temperature.to('kelvin').magnitude
     td = dewpoint.to('kelvin').magnitude
-    p = pressure.to('hPa').magnitude
-    e = saturation_vapor_pressure(dewpoint).to('hPa').magnitude
     r = saturation_mixing_ratio(pressure, dewpoint).magnitude
+    e = saturation_vapor_pressure(dewpoint)
 
     t_l = 56 + 1. / (1. / (td - 56) + np.log(t / td) / 800.)
-    th_l = t * (1000 / (p - e)) ** mpconsts.kappa * (t / t_l) ** (0.28 * r)
-    th_e = th_l * np.exp(r * (1 + 0.448 * r) * (3036. / t_l - 1.78))
-
-    return units.Quantity(th_e, units.kelvin)
+    th_l = potential_temperature(pressure - e, temperature) * (t / t_l) ** (0.28 * r)
+    return th_l * np.exp(r * (1 + 0.448 * r) * (3036. / t_l - 1.78))
 
 
 @exporter.export

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -986,7 +986,7 @@ def equivalent_potential_temperature(pressure, temperature, dewpoint):
 
     t_l = 56 + 1. / (1. / (td - 56) + np.log(t / td) / 800.)
     th_l = t * (1000 / (p - e)) ** mpconsts.kappa * (t / t_l) ** (0.28 * r)
-    th_e = th_l * np.exp((3036. / t_l - 1.78) * r * (1 + 0.448 * r))
+    th_e = th_l * np.exp(r * (1 + 0.448 * r) * (3036. / t_l - 1.78))
 
     return units.Quantity(th_e, units.kelvin)
 

--- a/src/metpy/io/metar.py
+++ b/src/metpy/io/metar.py
@@ -16,12 +16,9 @@ from .station_data import station_info
 from ..calc import altimeter_to_sea_level_pressure, wind_components
 from ..package_tools import Exporter
 from ..plots.wx_symbols import wx_code_map
-from ..units import pandas_dataframe_to_unit_arrays, units
+from ..units import units
 
 exporter = Exporter(globals())
-
-# Ignore the pandas warning
-warnings.filterwarnings('ignore', "Pandas doesn't allow columns to be created", UserWarning)
 
 # Configure the named tuple used for storing METAR data
 Metar = namedtuple('metar', ['station_id', 'latitude', 'longitude', 'elevation',
@@ -171,13 +168,11 @@ def parse_metar_to_dataframe(metar_text, year=datetime.now().year, month=datetim
     df['altimeter'] = df.altimeter.round(2)
     df['air_pressure_at_sea_level'] = df.air_pressure_at_sea_level.round(2)
 
-    # Set the units for the dataframe
-    df.units = col_units
+    # Set the units for the dataframe--filter out warning from pandas
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        df.units = col_units
 
-    # Add the array for units to the dataframe
-    pandas_dataframe_to_unit_arrays(df)
-
-    # Return the dataframe
     return df
 
 
@@ -623,8 +618,9 @@ def parse_metar_file(filename, year=datetime.now().year, month=datetime.now().mo
     df['altimeter'] = df.altimeter.round(2)
     df['air_pressure_at_sea_level'] = df.air_pressure_at_sea_level.round(2)
 
-    # Set the units for the dataframe
-    df.units = col_units
-    pandas_dataframe_to_unit_arrays(df)
+    # Set the units for the dataframe--filter out warning from Pandas
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        df.units = col_units
 
     return df

--- a/tests/plots/test_skewt.py
+++ b/tests/plots/test_skewt.py
@@ -481,7 +481,8 @@ def test_hodograph_wind_vectors():
     return fig
 
 
-@pytest.mark.xfail
+@pytest.mark.skipif(matplotlib.__version__ < '3.0.1',
+                    reason="Earlier Matplotlib versions don't have a required fix.")
 def test_united_hodograph_range():
     """Tests making a hodograph with a united ranged."""
     fig = plt.figure(figsize=(6, 6))

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -3,13 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 r"""Tests the operation of MetPy's unit support code."""
 
-from distutils.version import LooseVersion
-import sys
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import pint
 import pytest
 
 from metpy.testing import assert_array_almost_equal, assert_array_equal
@@ -36,8 +32,6 @@ def test_concatenate_masked():
     assert_array_equal(result.mask, np.array([False, True, False, False]))
 
 
-@pytest.mark.skipif(pint.__version__ == '0.9', reason=('Currently broken upstream (see '
-                                                       'pint#751'))
 @pytest.mark.mpl_image_compare(tolerance=0, remove_text=True)
 def test_axhline():
     r"""Ensure that passing a quantity to axhline does not error."""
@@ -48,8 +42,6 @@ def test_axhline():
     return fig
 
 
-@pytest.mark.skipif(pint.__version__ == '0.9', reason=('Currently broken upstream (see '
-                                                       'pint#751'))
 @pytest.mark.mpl_image_compare(tolerance=0, remove_text=True)
 def test_axvline():
     r"""Ensure that passing a quantity to axvline does not error."""
@@ -97,7 +89,6 @@ test_params = [((30 * units.degC, 1000 * units.mb, 1 * units('kg/m^3'), 1, 5 * u
                  ('mixing', '[dimensionless]', 'meter')])]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 3), reason='Unit checking requires Python >= 3.3')
 @pytest.mark.parametrize('func', test_funcs, ids=['some kwargs', 'all kwargs', 'all pos'])
 @pytest.mark.parametrize('args,kwargs,bad_parts', test_params,
                          ids=['one bad arg', 'all args no units', 'mixed args'])
@@ -196,15 +187,11 @@ def test_assert_nan_checks_units():
         assert_nan(np.nan * units.m, units.second)
 
 
-@pytest.mark.skipif(LooseVersion(pint.__version__) < LooseVersion('0.10'),
-                    reason='Custom preprocessors only available in Pint 0.10')
 def test_percent_units():
     """Test that percent sign units are properly parsed and interpreted."""
     assert str(units('%').units) == 'percent'
 
 
-@pytest.mark.skipif(LooseVersion(pint.__version__) < LooseVersion('0.10'),
-                    reason='Custom preprocessors only available in Pint 0.10')
 def test_udunits_power_syntax():
     """Test that UDUNITS style powers are properly parsed and interpreted."""
     assert units('m2 s-2').units == units.m ** 2 / units.s ** 2


### PR DESCRIPTION
A few clean-ups to some tests:
* One test that was marked as expected fail now passes (Thanks to pint 0.10.1). This closes #832.
* Removed a bunch of out-dated `skipif`s that apply to versions of things we no longer support.
* Removed warnings triggered in some calculations for a variety of reasons
* Slightly refactored `equivalent_potential_temperature` to use our own `potential_temperature` function