### PR TITLE
Improve testing framework and infrastructure

### DIFF
--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -14,27 +14,23 @@ jobs:
   PyPITests:
     name: ${{ matrix.python-version }} ${{ matrix.dep-versions }} ${{ matrix.no-extras }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.dep-versions == 'Prerelease' }}
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
         dep-versions: [Current.txt]
         no-extras: ['']
-        experimental: [false]
         include:
           - python-version: 3.6
             dep-versions: Minimum
             no-extras: ''
-            experimental: false
           - python-version: 3.8
             dep-versions: Current.txt
             no-extras: 'No Extras'
-            experimental: false
           - python-version: 3.8
             dep-versions: Prerelease
             no-extras: ''
-            experimental: true
 
     steps:
     # We check out only a limited depth and then pull tags to save time

--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -12,7 +12,7 @@ jobs:
   # Run all tests on Linux using standard PyPI packages, including min and pre-releases
   #
   PyPITests:
-    name: ${{ matrix.python-version }} ${{ matrix.dep-versions }}
+    name: ${{ matrix.python-version }} ${{ matrix.dep-versions }} ${{ matrix.no-extras }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -20,16 +20,20 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
         dep-versions: [Current.txt]
-        git-versions: ['']
+        no-extras: ['']
         experimental: [false]
         include:
           - python-version: 3.6
             dep-versions: Minimum
-            git-versions: ''
+            no-extras: ''
+            experimental: false
+          - python-version: 3.8
+            dep-versions: Current.txt
+            no-extras: 'No Extras'
             experimental: false
           - python-version: 3.8
             dep-versions: Prerelease
-            git-versions: 'git+git://github.com/hgrecco/pint@master#egg=pint git+git://github.com/pydata/xarray@master#egg=xarray'
+            no-extras: ''
             experimental: true
 
     steps:
@@ -63,6 +67,16 @@ jobs:
           pip-tests-${{ runner.os }}-
           pip-tests-
 
+    - name: Add extras to requirements
+      if: ${{ matrix.no-extras != 'No Extras' }}
+      run: cat ci/extra_requirements.txt >> ci/test_requirements.txt
+
+    - name: Add git versions to requirements
+      if: ${{ matrix.dep-versions == 'Prerelease' }}
+      run: |
+        echo git+git://github.com/hgrecco/pint@master#egg=pint >> ci/test_requirements.txt
+        echo git+git://github.com/pydata/xarray@master#egg=xarray >> ci/test_requirements.txt
+
     # This installs the stuff needed to build and install Shapely and CartoPy from source.
     # Need to install numpy first to make CartoPy happy.
     - name: Install dependencies
@@ -71,14 +85,16 @@ jobs:
         python -m pip install --upgrade pip setuptools
         python -m pip install --no-binary :all: shapely
         python -m pip install -c ci/${{ matrix.dep-versions }} numpy
-        python -m pip install -r ci/test_requirements.txt -r ci/extra_requirements.txt -c ci/${{ matrix.dep-versions }} ${{ matrix.git-versions }}
+        python -m pip install -r ci/test_requirements.txt -c ci/${{ matrix.dep-versions }}
 
     # This imports CartoPy to find its map data cache directory
     - name: Get CartoPy maps dir
+      if: ${{ matrix.no-extras != 'No Extras' }}
       id: cartopy-cache
       run: echo "::set-output name=dir::$(python -c 'import cartopy;print(cartopy.config["data_dir"])')"
 
     - name: Setup mapdata caching
+      if: ${{ steps.cartopy-cache.outputs.dir != '' }}
       uses: actions/cache@v2
       env:
         # Increase to reset cache of map data
@@ -98,7 +114,7 @@ jobs:
         python -m pytest --mpl -W error::metpy.deprecation.MetpyDeprecationWarning --cov=metpy --cov=tests --cov-report=xml
 
     - name: Run doctests
-      if: ${{ matrix.dep-versions == 'Current.txt' }}
+      if: ${{ matrix.dep-versions == 'Current.txt' && matrix.no-extras != 'No Extras' }}
       env:
         PY_IGNORE_IMPORTMISMATCH: 1
       run: python -m pytest --doctest-modules -k "not test" src;

--- a/conftest.py
+++ b/conftest.py
@@ -37,3 +37,23 @@ def doctest_available_modules(doctest_namespace):
     doctest_namespace['metpy'] = metpy
     doctest_namespace['metpy.calc'] = metpy.calc
     doctest_namespace['plt'] = matplotlib.pyplot
+
+
+@pytest.fixture()
+def ccrs():
+    """Provide access to the ``cartopy.crs`` module through a global fixture.
+
+    Any testing function/fixture that needs access to ``cartopy.crs`` can simply add this to
+    their parameter list.
+    """
+    return pytest.importorskip('cartopy.crs')
+
+
+@pytest.fixture
+def cfeature():
+    """Provide access to the ``cartopy.feature`` module through a global fixture.
+
+    Any testing function/fixture that needs access to ``cartopy.feature`` can simply add this
+    to their parameter list.
+    """
+    return pytest.importorskip('cartopy.feature')

--- a/src/metpy/plots/cartopy_utils.py
+++ b/src/metpy/plots/cartopy_utils.py
@@ -55,3 +55,23 @@ try:
     USSTATES = MetPyMapFeature('us_states', '20m', facecolor='None', edgecolor='black')
 except ImportError:
     pass
+
+
+def import_cartopy():
+    """Import CartoPy; return a stub if unable.
+
+    This allows code requiring CartoPy to fail at use time rather than import time.
+    """
+    try:
+        import cartopy.crs as ccrs
+        return ccrs
+    except ImportError:
+        return CartopyStub()
+
+
+class CartopyStub:
+    """Fail if a CartoPy attribute is accessed."""
+
+    def __getattr__(self, item):
+        """Raise an error on any attribute access."""
+        raise RuntimeError(f'CartoPy is required to use this feature ({item}).')

--- a/src/metpy/plots/cartopy_utils.py
+++ b/src/metpy/plots/cartopy_utils.py
@@ -3,54 +3,55 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Cartopy specific mapping utilities."""
 
-import cartopy.crs as ccrs
-import cartopy.feature as cfeature
+try:
+    import cartopy.feature as cfeature
 
-from ..cbook import get_test_data
+    from ..cbook import get_test_data
 
+    class MetPyMapFeature(cfeature.Feature):
+        """A simple interface to MetPy-included shapefiles."""
 
-class MetPyMapFeature(cfeature.Feature):
-    """A simple interface to MetPy-included shapefiles."""
+        def __init__(self, name, scale, **kwargs):
+            """Create MetPyMapFeature instance."""
+            import cartopy.crs as ccrs
+            super().__init__(ccrs.PlateCarree(), **kwargs)
+            self.name = name
 
-    def __init__(self, name, scale, **kwargs):
-        """Create MetPyMapFeature instance."""
-        super().__init__(ccrs.PlateCarree(), **kwargs)
-        self.name = name
+            if isinstance(scale, str):
+                scale = cfeature.Scaler(scale)
+            self.scaler = scale
 
-        if isinstance(scale, str):
-            scale = cfeature.Scaler(scale)
-        self.scaler = scale
+        def geometries(self):
+            """Return an iterator of (shapely) geometries for this feature."""
+            import cartopy.io.shapereader as shapereader
+            # Ensure that the associated files are in the cache
+            fname = f'{self.name}_{self.scaler.scale}'
+            for extension in ['.dbf', '.shx']:
+                get_test_data(fname + extension)
+            path = get_test_data(fname + '.shp', as_file_obj=False)
+            return iter(tuple(shapereader.Reader(path).geometries()))
 
-    def geometries(self):
-        """Return an iterator of (shapely) geometries for this feature."""
-        import cartopy.io.shapereader as shapereader
-        # Ensure that the associated files are in the cache
-        fname = f'{self.name}_{self.scaler.scale}'
-        for extension in ['.dbf', '.shx']:
-            get_test_data(fname + extension)
-        path = get_test_data(fname + '.shp', as_file_obj=False)
-        return iter(tuple(shapereader.Reader(path).geometries()))
+        def intersecting_geometries(self, extent):
+            """Return geometries that intersect the extent."""
+            self.scaler.scale_from_extent(extent)
+            return super().intersecting_geometries(extent)
 
-    def intersecting_geometries(self, extent):
-        """Return geometries that intersect the extent."""
-        self.scaler.scale_from_extent(extent)
-        return super().intersecting_geometries(extent)
+        def with_scale(self, new_scale):
+            """
+            Return a copy of the feature with a new scale.
 
-    def with_scale(self, new_scale):
-        """
-        Return a copy of the feature with a new scale.
+            Parameters
+            ----------
+            new_scale
+                The new dataset scale, i.e. one of '500k', '5m', or '20m'.
+                Corresponding to 1:500,000, 1:5,000,000, and 1:20,000,000
+                respectively.
 
-        Parameters
-        ----------
-        new_scale
-            The new dataset scale, i.e. one of '500k', '5m', or '20m'.
-            Corresponding to 1:500,000, 1:5,000,000, and 1:20,000,000
-            respectively.
+            """
+            return MetPyMapFeature(self.name, new_scale, **self.kwargs)
 
-        """
-        return MetPyMapFeature(self.name, new_scale, **self.kwargs)
+    USCOUNTIES = MetPyMapFeature('us_counties', '20m', facecolor='None', edgecolor='black')
 
-
-USCOUNTIES = MetPyMapFeature('us_counties', '20m', facecolor='None', edgecolor='black')
-
-USSTATES = MetPyMapFeature('us_states', '20m', facecolor='None', edgecolor='black')
+    USSTATES = MetPyMapFeature('us_states', '20m', facecolor='None', edgecolor='black')
+except ImportError:
+    pass

--- a/src/metpy/plots/mapping.py
+++ b/src/metpy/plots/mapping.py
@@ -6,9 +6,10 @@
 Currently this includes tools for working with CartoPy projections.
 
 """
-import cartopy.crs as ccrs
-
 from ..cbook import Registry
+from ..plots.cartopy_utils import import_cartopy
+
+ccrs = import_cartopy()
 
 
 class CFProjection:

--- a/src/metpy/plots/mapping.py
+++ b/src/metpy/plots/mapping.py
@@ -60,6 +60,11 @@ class CFProjection:
 
         return ccrs.Globe(**kwargs)
 
+    @property
+    def cartopy_geodetic(self):
+        """Make a `cartopy.crs.Geodetic` instance from the appropriate `cartopy.crs.Globe`."""
+        return ccrs.Geodetic(self.cartopy_globe)
+
     def to_cartopy(self):
         """Convert to a CartoPy projection."""
         globe = self.cartopy_globe

--- a/src/metpy/testing.py
+++ b/src/metpy/testing.py
@@ -21,6 +21,19 @@ from metpy.deprecation import MetpyDeprecationWarning
 from .units import units
 
 
+def needs_cartopy(test_func):
+    """Decorate a test function or fixture as requiring CartoPy.
+
+    Will skip the decorated test, or any test using the decorated fixture, if ``cartopy`` is
+    unable to be imported.
+    """
+    @functools.wraps(test_func)
+    def wrapped(*args, **kwargs):
+        pytest.importorskip('cartopy')
+        return test_func(*args, **kwargs)
+    return wrapped
+
+
 def get_upper_air_data(date, station):
     """Get upper air observations from the test data cache.
 

--- a/src/metpy/testing.py
+++ b/src/metpy/testing.py
@@ -34,6 +34,19 @@ def needs_cartopy(test_func):
     return wrapped
 
 
+def needs_pyproj(test_func):
+    """Decorate a test function or fixture as requiring PyProj.
+
+    Will skip the decorated test, or any test using the decorated fixture, if ``pyproj`` is
+    unable to be imported.
+    """
+    @functools.wraps(test_func)
+    def wrapped(*args, **kwargs):
+        pytest.importorskip('pyproj')
+        return test_func(*args, **kwargs)
+    return wrapped
+
+
 def get_upper_air_data(date, station):
     """Get upper air observations from the test data cache.
 

--- a/tests/calc/test_calc_tools.py
+++ b/tests/calc/test_calc_tools.py
@@ -5,7 +5,6 @@
 
 from collections import namedtuple
 
-import cartopy.crs as ccrs
 import numpy as np
 import numpy.ma as ma
 import pandas as pd
@@ -21,7 +20,8 @@ from metpy.calc.tools import (_delete_masked_points, _get_bound_pressure_height,
                               _greater_or_close, _less_or_close, _next_non_masked_element,
                               _remove_nans, azimuth_range_to_lat_lon, BASE_DEGREE_MULTIPLIER,
                               DIR_STRS, UND, wrap_output_like)
-from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal)
+from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal,
+                           needs_cartopy)
 from metpy.units import DimensionalityError, units
 
 
