### PR TITLE
Replace use of Dataset.apply and .drop to clear PendingDeprecationWarnings

### DIFF
--- a/src/metpy/interpolate/slices.py
+++ b/src/metpy/interpolate/slices.py
@@ -152,8 +152,8 @@ def cross_section(data, start, end, steps=100, interp_type='linear'):
     """
     if isinstance(data, xr.Dataset):
         # Recursively apply to dataset
-        return data.apply(cross_section, True, (start, end), steps=steps,
-                          interp_type=interp_type)
+        return data.map(cross_section, True, (start, end), steps=steps,
+                        interp_type=interp_type)
     elif data.ndim == 0:
         # This has no dimensions, so it is likely a projection variable. In any case, there
         # are no data here to take the cross section with. Therefore, do nothing.

--- a/tests/calc/test_cross_sections.py
+++ b/tests/calc/test_cross_sections.py
@@ -148,7 +148,7 @@ def test_distances_from_cross_section_given_xy(test_cross_xy):
 def test_distances_from_cross_section_given_bad_coords(test_cross_xy):
     """Ensure an AttributeError is raised when the cross section lacks neeed coordinates."""
     with pytest.raises(AttributeError):
-        distances_from_cross_section(test_cross_xy['u_wind'].drop('x'))
+        distances_from_cross_section(test_cross_xy['u_wind'].drop_vars('x'))
 
 
 def test_latitude_from_cross_section_given_lat(test_cross_lonlat):

--- a/tests/calc/test_kinematics.py
+++ b/tests/calc/test_kinematics.py
@@ -1035,7 +1035,7 @@ def data_4d():
     data = xr.open_dataset(get_test_data('irma_gfs_example.nc', False))
     data = data.metpy.parse_cf()
     data['Geopotential_height_isobaric'].attrs['units'] = 'm'
-    subset = data.drop((
+    subset = data.drop_vars((
         'LatLon_361X720-0p25S-180p00E', 'Vertical_velocity_pressure_isobaric', 'isobaric1',
         'Relative_humidity_isobaric', 'reftime'
 

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -57,7 +57,7 @@ def test_var_multidim_full(test_ds):
 @pytest.fixture
 def test_var_multidim_no_xy(test_var_multidim_full):
     """Provide a variable with multidimensional lat/lon coords but without x/y coords."""
-    return test_var_multidim_full.drop(['y', 'x'])
+    return test_var_multidim_full.drop_vars(['y', 'x'])
 
 
 def test_projection(test_var):
@@ -498,7 +498,7 @@ def test_coordinates_identical_true(test_ds_generic):
 
 def test_coordinates_identical_false_number_of_coords(test_ds_generic):
     """Test coordinates identical method when false due to number of coordinates."""
-    other_ds = test_ds_generic.drop('e')
+    other_ds = test_ds_generic.drop_vars('e')
     assert not test_ds_generic['test'].metpy.coordinates_identical(other_ds['test'])
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes

As alluded to in https://github.com/Unidata/MetPy/pull/1430#issuecomment-665418689, bumping xarray's minimum version to 0.14.1 allows us to clear out some `PendingDeprecationWarnings` due to our usage of `Dataset.apply` and `Dataset.drop`, so that's what I've done here. From running the test suite locally, it goes from

```
1040 passed, 68 warnings in 60.24s
```
to
```
1040 passed, 42 warnings in 58.61s
```

Not sure if I should add any direct testing that these warnings are no longer issued?

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Fully documented