### PR TITLE
New GitHub Workflow for Docs

### DIFF
--- a/.github/workflows/docs-conda.yml
+++ b/.github/workflows/docs-conda.yml
@@ -1,0 +1,102 @@
+name: Build Docs (Conda)
+
+# We don't want pushes (or PRs) to gh-pages to kick anything off
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  #
+  # Build our docs on macOS and Windows on Python 3.6 and 3.7, respectively.
+  #
+  Docs:
+    name: ${{ matrix.os }} ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: 3.6
+            os: macOS
+          - python-version: 3.7
+            os: Windows
+
+    steps:
+    # We check out only a limited depth and then pull tags to save time
+    - name: Checkout source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 100
+
+    - name: Get tags
+      run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+
+    - name: Setup conda caching
+      uses: actions/cache@v2
+      with:
+        path: ~/conda_pkgs_dir
+        key: conda-docs-${{ runner.os }}-${{ matrix.python-version}}-${{ hashFiles('ci/*') }}
+        restore-keys: |
+          conda-docs-${{ runner.os }}-${{ matrix.python-version}}
+          conda-docs-${{ runner.os }}
+          conda-docs-
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: goanpeca/setup-miniconda@v1
+      with:
+        auto-update-conda: true
+        miniconda-version: "latest"
+        python-version: ${{ matrix.python-version }}
+        channel-priority: strict
+        channels: conda-forge
+        show-channel-urls: true
+        # Needed for caching
+        use-only-tar-bz2: true
+
+    - name: Adjust dependencies for Windows
+      if: ${{ runner.os == 'Windows' }}
+      run: sed -e "s/scipy==.*/scipy==1.5.0/" -i'' ci/Current.txt
+
+    - name: Install dependencies
+      run: conda install --quiet --yes --file ci/doc_requirements.txt --file ci/extra_requirements.txt --file ci/Current.txt
+
+    # This imports CartoPy to find its map data cache directory
+    - name: Get CartoPy maps dir
+      id: cartopy-cache
+      run: echo "::set-output name=dir::$(python -c 'import cartopy;print(cartopy.config["data_dir"])')"
+
+    - name: Setup mapdata caching
+      uses: actions/cache@v2
+      env:
+        # Increase to reset cache of map data
+        CACHE_NUMBER: 0
+      with:
+        path: ${{ steps.cartopy-cache.outputs.dir }}
+        key: docs-cartopy-${{ env.CACHE_NUMBER }}
+        restore-keys: docs-cartopy-
+
+    - name: Install
+      # For some reason on Windows 3.7 building the wheel fails to properly include our extra
+      # stuff. Executing the egg_info beforehand for some reason fixes it. No idea why. We're
+      # deep in territory where googling for answers helps not at all.
+      run: |
+        python setup.py egg_info
+        python -m pip install --no-deps .
+
+    - name: Build docs
+      run: |
+        export TEST_DATA_DIR=$GITHUB_WORKSPACE/staticdata
+        pushd docs
+        make overridecheck html O=-W
+        popd
+
+    - name: Upload docs as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.os }}-${{ matrix.python-version }}-docs
+        path: |
+          docs/build/html
+          !docs/_static/*.pdf

--- a/.github/workflows/docs-conda.yml
+++ b/.github/workflows/docs-conda.yml
@@ -47,7 +47,6 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: goanpeca/setup-miniconda@v1
       with:
-        auto-update-conda: true
         miniconda-version: "latest"
         python-version: ${{ matrix.python-version }}
         channel-priority: strict

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,11 +18,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7]
-        linkcheck: ['']
-        dep-versions: [Current.txt]
-        git-versions: ['']
-        experimental: [false]
         include:
           - python-version: 3.8
             linkcheck: linkcheck

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -85,8 +85,8 @@ jobs:
         CACHE_NUMBER: 0
       with:
         path: ${{ steps.cartopy-cache.outputs.dir }}
-        key: cartopy-${{ env.CACHE_NUMBER }}
-        restore-keys: cartopy-
+        key: docs-cartopy-${{ env.CACHE_NUMBER }}
+        restore-keys: docs-cartopy-
 
     - name: Install self
       run: python -m pip install -c ci/${{ matrix.dep-versions }} .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,9 +3,12 @@ name: Build Docs
 # We don't want pushes (or PRs) to gh-pages to kick anything off
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - '[0-9]+.[0-9]+.x'
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
   pull_request:
-    branches: [ master ]
 
 jobs:
   #
@@ -15,6 +18,8 @@ jobs:
     name: ${{ matrix.python-version }} ${{ matrix.dep-versions }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
+    env:
+      DOC_VERSION: dev
     strategy:
       fail-fast: false
       matrix:
@@ -99,9 +104,26 @@ jobs:
         popd
 
     - name: Upload docs as artifact
+      if: ${{ github.event_name == 'pull_request' }}
       uses: actions/upload-artifact@v2
       with:
-        name: ${{ matrix.python-version }}-docs
+        name: ${{ matrix.python-version }}-${{ matrix.dep-versions }}-docs
         path: |
           docs/build/html
           !docs/_static/*.pdf
+
+    # This overrides the version "dev" with the proper version if we're building off a
+    # branch that's not master (which is confined to n.nn.x above) or on a tag.
+    - name: Set doc version
+      if: ${{ github.event_name != 'push' || !contains(github.ref, 'master') }}
+      run: echo "::set-env name=DOC_VERSION::v$(python -c 'import metpy; print(metpy.__version__.rsplit(".", maxsplit=2)[0])')"
+
+    - name: Upload to GitHub Pages
+      if: ${{ github.event_name != 'pull_request' && matrix.experimental == false }}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/
+        exclude_assets: docs/build/html/_static/jquery-*.js,docs/build/html/_static/underscore-*.js,docs/build/html/.buildinfo
+        destination_dir: ${{ env.DOC_VERSION }}/
+        full_commit_message: Deploy ${{ steps.doc-version.outputs.version }} to GitHub Pages

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -46,7 +46,6 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: goanpeca/setup-miniconda@v1
       with:
-        auto-update-conda: true
         miniconda-version: "latest"
         python-version: ${{ matrix.python-version }}
         channel-priority: strict

--- a/ci/doc_requirements.txt
+++ b/ci/doc_requirements.txt
@@ -1,6 +1,6 @@
 sphinx==3.1.2
 sphinx-gallery==0.7
-myst_parser==0.10.0
+myst-parser==0.10.0
 netCDF4==1.5.3
 # Needed for sphinx-gallery, which refuses to list dependencies
 pillow==7.2.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ intersphinx_mapping = {
                        # 'pint': ('http://pint.readthedocs.io/en/stable/', None),
                        'matplotlib': ('https://matplotlib.org/', None),
                        'python': ('https://docs.python.org/3/', None),
-                       'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+                       'numpy': ('https://numpy.org/doc/stable/', None),
                        'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
                        'xarray': ('https://xarray.pydata.org/en/stable/', None)
                        }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
More updates to our GitHub Actions workflow, this times for building documentation:
- Move 3.6 build to macOS with conda
- Move 3.7 build to Windows with conda
- Add machinery to upload built docs (on main repo) to GH Pages. This has the benefit that it will work with tags *and* branches named e.g. 0.12.x. This gives us the capability to update the live/released docs just by pushing to the appropriate branch.

This gives us additional platform coverage for examples *without* adding additional builds to the overall matrix, which is a little large.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1380