@@ -963,6 +963,8 @@ def test_2d_gradient_4d_data_2_axes_1_deltas(deriv_4d_data):
 @pytest.fixture()
 def test_da_lonlat():
     """Return a DataArray with a lon/lat grid and no time coordinate for use in tests."""
+    pytest.importorskip('cartopy')
+
     data = np.linspace(300, 250, 3 * 4 * 4).reshape((3, 4, 4))
     ds = xr.Dataset(
         {'temperature': (['isobaric', 'lat', 'lon'], data)},
@@ -995,6 +997,8 @@ def test_da_lonlat():
 @pytest.fixture()
 def test_da_xy():
     """Return a DataArray with a x/y grid and a time coordinate for use in tests."""
+    pytest.importorskip('cartopy')
+
     data = np.linspace(300, 250, 3 * 3 * 4 * 4).reshape((3, 3, 4, 4))
     ds = xr.Dataset(
         {'temperature': (['time', 'isobaric', 'y', 'x'], data),
@@ -1067,7 +1071,7 @@ def test_grid_deltas_from_dataarray_xy(test_da_xy):
     assert_array_almost_equal(dy, true_dy, 5)
 
 
-def test_grid_deltas_from_dataarray_actual_xy(test_da_xy):
+def test_grid_deltas_from_dataarray_actual_xy(test_da_xy, ccrs):
     """Test grid_deltas_from_dataarray with a xy grid and kind='actual'."""
     # Construct lon/lat coordinates
     y, x = xr.broadcast(*test_da_xy.metpy.coordinates('y', 'x'))
@@ -1101,6 +1105,7 @@ def test_grid_deltas_from_dataarray_nominal_lonlat(test_da_lonlat):
     assert_array_almost_equal(dy, true_dy, 5)
 
 
+@needs_cartopy
 def test_grid_deltas_from_dataarray_lonlat_assumed_order():
     """Test grid_deltas_from_dataarray when dim order must be assumed."""
     # Create test dataarray

--- a/tests/calc/test_calc_tools.py
+++ b/tests/calc/test_calc_tools.py
@@ -21,7 +21,7 @@ from metpy.calc.tools import (_delete_masked_points, _get_bound_pressure_height,
                               _remove_nans, azimuth_range_to_lat_lon, BASE_DEGREE_MULTIPLIER,
                               DIR_STRS, UND, wrap_output_like)
 from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal,
-                           needs_cartopy)
+                           needs_cartopy, needs_pyproj)
 from metpy.units import DimensionalityError, units
 
 
@@ -421,6 +421,7 @@ def test_get_layer_heights_agl_bottom_no_interp():
     assert_array_almost_equal(data_true, data, 6)
 
 
+@needs_pyproj
 def test_lat_lon_grid_deltas_1d():
     """Test for lat_lon_grid_deltas for variable grid."""
     lat = np.arange(40, 50, 2.5)
@@ -438,6 +439,7 @@ def test_lat_lon_grid_deltas_1d():
 
 
 @pytest.mark.parametrize('flip_order', [(False, True)])
+@needs_pyproj
 def test_lat_lon_grid_deltas_2d(flip_order):
     """Test for lat_lon_grid_deltas for variable grid with negative delta distances."""
     lat = np.arange(40, 50, 2.5)
@@ -461,6 +463,7 @@ def test_lat_lon_grid_deltas_2d(flip_order):
     assert_almost_equal(dy, dy_truth, 4)
 
 
+@needs_pyproj
 def test_lat_lon_grid_deltas_extra_dimensions():
     """Test for lat_lon_grid_deltas with extra leading dimensions."""
     lon, lat = np.meshgrid(np.arange(-100, -90, 2.5), np.arange(40, 50, 2.5))
@@ -479,6 +482,7 @@ def test_lat_lon_grid_deltas_extra_dimensions():
     assert_almost_equal(dy, dy_truth, 4)
 
 
+@needs_pyproj
 def test_lat_lon_grid_deltas_mismatched_shape():
     """Test for lat_lon_grid_deltas for variable grid."""
     lat = np.arange(40, 50, 2.5)
@@ -488,6 +492,24 @@ def test_lat_lon_grid_deltas_mismatched_shape():
                     [-100., -97.5, -95., -92.5]])
     with pytest.raises(ValueError):
         lat_lon_grid_deltas(lon, lat)
