### PR TITLE
BUG: Fix passing masked arrays to CAPE/CIN calcs

### DIFF
--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -837,7 +837,7 @@ def _insert_lcl_level(pressure, temperature, lcl_pressure):
     # Pressure needs to be increasing for searchsorted, so flip it and then convert
     # the index back to the original array
     loc = pressure.size - pressure[::-1].searchsorted(lcl_pressure)
-    return np.insert(temperature.m, loc, interp_temp.m) * temperature.units
+    return temperature.units * np.insert(temperature.m, loc, interp_temp.m)
 
 
 @exporter.export
@@ -1720,7 +1720,7 @@ def _find_append_zero_crossings(x, y):
         y values of data
 
     """
-    crossings = find_intersections(x[1:], y[1:], np.zeros_like(y[1:]) * y.units, log_x=True)
+    crossings = find_intersections(x[1:], y[1:], y.units * np.zeros_like(y[1:]), log_x=True)
     x = concatenate((x, crossings[0]))
     y = concatenate((y, crossings[1]))
 

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -37,7 +37,7 @@ from metpy.calc import (brunt_vaisala_frequency, brunt_vaisala_frequency_squared
                         wet_bulb_temperature)
 from metpy.calc.thermo import _find_append_zero_crossings
 from metpy.testing import assert_almost_equal, assert_array_almost_equal, assert_nan
-from metpy.units import units
+from metpy.units import masked_array, units
 
 
 def test_relative_humidity_from_dewpoint():
@@ -1159,11 +1159,12 @@ def test_isentropic_interpolation_as_dataset():
     assert result['isentropic_level'].attrs == expected['isentropic_level'].attrs
 
 
-def test_surface_based_cape_cin():
+@pytest.mark.parametrize('array_class', (units.Quantity, masked_array))
+def test_surface_based_cape_cin(array_class):
     """Test the surface-based CAPE and CIN calculation."""
-    p = np.array([959., 779.2, 751.3, 724.3, 700., 269.]) * units.mbar
-    temperature = np.array([22.2, 14.6, 12., 9.4, 7., -38.]) * units.celsius
-    dewpoint = np.array([19., -11.2, -10.8, -10.4, -10., -53.2]) * units.celsius
+    p = array_class([959., 779.2, 751.3, 724.3, 700., 269.], units.mbar)
+    temperature = array_class([22.2, 14.6, 12., 9.4, 7., -38.], units.celsius)
+    dewpoint = array_class([19., -11.2, -10.8, -10.4, -10., -53.2], units.celsius)
     cape, cin = surface_based_cape_cin(p, temperature, dewpoint)
     assert_almost_equal(cape, 75.7340825 * units('joule / kilogram'), 2)
     assert_almost_equal(cin, -136.607809 * units('joule / kilogram'), 2)


### PR DESCRIPTION
#### Description Of Changes
This is to explicitly fix passing masked arrays to surface_based_cape_cin, but really fixes some low-level helper functions, so this likely fixes all of the CAPE/CIN calculations.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Fixes #1496
- [x] Tests added
- [x] Fully documented