### PR TITLE
Fixing handling of level in PlotObs

### DIFF
--- a/src/metpy/plots/declarative.py
+++ b/src/metpy/plots/declarative.py
@@ -1463,7 +1463,8 @@ class PlotObs(HasTraits):
 
             # Subset for a particular level if given
             if self.level is not None:
-                data = data[data.pressure == self.level.m]
+                mag = getattr(self.level, 'magnitude', self.level)
+                data = data[data.pressure == mag]
 
             # Subset for our particular time
             if self.time is not None:

--- a/src/metpy/plots/declarative.py
+++ b/src/metpy/plots/declarative.py
@@ -1317,7 +1317,7 @@ class PlotObs(HasTraits):
     parent = Instance(Panel)
     _need_redraw = Bool(default_value=True)
 
-    level = Union([Int(allow_none=True), Instance(units.Quantity)])
+    level = Union([Int(allow_none=True), Instance(units.Quantity)], default_value=None)
     level.__doc__ = """The level of the field to be plotted.
 
     This is a value with units to choose the desired plot level. For example, selecting the

--- a/tests/plots/test_declarative.py
+++ b/tests/plots/test_declarative.py
@@ -553,7 +553,6 @@ def test_plotobs_subset_default_nolevel(sample_obs):
     """Test PlotObs subsetting with minimal config."""
     obs = PlotObs()
     obs.data = sample_obs
-    obs.level = None
 
     truth = pd.DataFrame([('2020-08-06 13:00', 'KDEN', 500, 7, 15),
                           ('2020-08-06 12:59', 'KOKC', 500, 8, 16)],

--- a/tests/plots/test_declarative.py
+++ b/tests/plots/test_declarative.py
@@ -575,7 +575,7 @@ def test_plotobs_subset_level(sample_obs):
 
 
 def test_plotobs_subset_level_no_units(sample_obs):
-    """Test PlotObs subsetting based on level."""
+    """Test PlotObs subsetting based on unitless level."""
     obs = PlotObs()
     obs.data = sample_obs
     obs.level = 1000

--- a/tests/plots/test_declarative.py
+++ b/tests/plots/test_declarative.py
@@ -574,6 +574,19 @@ def test_plotobs_subset_level(sample_obs):
     pd.testing.assert_frame_equal(obs.obsdata, truth)
 
 
+def test_plotobs_subset_level_no_units(sample_obs):
+    """Test PlotObs subsetting based on level."""
+    obs = PlotObs()
+    obs.data = sample_obs
+    obs.level = 1000
+
+    truth = pd.DataFrame([('2020-08-06 13:00', 'KDEN', 1000, 5, 13),
+                          ('2020-08-06 12:59', 'KOKC', 1000, 6, 14)],
+                         columns=['time', 'stid', 'pressure', 'temperature', 'dewpoint'],
+                         index=[4, 5])
+    pd.testing.assert_frame_equal(obs.obsdata, truth)
+
+
 def test_plotobs_subset_time(sample_obs):
     """Test PlotObs subsetting for a particular time."""
     obs = PlotObs()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes

Fixes some issues with the level trait in `PlotObs`, as noted in #1474:
* Make `None` the default
* Allow passing in level values that do not have units

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1474 
- [x] Tests added
- [x] Fully documented