+
+
+@needs_pyproj
+def test_lat_lon_grid_deltas_geod_kwargs():
+    """Test that geod kwargs are overridden by users #774."""
+    lat = np.arange(40, 50, 2.5)
+    lon = np.arange(-100, -90, 2.5)
+    dx, dy = lat_lon_grid_deltas(lon, lat, a=4370997)
+    dx_truth = np.array([[146095.76101984, 146095.76101984, 146095.76101984],
+                         [140608.9751528, 140608.9751528, 140608.9751528],
+                         [134854.56713287, 134854.56713287, 134854.56713287],
+                         [128843.49645823, 128843.49645823, 128843.49645823]]) * units.meter
+    dy_truth = np.array([[190720.72311199, 190720.72311199, 190720.72311199, 190720.72311199],
+                         [190720.72311199, 190720.72311199, 190720.72311199, 190720.72311199],
+                         [190720.72311199, 190720.72311199, 190720.72311199,
+                          190720.72311199]]) * units.meter
+    assert_almost_equal(dx, dx_truth, 4)
+    assert_almost_equal(dy, dy_truth, 4)
 
 
 @pytest.fixture()
@@ -852,6 +874,7 @@ def test_angle_to_direction_level_1():
     assert_array_equal(output_dirs, expected_dirs)
 
 
+@needs_pyproj
 def test_azimuth_range_to_lat_lon():
     """Test converstion of azimuth and range to lat/lon grid."""
     az = [332.2403, 334.6765, 337.2528, 339.73846, 342.26257]
@@ -883,6 +906,7 @@ def test_azimuth_range_to_lat_lon():
     assert_array_almost_equal(output_lat, true_lat, 6)
 
 
+@needs_pyproj
 def test_azimuth_range_to_lat_lon_diff_ellps():
     """Test converstion of azimuth and range to lat/lon grid."""
     az = [332.2403, 334.6765, 337.2528, 339.73846, 342.26257]

--- a/tests/calc/test_cross_sections.py
+++ b/tests/calc/test_cross_sections.py
@@ -12,11 +12,12 @@ from metpy.calc import (absolute_momentum, cross_section_components, normal_comp
 from metpy.calc.cross_sections import (distances_from_cross_section,
                                        latitude_from_cross_section)
 from metpy.interpolate import cross_section
-from metpy.testing import assert_array_almost_equal, assert_xarray_allclose
+from metpy.testing import assert_array_almost_equal, assert_xarray_allclose, needs_cartopy
 from metpy.units import units
 
 
 @pytest.fixture()
+@needs_cartopy
 def test_cross_lonlat():
     """Return cross section on a lon/lat grid with no time coordinate for use in tests."""
     data_u = np.linspace(-40, 40, 5 * 6 * 7).reshape((5, 6, 7)) * units.knots
@@ -53,6 +54,7 @@ def test_cross_lonlat():
 
 
 @pytest.fixture()
+@needs_cartopy
 def test_cross_xy():
     """Return cross section on a x/y grid with a time coordinate for use in tests."""
     data_u = np.linspace(-25, 25, 5 * 6 * 7).reshape((1, 5, 6, 7)) * units('m/s')

--- a/tests/calc/test_kinematics.py
+++ b/tests/calc/test_kinematics.py
@@ -18,7 +18,7 @@ from metpy.calc import (absolute_vorticity, advection, ageostrophic_wind, coriol
                         total_deformation, vorticity, wind_components)
 from metpy.constants import g, omega, Re
 from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal,
-                           get_test_data, needs_cartopy)
+                           get_test_data, needs_cartopy, needs_pyproj)
 from metpy.units import concatenate, units
 
 
