### PR TITLE
Fix test coverage reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,3 @@
-codecov:
-  notify:
-    require_ci_to_pass: no
-
 coverage:
   status:
     patch:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[paths]
+source =
+    src/
+    /*/site-packages
+
+[run]
+source = tests
+source_pkgs = metpy
+omit =
+    src/metpy/io/_nexrad_msgs/parse_spec.py

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -109,3 +109,5 @@ jobs:
 
     - name: Upload coverage
       uses: codecov/codecov-action@v1
+      with:
+        name: conda-${{ matrix.python-version }}-${{ runner.os }}

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -85,9 +85,13 @@ jobs:
         python -m pip install --no-deps .
 
     - name: Run tests
+      # By running coverage in "parallel" mode and "combining", we can clean up the path names
       run: |
         export TEST_DATA_DIR=$GITHUB_WORKSPACE/staticdata
-        python -m pytest --mpl -W error::metpy.deprecation.MetpyDeprecationWarning --cov=metpy --cov=tests --cov-report=xml
+        python -m coverage run -p -m pytest --mpl -W error::metpy.deprecation.MetpyDeprecationWarning tests/
+        python -m coverage combine
+        python -m coverage report
+        python -m coverage xml
 
     - name: Run doctests
       # Windows produces some slightly different types that causes doctests to fail

--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -107,7 +107,10 @@ jobs:
       run: |
         export TEST_DATA_DIR=$GITHUB_WORKSPACE/staticdata
         export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
-        python -m pytest --mpl -W error::metpy.deprecation.MetpyDeprecationWarning --cov=metpy --cov=tests --cov-report=xml
+        python -m coverage run -p -m pytest --mpl -W error::metpy.deprecation.MetpyDeprecationWarning tests/
+        python -m coverage combine
+        python -m coverage report
+        python -m coverage xml
 
     - name: Run doctests
       if: ${{ matrix.dep-versions == 'Current.txt' && matrix.no-extras != 'No Extras' }}

--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -127,3 +127,5 @@ jobs:
 
     - name: Upload coverage
       uses: codecov/codecov-action@v1
+      with:
+        name: pypi-${{ matrix.python-version }}-${{ matrix.dep-versions }}-${{ matrix.no-extras }}-${{ runner.os }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,10 @@ script:
         false;
       fi;
     else
-      python -m pytest --mpl -W error::metpy.deprecation.MetpyDeprecationWarning --cov=metpy --cov=tests;
+      python -m coverage run -p -m pytest --mpl -W error::metpy.deprecation.MetpyDeprecationWarning tests/;
+      python -m coverage combine;
+      python -m coverage report;
+      python -m coverage xml;
     fi
 
 after_script:

--- a/ci/test_requirements.txt
+++ b/ci/test_requirements.txt
@@ -1,4 +1,4 @@
 pytest==6.1.0
-pytest-cov==2.10.1
 pytest-mpl==0.11
 netCDF4==1.5.4
+coverage==5.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,9 +96,6 @@ norecursedirs = build docs .idea
 doctest_optionflags = NORMALIZE_WHITESPACE
 mpl-results-path = test_output
 
-[coverage:run]
-omit = src/metpy/io/_nexrad_msgs/parse_spec.py,src/metpy/io/metar_parser.py
-
 [doc8]
 ignore-path = docs/build,docs/api/generated,docs/_templates,docs/tutorials,docs/examples
 file-encoding = utf8

--- a/src/metpy/io/gini.py
+++ b/src/metpy/io/gini.py
@@ -14,10 +14,7 @@ import re
 import numpy as np
 from xarray import Variable
 from xarray.backends.common import AbstractDataStore
-try:
-    from xarray.core.utils import FrozenDict
-except ImportError:
-    from xarray.core.utils import FrozenOrderedDict as FrozenDict
+from xarray.core.utils import FrozenDict
 
 from ._tools import Bits, IOBuffer, NamedStruct, open_as_needed, zlib_decompress_all_frames
 from ..package_tools import Exporter
@@ -405,11 +402,3 @@ class GiniFile(AbstractDataStore):
         """
         return FrozenDict(satellite=self.prod_desc.creating_entity,
                           sector=self.prod_desc.sector_id)
-
-    def get_dimensions(self):
-        """Get the file's dimensions.
-
-        This is used by `xarray.open_dataset`.
-
-        """
-        return FrozenDict(x=self.prod_desc.nx, y=self.prod_desc.ny)


### PR DESCRIPTION
#### Description Of Changes

This fixes some issues in our test coverage reporting. In recent versions of pytest, it seems the warning filter is initialized early on. This is a problem for us because that ends up importing `metpy.deprecation` before pytest-cov has a chance to set up coverage. Thus, currently, `metpy`, `metpy._version`, `metpy.xarray`, `metpy.units`, and `metpy.deprecation` aren't included in the coverage--at least any code that executes at import time. 😭 This was *really* annoying to figure out. 

Fix this by running coverage manually. As a result, we no longer need to install pytest-cov for CI--it's still fine to use locally (so long as you're not running a warning filter on the `MetpyDeprecationWarning`).

* Tweak our GitHub Actions workflows to upload coverage reports with an appropriate name to aid debugging. 
* Fix up some places we lost coverage, as noted in #1318 .

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1318 