### PR TITLE
Update copyright year to include 2020

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2008-2019, MetPy Developers
+Copyright (c) 2008-2020, MetPy Developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,8 @@ master_doc = 'index'
 # General information about the project.
 project = 'MetPy'
 # noinspection PyShadowingBuiltins
-copyright = ('2019, MetPy Developers. Development supported by National Science Foundation grants '
+copyright = ('2019-2020, MetPy Developers. '
+             'Development supported by National Science Foundation grants '
              'AGS-1344155, OAC-1740315, and AGS-1901712.')
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,7 @@ master_doc = 'index'
 # General information about the project.
 project = 'MetPy'
 # noinspection PyShadowingBuiltins
-copyright = ('2019-2020, MetPy Developers. '
+copyright = ('2008-2020, MetPy Developers. '
              'Development supported by National Science Foundation grants '
              'AGS-1344155, OAC-1740315, and AGS-1901712.')
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes

I noticed reading through the documentation (trying to figure out #1445) that the copyright only includes 2019, but there's been code written this year, so I've updated the copyright statement.

Let me know if there's some reason this shouldn't be done.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [ n/a ] Closes #xxxx -- *Do you want me to create a ticket?*
- [ n/a ] Tests added
- [ n/a ] Fully documented

## Further Notes

It would be simple to parametrically update this to the current year the docs are generated (perks of sphinx being configured with a Python file!). Let me know if you would rather than approach.