### PR TITLE
Fix formatting of link in references

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -135,9 +135,9 @@ References
            doi:`10.1175/1520-0493(1999)127%3C2709%3ATUAMOC%3E2.0.CO;2
            <https://doi.org/10.1175/1520-0493(1999)127%3C2709%3ATUAMOC%3E2.0.CO;2>`_.
 
-.. [Smithsonian1951] Smithsonian Institution and List, Robert J. 1951: `Smithsonian
-           meteorological tables <_static/Smithsonian1951.pdf>`  *Smithsonian Miscellaneous
-           Collections*, **144**, 151 pp.
+.. [Smithsonian1951] Smithsonian Institution and List, Robert J. 1951:
+           `Smithsonian meteorological tables <_static/Smithsonian1951.pdf>`_ *Smithsonian
+           Miscellaneous Collections*, **144**, 151 pp.
 
 .. [Steadman1979] Steadman, R.G., 1979: The assessment of sultriness. Part I: A
            temperature-humidity index based on human physiology and clothing


### PR DESCRIPTION
#### Description Of Changes

RST formatting was not correct for Smithsonian tables.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->


#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1427