@@ -427,6 +427,7 @@ def test_absolute_vorticity_asym():
 
 
 @pytest.fixture
+@needs_pyproj
 def pv_data():
     """Test data for all PV testing."""
     u = np.array([[[100, 90, 80, 70],
@@ -542,6 +543,7 @@ def test_potential_vorticity_baroclinic_wrong_number_of_levels_axis_0(pv_data):
                                        pressure[:1, :, :])
 
 
+@needs_pyproj
 def test_potential_vorticity_baroclinic_isentropic_real_data():
     """Test potential vorticity calculation with real isentropic data."""
     isentlevs = [328, 330, 332] * units.K
@@ -636,6 +638,7 @@ def test_potential_vorticity_baroclinic_isentropic_real_data():
     assert_almost_equal(pvor, true_pv, 14)
 
 
+@needs_pyproj
 def test_potential_vorticity_baroclinic_isobaric_real_data():
     """Test potential vorticity calculation with real isentropic data."""
     pres = [20000., 25000., 30000.] * units.Pa
@@ -744,23 +747,7 @@ def test_potential_vorticity_barotropic(pv_data):
     assert_almost_equal(pv, truth, 10)
 
 
-def test_lat_lon_grid_deltas_geod_kwargs():
-    """Test that geod kwargs are overridden by users #774."""
-    lat = np.arange(40, 50, 2.5)
-    lon = np.arange(-100, -90, 2.5)
-    dx, dy = lat_lon_grid_deltas(lon, lat, a=4370997)
-    dx_truth = np.array([[146095.76101984, 146095.76101984, 146095.76101984],
-                         [140608.9751528, 140608.9751528, 140608.9751528],
-                         [134854.56713287, 134854.56713287, 134854.56713287],
-                         [128843.49645823, 128843.49645823, 128843.49645823]]) * units.meter
-    dy_truth = np.array([[190720.72311199, 190720.72311199, 190720.72311199, 190720.72311199],
-                         [190720.72311199, 190720.72311199, 190720.72311199, 190720.72311199],
-                         [190720.72311199, 190720.72311199, 190720.72311199,
-                          190720.72311199]]) * units.meter
-    assert_almost_equal(dx, dx_truth, 4)
-    assert_almost_equal(dy, dy_truth, 4)
-
-
+@needs_pyproj
 def test_inertial_advective_wind_diffluent():
     """Test inertial advective wind with a diffluent flow."""
     lats = np.array([[50., 50., 50., 50., 50., 50., 50., 50., 50., 50., 50.],
@@ -952,6 +939,7 @@ def test_inertial_advective_wind_diffluent():
 
 
 @pytest.fixture
+@needs_pyproj
 def q_vector_data():
     """Define data for use in Q-vector tests."""
     speed = np.ones((4, 4)) * 50. * units('knots')

--- a/tests/calc/test_kinematics.py
+++ b/tests/calc/test_kinematics.py
@@ -18,7 +18,7 @@ from metpy.calc import (absolute_vorticity, advection, ageostrophic_wind, coriol
                         total_deformation, vorticity, wind_components)
 from metpy.constants import g, omega, Re
 from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal,
-                           get_test_data)
+                           get_test_data, needs_cartopy)
 from metpy.units import concatenate, units
 
 
@@ -1030,6 +1030,7 @@ def test_q_vector_with_static_stability(q_vector_data):
 
 
 @pytest.fixture
+@needs_cartopy
 def data_4d():
     """Define 4D data (extracted from Irma GFS example) for testing kinematics functions."""
     data = xr.open_dataset(get_test_data('irma_gfs_example.nc', False))

--- a/tests/interpolate/test_slices.py
+++ b/tests/interpolate/test_slices.py
@@ -8,7 +8,7 @@ import pytest
 import xarray as xr
 
 from metpy.interpolate import cross_section, geodesic, interpolate_to_slice
-from metpy.testing import assert_array_almost_equal
+from metpy.testing import assert_array_almost_equal, needs_cartopy
 from metpy.units import units
 
 
@@ -107,6 +107,7 @@ def test_interpolate_to_slice_against_selection(test_ds_lonlat):
     assert_array_almost_equal(true_slice.metpy.unit_array, test_slice.metpy.unit_array, 5)
 
 
+@needs_cartopy
 def test_geodesic(test_ds_xy):
     """Test the geodesic construction."""
     crs = test_ds_xy['temperature'].metpy.cartopy_crs
@@ -121,6 +122,7 @@ def test_geodesic(test_ds_xy):
     assert_array_almost_equal(path, truth, 0)
 
 
+@needs_cartopy
 def test_cross_section_dataarray_and_linear_interp(test_ds_xy):
     """Test the cross_section function with a data array and linear interpolation."""
     data = test_ds_xy['temperature']
@@ -191,6 +193,7 @@ def test_cross_section_dataarray_projection_noop(test_ds_xy):
     xr.testing.assert_identical(data, data_cross)
 
 
+@needs_cartopy
 def test_cross_section_dataset_and_nearest_interp(test_ds_lonlat):
     """Test the cross_section function with a dataset and nearest interpolation."""
     start, end = (30.5, 255.5), (44.5, 274.5)

--- a/tests/io/test_gini.py
+++ b/tests/io/test_gini.py
@@ -14,6 +14,7 @@ import xarray as xr
 from metpy.cbook import get_test_data
 from metpy.io import GiniFile
 from metpy.io.gini import GiniProjection
+from metpy.testing import needs_pyproj
 
 logging.getLogger('metpy.io.gini').setLevel(logging.ERROR)
 
@@ -97,6 +98,7 @@ gini_dataset_info = [('WEST-CONUS_4km_WV_20151208_2200.gini',
 
 @pytest.mark.parametrize('filename,bounds,data_var,proj_attrs,image,dt', gini_dataset_info,
                          ids=['LCC', 'Stereographic', 'Mercator'])
+@needs_pyproj
 def test_gini_xarray(filename, bounds, data_var, proj_attrs, image, dt):
     """Test that GINIFile can be passed to XArray as a datastore."""
     f = GiniFile(get_test_data(filename))
@@ -132,6 +134,7 @@ def test_gini_xarray(filename, bounds, data_var, proj_attrs, image, dt):
     assert np.asarray(dt, dtype='datetime64[ms]') == ds.variables['time']
 
 
+@needs_pyproj
 def test_gini_mercator_upper_corner():
     """Test that the upper corner of the Mercator coordinates is correct."""
     f = GiniFile(get_test_data('HI-REGIONAL_4km_3.9_20160616_1715.gini'))

--- a/tests/plots/test_cartopy_utils.py
+++ b/tests/plots/test_cartopy_utils.py
@@ -3,13 +3,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Test the cartopy utilities."""
 
-import cartopy.crs as ccrs
 import matplotlib
 import matplotlib.pyplot as plt
 import pytest
 
-from metpy.plots import USCOUNTIES, USSTATES
-# Fixtures to make sure we have the right backend and consistent round
+try:
+    from metpy.plots import USCOUNTIES, USSTATES
+except ImportError:
+    pass  # No CartoPy
+# Fixture to make sure we have the right backend
 from metpy.testing import set_agg_backend  # noqa: F401, I202
 
 MPL_VERSION = matplotlib.__version__[:3]
@@ -17,7 +19,7 @@ MPL_VERSION = matplotlib.__version__[:3]
 
 @pytest.mark.mpl_image_compare(tolerance={'2.1': 0.161}.get(MPL_VERSION, 0.053),
                                remove_text=True)
-def test_us_county_defaults():
+def test_us_county_defaults(ccrs):
     """Test the default US county plotting."""
     proj = ccrs.LambertConformal(central_longitude=-85.0, central_latitude=45.0)
 
@@ -30,7 +32,7 @@ def test_us_county_defaults():
 
 @pytest.mark.mpl_image_compare(tolerance={'2.1': 0.1994}.get(MPL_VERSION, 0.092),
                                remove_text=True)
-def test_us_county_scales():
+def test_us_county_scales(ccrs):
     """Test US county plotting with all scales."""
     proj = ccrs.LambertConformal(central_longitude=-85.0, central_latitude=45.0)
 
@@ -46,7 +48,7 @@ def test_us_county_scales():
 
 
 @pytest.mark.mpl_image_compare(tolerance=0.053, remove_text=True)
-def test_us_states_defaults():
+def test_us_states_defaults(ccrs):
     """Test the default US States plotting."""
     proj = ccrs.LambertConformal(central_longitude=-85.0, central_latitude=45.0)
 
@@ -59,7 +61,7 @@ def test_us_states_defaults():
 
 @pytest.mark.mpl_image_compare(tolerance={'2.1': 0.991}.get(MPL_VERSION, 0.092),
                                remove_text=True)
-def test_us_states_scales():
+def test_us_states_scales(ccrs):
     """Test the default US States plotting with all scales."""
     proj = ccrs.LambertConformal(central_longitude=-85.0, central_latitude=45.0)
 

--- a/tests/plots/test_cartopy_utils.py
+++ b/tests/plots/test_cartopy_utils.py
@@ -11,6 +11,7 @@ try:
     from metpy.plots import USCOUNTIES, USSTATES
 except ImportError:
     pass  # No CartoPy
+from metpy.plots.cartopy_utils import import_cartopy
 # Fixture to make sure we have the right backend
 from metpy.testing import set_agg_backend  # noqa: F401, I202
 
@@ -74,3 +75,14 @@ def test_us_states_scales(ccrs):
         axis.set_extent([270, 280, 28, 39], ccrs.Geodetic())
         axis.add_feature(USSTATES.with_scale(scale))
     return fig
+
+
+def test_cartopy_stub(monkeypatch):
+    """Test that the CartoPy stub will issue an error if CartoPy is not present."""
+    import sys
+    # This makes sure that cartopy is not found
+    monkeypatch.setitem(sys.modules, 'cartopy.crs', None)
+
+    ccrs = import_cartopy()
+    with pytest.raises(RuntimeError, match='CartoPy is required'):
+        ccrs.PlateCarree()

--- a/tests/plots/test_declarative.py
+++ b/tests/plots/test_declarative.py
@@ -7,8 +7,6 @@ from datetime import datetime, timedelta
 from io import BytesIO
 import warnings
 
-import cartopy.crs as ccrs
-import cartopy.feature as cfeature
 import matplotlib
 import numpy as np
 import pandas as pd
@@ -22,7 +20,7 @@ from metpy.io.metar import parse_metar_file
 from metpy.plots import (BarbPlot, ContourPlot, FilledContourPlot, ImagePlot, MapPanel,
                          PanelContainer, PlotObs)
 # Fixtures to make sure we have the right backend
-from metpy.testing import set_agg_backend  # noqa: F401, I202
+from metpy.testing import needs_cartopy, set_agg_backend  # noqa: F401, I202
 from metpy.units import units
 
 
@@ -53,6 +51,7 @@ def test_declarative_image():
 
 @pytest.mark.mpl_image_compare(remove_text=True,
                                tolerance={'2.1': 0.256}.get(MPL_VERSION, 0.022))
+@needs_cartopy
 def test_declarative_contour():
     """Test making a contour plot."""
     data = xr.open_dataset(get_test_data('narr_example.nc', as_file_obj=False))
@@ -95,6 +94,7 @@ def fix_is_closed_polygon(monkeypatch):
 
 @pytest.mark.mpl_image_compare(remove_text=True,
                                tolerance={'2.1': 5.477}.get(MPL_VERSION, 0.035))
+@needs_cartopy
 def test_declarative_contour_options(fix_is_closed_polygon):
     """Test making a contour plot."""
     data = xr.open_dataset(get_test_data('narr_example.nc', as_file_obj=False))
@@ -125,6 +125,7 @@ def test_declarative_contour_options(fix_is_closed_polygon):
 
 @pytest.mark.mpl_image_compare(remove_text=True,
                                tolerance={'2.1': 2.007}.get(MPL_VERSION, 0.035))
+@needs_cartopy
 def test_declarative_contour_convert_units(fix_is_closed_polygon):
     """Test making a contour plot."""
     data = xr.open_dataset(get_test_data('narr_example.nc', as_file_obj=False))
@@ -155,6 +156,7 @@ def test_declarative_contour_convert_units(fix_is_closed_polygon):
 
 
 @pytest.mark.mpl_image_compare(remove_text=True, tolerance=0.016)
+@needs_cartopy
 def test_declarative_events():
     """Test that resetting traitlets properly propagates."""
     data = xr.open_dataset(get_test_data('narr_example.nc', as_file_obj=False))
@@ -221,7 +223,7 @@ def test_no_field_error_barbs():
         barbs.draw()
 
 
-def test_projection_object():
+def test_projection_object(ccrs, cfeature):
     """Test that we can pass a custom map projection."""
     data = xr.open_dataset(get_test_data('narr_example.nc', as_file_obj=False))
 
@@ -244,7 +246,7 @@ def test_projection_object():
 
 
 @pytest.mark.mpl_image_compare(remove_text=True, tolerance=0.016)
-def test_colorfill():
+def test_colorfill(cfeature):
     """Test that we can use ContourFillPlot."""
     data = xr.open_dataset(get_test_data('narr_example.nc', as_file_obj=False))
 
@@ -269,7 +271,7 @@ def test_colorfill():
 
 
 @pytest.mark.mpl_image_compare(remove_text=True, tolerance=0.016)
-def test_colorfill_horiz_colorbar():
+def test_colorfill_horiz_colorbar(cfeature):
     """Test that we can use ContourFillPlot."""
     data = xr.open_dataset(get_test_data('narr_example.nc', as_file_obj=False))
 
@@ -295,7 +297,7 @@ def test_colorfill_horiz_colorbar():
 
 @pytest.mark.mpl_image_compare(remove_text=True,
                                tolerance={'2.1': 0.355}.get(MPL_VERSION, 0.016))
-def test_colorfill_no_colorbar():
+def test_colorfill_no_colorbar(cfeature):
     """Test that we can use ContourFillPlot."""
     data = xr.open_dataset(get_test_data('narr_example.nc', as_file_obj=False))
 
@@ -341,7 +343,7 @@ def test_global():
 
 
 @pytest.mark.mpl_image_compare(remove_text=True)
-@pytest.mark.xfail(xr.__version__ < '0.11.0', reason='Does not work with older xarray.')
+@needs_cartopy
 def test_latlon():
     """Test our handling of lat/lon information."""
     data = xr.open_dataset(get_test_data('irma_gfs_example.nc', as_file_obj=False))
@@ -373,6 +375,7 @@ def test_latlon():
 
 @pytest.mark.mpl_image_compare(remove_text=True,
                                tolerance={'2.1': 0.418}.get(MPL_VERSION, 0.37))
+@needs_cartopy
 def test_declarative_barb_options():
     """Test making a contour plot."""
     data = xr.open_dataset(get_test_data('narr_example.nc', as_file_obj=False))
@@ -402,6 +405,7 @@ def test_declarative_barb_options():
 
 @pytest.mark.mpl_image_compare(remove_text=True,
                                tolerance={'2.1': 0.819}.get(MPL_VERSION, 0.612))
+@needs_cartopy
 def test_declarative_barb_earth_relative():
     """Test making a contour plot."""
     import numpy as np
@@ -441,6 +445,7 @@ def test_declarative_barb_earth_relative():
 
 
 @pytest.mark.mpl_image_compare(remove_text=True, tolerance=0.612)
+@needs_cartopy
 def test_declarative_gridded_scale():
     """Test making a contour plot."""
     import numpy as np
@@ -470,6 +475,7 @@ def test_declarative_gridded_scale():
 
 
 @pytest.mark.mpl_image_compare(remove_text=True, tolerance=0.607)
+@needs_cartopy
 def test_declarative_barb_gfs():
     """Test making a contour plot."""
     data = xr.open_dataset(get_test_data('GFS_test.nc', as_file_obj=False))
@@ -498,6 +504,7 @@ def test_declarative_barb_gfs():
 
 
 @pytest.mark.mpl_image_compare(remove_text=True, tolerance=0.466)
+@needs_cartopy
 def test_declarative_barb_gfs_knots():
     """Test making a contour plot."""
     data = xr.open_dataset(get_test_data('GFS_test.nc', as_file_obj=False))
@@ -617,7 +624,7 @@ def test_plotobs_subset_time_window_level(sample_obs):
 
 @pytest.mark.mpl_image_compare(remove_text=True,
                                tolerance={'2.1': 0.407}.get(MPL_VERSION, 0.022))
-def test_declarative_sfc_obs():
+def test_declarative_sfc_obs(ccrs):
     """Test making a surface observation plot."""
     data = pd.read_csv(get_test_data('SFC_obs.csv', as_file_obj=False),
                        infer_datetime_format=True, parse_dates=['valid'])
@@ -650,6 +657,7 @@ def test_declarative_sfc_obs():
 
 @pytest.mark.mpl_image_compare(remove_text=True,
                                tolerance={'2.1': 8.09}.get(MPL_VERSION, 0.022))
+@needs_cartopy
 def test_declarative_sfc_text():
     """Test making a surface observation plot with text."""
     data = pd.read_csv(get_test_data('SFC_obs.csv', as_file_obj=False),
@@ -684,7 +692,7 @@ def test_declarative_sfc_text():
 
 @pytest.mark.mpl_image_compare(remove_text=True,
                                tolerance={'2.1': 0.407}.get(MPL_VERSION, 0.022))
-def test_declarative_sfc_obs_changes():
+def test_declarative_sfc_obs_changes(ccrs):
     """Test making a surface observation plot, changing the field."""
     data = pd.read_csv(get_test_data('SFC_obs.csv', as_file_obj=False),
                        infer_datetime_format=True, parse_dates=['valid'])
@@ -721,7 +729,7 @@ def test_declarative_sfc_obs_changes():
 
 @pytest.mark.mpl_image_compare(remove_text=True,
                                tolerance={'2.1': 0.378}.get(MPL_VERSION, 0.00586))
-def test_declarative_colored_barbs():
+def test_declarative_colored_barbs(ccrs):
     """Test making a surface plot with a colored barb (gh-1274)."""
     data = pd.read_csv(get_test_data('SFC_obs.csv', as_file_obj=False),
                        infer_datetime_format=True, parse_dates=['valid'])
@@ -755,7 +763,7 @@ def test_declarative_colored_barbs():
 @pytest.mark.mpl_image_compare(remove_text=True,
                                tolerance={'3.1': 9.771,
                                           '2.1': 9.785}.get(MPL_VERSION, 0.00651))
-def test_declarative_sfc_obs_full():
+def test_declarative_sfc_obs_full(ccrs):
     """Test making a full surface observation plot."""
     data = pd.read_csv(get_test_data('SFC_obs.csv', as_file_obj=False),
                        infer_datetime_format=True, parse_dates=['valid'])
@@ -793,6 +801,7 @@ def test_declarative_sfc_obs_full():
 
 
 @pytest.mark.mpl_image_compare(remove_text=True, tolerance=0.08)
+@needs_cartopy
 def test_declarative_upa_obs():
     """Test making a full upperair observation plot."""
     data = pd.read_csv(get_test_data('UPA_obs.csv', as_file_obj=False))
@@ -829,6 +838,7 @@ def test_declarative_upa_obs():
 
 
 @pytest.mark.mpl_image_compare(remove_text=True, tolerance=0.08)
+@needs_cartopy
 def test_declarative_upa_obs_convert_barb_units():
     """Test making a full upperair observation plot."""
     data = pd.read_csv(get_test_data('UPA_obs.csv', as_file_obj=False))
@@ -870,7 +880,7 @@ def test_declarative_upa_obs_convert_barb_units():
     return pc.figure
 
 
-def test_attribute_error_time():
+def test_attribute_error_time(ccrs):
     """Make sure we get a useful error when the time variable is not found."""
     data = pd.read_csv(get_test_data('SFC_obs.csv', as_file_obj=False),
                        infer_datetime_format=True, parse_dates=['valid'])
@@ -901,7 +911,7 @@ def test_attribute_error_time():
         pc.draw()
 
 
-def test_attribute_error_station():
+def test_attribute_error_station(ccrs):
     """Make sure we get a useful error when the station variable is not found."""
     data = pd.read_csv(get_test_data('SFC_obs.csv', as_file_obj=False),
                        infer_datetime_format=True, parse_dates=['valid'])
@@ -934,7 +944,7 @@ def test_attribute_error_station():
 
 @pytest.mark.mpl_image_compare(remove_text=True,
                                tolerance={'2.1': 0.407}.get(MPL_VERSION, 0.022))
-def test_declarative_sfc_obs_change_units():
+def test_declarative_sfc_obs_change_units(ccrs):
     """Test making a surface observation plot."""
     data = parse_metar_file(get_test_data('metar_20190701_1200.txt', as_file_obj=False),
                             year=2019, month=7)
@@ -968,7 +978,7 @@ def test_declarative_sfc_obs_change_units():
 
 @pytest.mark.mpl_image_compare(remove_text=True,
                                tolerance={'2.1': 0.09}.get(MPL_VERSION, 0.022))
-def test_declarative_multiple_sfc_obs_change_units():
+def test_declarative_multiple_sfc_obs_change_units(ccrs):
     """Test making a surface observation plot."""
     data = parse_metar_file(get_test_data('metar_20190701_1200.txt', as_file_obj=False),
                             year=2019, month=7)
@@ -1024,6 +1034,7 @@ def test_show():
         pc.show()
 
 
+@needs_cartopy
 def test_panel():
     """Test the functionality of the panel property."""
     panel = MapPanel()

--- a/tests/plots/test_declarative.py
+++ b/tests/plots/test_declarative.py
@@ -29,6 +29,7 @@ MPL_VERSION = matplotlib.__version__[:3]
 
 @pytest.mark.mpl_image_compare(remove_text=True, tolerance=0.005)
 @needs_pyproj
+@needs_cartopy
 def test_declarative_image():
     """Test making an image plot."""
     data = xr.open_dataset(GiniFile(get_test_data('NHEM-MULTICOMP_1km_IR_20151208_2100.gini')))
@@ -324,6 +325,7 @@ def test_colorfill_no_colorbar(cfeature):
 
 @pytest.mark.mpl_image_compare(remove_text=True, tolerance=1.23)
 @needs_pyproj
+@needs_cartopy
 def test_global():
     """Test that we can set global extent."""
     data = xr.open_dataset(GiniFile(get_test_data('NHEM-MULTICOMP_1km_IR_20151208_2100.gini')))

--- a/tests/plots/test_declarative.py
+++ b/tests/plots/test_declarative.py
@@ -20,7 +20,7 @@ from metpy.io.metar import parse_metar_file
 from metpy.plots import (BarbPlot, ContourPlot, FilledContourPlot, ImagePlot, MapPanel,
                          PanelContainer, PlotObs)
 # Fixtures to make sure we have the right backend
-from metpy.testing import needs_cartopy, set_agg_backend  # noqa: F401, I202
+from metpy.testing import needs_cartopy, needs_pyproj, set_agg_backend  # noqa: F401, I202
 from metpy.units import units
 
 
@@ -28,6 +28,7 @@ MPL_VERSION = matplotlib.__version__[:3]
 
 
 @pytest.mark.mpl_image_compare(remove_text=True, tolerance=0.005)
+@needs_pyproj
 def test_declarative_image():
     """Test making an image plot."""
     data = xr.open_dataset(GiniFile(get_test_data('NHEM-MULTICOMP_1km_IR_20151208_2100.gini')))
@@ -322,6 +323,7 @@ def test_colorfill_no_colorbar(cfeature):
 
 
 @pytest.mark.mpl_image_compare(remove_text=True, tolerance=1.23)
+@needs_pyproj
 def test_global():
     """Test that we can set global extent."""
     data = xr.open_dataset(GiniFile(get_test_data('NHEM-MULTICOMP_1km_IR_20151208_2100.gini')))

--- a/tests/plots/test_mapping.py
+++ b/tests/plots/test_mapping.py
@@ -3,10 +3,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Test the handling of various mapping tasks."""
 
-import cartopy.crs as ccrs
 import pytest
 
-from metpy.plots.mapping import CFProjection
+ccrs = pytest.importorskip('cartopy.crs')
+
+from metpy.plots.mapping import CFProjection  # noqa: E402
 
 
 def test_cfprojection_arg_mapping():

--- a/tests/plots/test_station_plot.py
+++ b/tests/plots/test_station_plot.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Tests for the `station_plot` module."""
 
-import cartopy.crs as ccrs
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
@@ -284,7 +283,7 @@ def wind_plot():
 
 @pytest.mark.mpl_image_compare(tolerance={'2.1': 0.0423}.get(MPL_VERSION, 0.00434),
                                remove_text=True)
-def test_barb_projection(wind_plot):
+def test_barb_projection(wind_plot, ccrs):
     """Test that barbs are properly projected (#598)."""
     u, v, x, y = wind_plot
 
@@ -300,7 +299,7 @@ def test_barb_projection(wind_plot):
 
 @pytest.mark.mpl_image_compare(tolerance={'2.1': 0.0693}.get(MPL_VERSION, 0.00382),
                                remove_text=True)
-def test_arrow_projection(wind_plot):
+def test_arrow_projection(wind_plot, ccrs):
     """Test that arrows are properly projected."""
     u, v, x, y = wind_plot
 

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -16,10 +16,6 @@ from metpy.units import units
 from metpy.xarray import check_axis, check_matching_coordinates, preprocess_xarray
 
 
-# Seed RandomState for deterministic tests
-np.random.seed(81964262)
-
-
 @pytest.fixture
 def test_ds():
     """Provide an xarray dataset for testing."""
@@ -29,7 +25,7 @@ def test_ds():
 @pytest.fixture
 def test_ds_generic():
     """Provide a generic-coordinate dataset for testing."""
-    return xr.DataArray(np.random.random((1, 3, 3, 5, 5)),
+    return xr.DataArray(np.zeros((1, 3, 3, 5, 5)),
                         coords={
                             'a': xr.DataArray(np.arange(1), dims='a'),
                             'b': xr.DataArray(np.arange(3), dims='b'),

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -4,14 +4,13 @@
 """Test the operation of MetPy's XArray accessors."""
 from collections import OrderedDict
 
-import cartopy.crs as ccrs
 import numpy as np
 import pytest
 import xarray as xr
 
 from metpy.plots.mapping import CFProjection
 from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal,
-                           get_test_data)
+                           get_test_data, needs_cartopy)
 from metpy.units import units
 from metpy.xarray import check_axis, check_matching_coordinates, preprocess_xarray
 
@@ -54,7 +53,7 @@ def test_var_multidim_no_xy(test_var_multidim_full):
     return test_var_multidim_full.drop_vars(['y', 'x'])
 
 
-def test_projection(test_var):
+def test_projection(test_var, ccrs):
     """Test getting the proper projection out of the variable."""
     crs = test_var.metpy.crs
     assert crs['grid_mapping_name'] == 'lambert_conformal_conic'
@@ -71,7 +70,7 @@ def test_no_projection(test_ds):
     assert 'not available' in str(exc.value)
 
 
-def test_globe(test_var):
+def test_globe(test_var, ccrs):
     """Test getting the globe belonging to the projection."""
     globe = test_var.metpy.cartopy_globe
 
@@ -81,7 +80,7 @@ def test_globe(test_var):
     assert isinstance(globe, ccrs.Globe)
 
 
-def test_geodetic(test_var):
+def test_geodetic(test_var, ccrs):
     """Test getting the Geodetic CRS for the projection."""
     geodetic = test_var.metpy.cartopy_geodetic
 
@@ -771,7 +770,7 @@ sample_cf_attrs = {
 }
 
 
-def test_assign_crs_dataarray_by_argument(test_ds_generic):
+def test_assign_crs_dataarray_by_argument(test_ds_generic, ccrs):
     """Test assigning CRS to DataArray by projection dict."""
     da = test_ds_generic['test']
     new_da = da.metpy.assign_crs(sample_cf_attrs)
@@ -779,7 +778,7 @@ def test_assign_crs_dataarray_by_argument(test_ds_generic):
     assert new_da['crs'] == CFProjection(sample_cf_attrs)
 
 
-def test_assign_crs_dataarray_by_kwargs(test_ds_generic):
+def test_assign_crs_dataarray_by_kwargs(test_ds_generic, ccrs):
     """Test assigning CRS to DataArray by projection kwargs."""
     da = test_ds_generic['test']
     new_da = da.metpy.assign_crs(**sample_cf_attrs)
@@ -787,14 +786,14 @@ def test_assign_crs_dataarray_by_kwargs(test_ds_generic):
     assert new_da['crs'] == CFProjection(sample_cf_attrs)
 
 
-def test_assign_crs_dataset_by_argument(test_ds_generic):
+def test_assign_crs_dataset_by_argument(test_ds_generic, ccrs):
     """Test assigning CRS to Dataset by projection dict."""
     new_ds = test_ds_generic.metpy.assign_crs(sample_cf_attrs)
     assert isinstance(new_ds['test'].metpy.cartopy_crs, ccrs.LambertConformal)
     assert new_ds['crs'] == CFProjection(sample_cf_attrs)
 
 
-def test_assign_crs_dataset_by_kwargs(test_ds_generic):
+def test_assign_crs_dataset_by_kwargs(test_ds_generic, ccrs):
     """Test assigning CRS to Dataset by projection kwargs."""
     new_ds = test_ds_generic.metpy.assign_crs(**sample_cf_attrs)
     assert isinstance(new_ds['test'].metpy.cartopy_crs, ccrs.LambertConformal)
@@ -879,6 +878,7 @@ def test_coord_helper_da_dummy_yx(test_coord_helper_da_latlon):
     return test_coord_helper_da_latlon.assign_coords(y=range(3), x=range(3))
 
 
+@needs_cartopy
 def test_assign_latitude_longitude_basic_dataarray(test_coord_helper_da_yx,
                                                    test_coord_helper_da_latlon):
     """Test assign_latitude_longitude in basic usage on DataArray."""
@@ -898,6 +898,7 @@ def test_assign_latitude_longitude_error_existing_dataarray(
     assert 'Latitude/longitude coordinate(s) are present' in str(exc)
 
 
+@needs_cartopy
 def test_assign_latitude_longitude_force_existing_dataarray(
         test_coord_helper_da_dummy_latlon, test_coord_helper_da_latlon):
     """Test assign_latitude_longitude with existing coordinates forcing new."""
@@ -909,6 +910,7 @@ def test_assign_latitude_longitude_force_existing_dataarray(
                                          lon.values, 3)
 
 
+@needs_cartopy
 def test_assign_latitude_longitude_basic_dataset(test_coord_helper_da_yx,
                                                  test_coord_helper_da_latlon):
     """Test assign_latitude_longitude in basic usage on Dataset."""
@@ -920,6 +922,7 @@ def test_assign_latitude_longitude_basic_dataset(test_coord_helper_da_yx,
                                          lon.values, 3)
 
 
+@needs_cartopy
 def test_assign_y_x_basic_dataarray(test_coord_helper_da_yx, test_coord_helper_da_latlon):
     """Test assign_y_x in basic usage on DataArray."""
     new_da = test_coord_helper_da_latlon.metpy.assign_y_x()
@@ -936,6 +939,7 @@ def test_assign_y_x_error_existing_dataarray(
     assert 'y/x coordinate(s) are present' in str(exc)
 
 
+@needs_cartopy
 def test_assign_y_x_force_existing_dataarray(
         test_coord_helper_da_dummy_yx, test_coord_helper_da_yx):
     """Test assign_y_x with existing coordinates forcing new."""
@@ -945,6 +949,7 @@ def test_assign_y_x_force_existing_dataarray(
     np.testing.assert_array_almost_equal(test_coord_helper_da_yx['x'].values, x.values, 3)
 
 
+@needs_cartopy
 def test_assign_y_x_dataarray_outside_tolerance(test_coord_helper_da_latlon):
     """Test assign_y_x raises ValueError when tolerance is exceeded on DataArray."""
     with pytest.raises(ValueError) as exc:
@@ -952,6 +957,7 @@ def test_assign_y_x_dataarray_outside_tolerance(test_coord_helper_da_latlon):
     assert 'cannot be collapsed to 1D within tolerance' in str(exc)
 
 
+@needs_cartopy
 def test_assign_y_x_dataarray_transposed(test_coord_helper_da_yx, test_coord_helper_da_latlon):
     """Test assign_y_x on DataArray with transposed order."""
     new_da = test_coord_helper_da_latlon.transpose(transpose_coords=True).metpy.assign_y_x()
@@ -960,6 +966,7 @@ def test_assign_y_x_dataarray_transposed(test_coord_helper_da_yx, test_coord_hel
     np.testing.assert_array_almost_equal(test_coord_helper_da_yx['x'].values, x.values, 3)
 
 
+@needs_cartopy
 def test_assign_y_x_dataset_assumed_order(test_coord_helper_da_yx,
                                           test_coord_helper_da_latlon):
     """Test assign_y_x on Dataset where order must be assumed."""

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -81,6 +81,13 @@ def test_globe(test_var):
     assert isinstance(globe, ccrs.Globe)
 
 
+def test_geodetic(test_var):
+    """Test getting the Geodetic CRS for the projection."""
+    geodetic = test_var.metpy.cartopy_geodetic
+
+    assert isinstance(geodetic, ccrs.Geodetic)
+
+
 def test_unit_array(test_var):
     """Test unit handling through the accessor."""
     arr = test_var.metpy.unit_array


### PR DESCRIPTION
#### Description Of Changes
* Make it possible to run tests without cartopy/pyproj
* Add CI run to check this configuration
* Refactor XArray support to no longer unconditionally import CartoPy

While it's nice to be able to have people run the tests with our so-called minimum dependencies, more importantly this allows us to have a CI configuration that proves to us that this is the case. This is not theoretical, at various points we've accidentally had a top-level import of pyproj (even though it's supposed to be "optional"), and before this PR on master we could not import MetPy without CartoPy installed.

This also makes it clear how much of our functionality relies on "optional" dependencies, which is a discussion for another issue...

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #845
- [x] Closes #1407
- [x] Tests added
- [x] Fully documented