### PR TITLE
Remove uses of pkg_resources

### DIFF
--- a/ci/Current.txt
+++ b/ci/Current.txt
@@ -6,3 +6,4 @@ xarray==0.16.1
 traitlets==4.3.3
 pooch==1.2.0
 pandas==1.1.2
+importlib_metadata==1.7.0

--- a/ci/Current.txt
+++ b/ci/Current.txt
@@ -7,3 +7,4 @@ traitlets==4.3.3
 pooch==1.2.0
 pandas==1.1.2
 importlib_metadata==1.7.0
+importlib_resources==3.0.0

--- a/ci/Minimum
+++ b/ci/Minimum
@@ -6,3 +6,4 @@ xarray==0.14.1
 traitlets==4.3.0
 pooch==0.1
 pandas==0.22.0
+importlib_metadata==1.0.0

--- a/ci/Minimum
+++ b/ci/Minimum
@@ -7,3 +7,4 @@ traitlets==4.3.0
 pooch==0.1
 pandas==0.22.0
 importlib_metadata==1.0.0
+importlib_resources==1.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
 [build-system]
-requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+version_scheme = "post-release"

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ install_requires =
     pooch>=0.1
     traitlets>=4.3.0
     pandas>=0.22.0
+    importlib_metadata>=1.0.0; python_version < '3.8'
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
     traitlets>=4.3.0
     pandas>=0.22.0
     importlib_metadata>=1.0.0; python_version < '3.8'
+    importlib_resources>=1.3.0; python_version < '3.9'
 
 [options.packages.find]
 where = src

--- a/src/metpy/_version.py
+++ b/src/metpy/_version.py
@@ -15,5 +15,12 @@ def get_version():
         return get_version(root='../..', relative_to=__file__,
                            version_scheme='post-release', local_scheme='dirty-tag')
     except (ImportError, LookupError):
-        from pkg_resources import get_distribution
-        return get_distribution(__package__).version
+        try:
+            from importlib.metadata import version, PackageNotFoundError
+        except ImportError:  # Can remove when we require Python > 3.7
+            from importlib_metadata import version, PackageNotFoundError
+
+        try:
+            return version(__package__)
+        except PackageNotFoundError:
+            return 'Unknown'

--- a/src/metpy/_version.py
+++ b/src/metpy/_version.py
@@ -12,7 +12,7 @@ def get_version():
     """
     try:
         from setuptools_scm import get_version
-        return get_version(root='..', relative_to=__file__,
+        return get_version(root='../..', relative_to=__file__,
                            version_scheme='post-release', local_scheme='dirty-tag')
     except (ImportError, LookupError):
         from pkg_resources import get_distribution

--- a/src/metpy/cbook.py
+++ b/src/metpy/cbook.py
@@ -4,6 +4,7 @@
 """Collection of generally useful utility code from the cookbook."""
 
 import os
+from pathlib import Path
 
 import numpy as np
 import pooch
@@ -19,13 +20,11 @@ POOCH = pooch.create(
 # Check if we have the data available directly from a git checkout, either from the
 # TEST_DATA_DIR variable, or looking relative to the path of this module's file. Use this
 # to override Pooch's path.
-dev_data_path = os.environ.get('TEST_DATA_DIR',
-                               os.path.join(os.path.dirname(__file__),
-                                            '..', '..', 'staticdata'))
-if os.path.exists(dev_data_path):
+dev_data_path = os.environ.get('TEST_DATA_DIR', Path(__file__).parents[2] / 'staticdata')
+if Path(dev_data_path).exists():
     POOCH.path = dev_data_path
 
-POOCH.load_registry(os.path.join(os.path.dirname(__file__), 'static-data-manifest.txt'))
+POOCH.load_registry(Path(__file__).parent / 'static-data-manifest.txt')
 
 
 def get_test_data(fname, as_file_obj=True, mode='rb'):

--- a/src/metpy/plots/_util.py
+++ b/src/metpy/plots/_util.py
@@ -4,13 +4,11 @@
 """Utilities for use in making plots."""
 
 from datetime import datetime
-import posixpath
 
 from matplotlib.collections import LineCollection
 import matplotlib.patheffects as mpatheffects
 from matplotlib.pyplot import imread
 import numpy as np
-import pkg_resources
 
 from ..units import concatenate
 
@@ -86,17 +84,22 @@ def _add_logo(fig, x=10, y=25, zorder=100, which='metpy', size='small', **kwargs
        The `matplotlib.image.FigureImage` instance created
 
     """
+    try:
+        from importlib.resources import files as importlib_resources_files
+    except ImportError:  # Can remove when we require Python > 3.8
+        from importlib_resources import files as importlib_resources_files
+
     fname_suffix = {'small': '_75x75.png',
                     'large': '_150x150.png'}
     fname_prefix = {'unidata': 'unidata',
                     'metpy': 'metpy'}
     try:
         fname = fname_prefix[which] + fname_suffix[size]
-        fpath = posixpath.join('_static', fname)
     except KeyError:
         raise ValueError('Unknown logo size or selection')
 
-    logo = imread(pkg_resources.resource_stream('metpy.plots', fpath))
+    with (importlib_resources_files('metpy.plots') / '_static' / fname).open('rb') as fobj:
+        logo = imread(fobj)
     return fig.figimage(logo, x, y, zorder=zorder, **kwargs)
 
 

--- a/src/metpy/plots/_util.py
+++ b/src/metpy/plots/_util.py
@@ -96,7 +96,7 @@ def _add_logo(fig, x=10, y=25, zorder=100, which='metpy', size='small', **kwargs
     try:
         fname = fname_prefix[which] + fname_suffix[size]
     except KeyError:
-        raise ValueError('Unknown logo size or selection')
+        raise ValueError('Unknown logo size or selection') from None
 
     with (importlib_resources_files('metpy.plots') / '_static' / fname).open('rb') as fobj:
         logo = imread(fobj)

--- a/src/metpy/plots/ctables.py
+++ b/src/metpy/plots/ctables.py
@@ -91,8 +91,8 @@ def read_colortable(fobj):
             if literal:
                 ret.append(mcolors.colorConverter.to_rgb(literal))
         return ret
-    except (SyntaxError, ValueError):
-        raise RuntimeError(f'Malformed colortable (bad line: {line})')
+    except (SyntaxError, ValueError) as e:
+        raise RuntimeError(f'Malformed colortable (bad line: {line})') from e
 
 
 def convert_gempak_table(infile, outfile):

--- a/src/metpy/plots/mapping.py
+++ b/src/metpy/plots/mapping.py
@@ -73,7 +73,7 @@ class CFProjection:
         try:
             proj_handler = self.projection_registry[proj_name]
         except KeyError:
-            raise ValueError(f'Unhandled projection: {proj_name}')
+            raise ValueError(f'Unhandled projection: {proj_name}') from None
 
         return proj_handler(self._attrs, globe)
 

--- a/src/metpy/plots/skewt.py
+++ b/src/metpy/plots/skewt.py
@@ -654,7 +654,7 @@ class SkewT:
             fill_args = fill_properties[which]
             fill_args.update(kwargs)
         except KeyError:
-            raise ValueError(f'Unknown option for which: {which}')
+            raise ValueError(f'Unknown option for which: {which}') from None
 
         arrs = y, x1, x2
 

--- a/src/metpy/plots/wx_symbols.py
+++ b/src/metpy/plots/wx_symbols.py
@@ -6,17 +6,25 @@
 See WMO manual 485 Vol 1 for more info on the symbols.
 """
 
+try:
+    from importlib.resources import (files as importlib_resources_files,
+                                     as_file as importlib_resources_as_file)
+except ImportError:  # Can remove when we require Python > 3.8
+    from importlib_resources import (files as importlib_resources_files,
+                                     as_file as importlib_resources_as_file)
+
 import matplotlib.font_manager as fm
 import numpy as np
-from pkg_resources import resource_filename
 
 from ..package_tools import Exporter
 
 exporter = Exporter(globals())
 
 # Create a matplotlib font object pointing to our weather symbol font
-wx_symbol_font = fm.FontProperties(fname=resource_filename('metpy.plots',
-                                                           'fonts/wx_symbols.ttf'))
+fontfile = importlib_resources_files('metpy.plots') / 'fonts/wx_symbols.ttf'
+with importlib_resources_as_file(fontfile) as fname:
+    # Need to pass str, not Path, for older matplotlib
+    wx_symbol_font = fm.FontProperties(fname=str(fname))
 
 
 @exporter.export

--- a/src/metpy/testing.py
+++ b/src/metpy/testing.py
@@ -150,7 +150,7 @@ def check_and_drop_units(actual, desired):
                 actual = actual.to('dimensionless')
     except DimensionalityError:
         raise AssertionError('Units are not compatible: {} should be {}'.format(
-            actual.units, getattr(desired, 'units', 'dimensionless')))
+            actual.units, getattr(desired, 'units', 'dimensionless'))) from None
 
     if hasattr(actual, 'magnitude'):
         actual = actual.magnitude

--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -86,7 +86,7 @@ def pandas_dataframe_to_unit_arrays(df, column_units=None):
             column_units = df.units
         except AttributeError:
             raise ValueError('No units attribute attached to pandas '
-                             'dataframe and col_units not given.')
+                             'dataframe and col_units not given.') from None
 
     # Iterate through columns attaching units if we have them, if not, don't touch it
     res = {}


### PR DESCRIPTION
#### Description Of Changes

Overall goal is to remove the uses of `pkg_resources` since this requires `setuptools` at runtime. This can have performance consequences and there are now better ways to achieve the same functionality coming to the standard library.

* Update `pyproject.toml` to allow using `setuptools_scm` without a `setup.py`; we can still use `setuptools` but this gets us closer (#1321)
* Fix setting path to static data for registry on development
* Use `importlib.metadata` instead of `pkg_resources` to get version on installed copies; this has a backported version `importlib_metadata` that we need on Python < 3.8.
* Use `importlib.resources` instead of `pkg_resources` to get files (e.g. fonts, images, colortables); this has a backported version `importlib_resources` that we need on Python < 3.9
* Use `pathlib` in the registry setup code (cleans things up a bit)
* Clean up exception handling by improving or disabling exception chaining as appropriate

Both backported versions are already required by Pint so we're not really requiring anything that doesn't already need to be installed (transitively) when installing MetPy.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1201 
- [x] Closes #1321 
- [x] Closes #1442 
