### PR TITLE
CI: Remove Windows+conda scipy dependency adjustment

### DIFF
--- a/.github/workflows/docs-conda.yml
+++ b/.github/workflows/docs-conda.yml
@@ -55,10 +55,6 @@ jobs:
         # Needed for caching
         use-only-tar-bz2: true
 
-    - name: Adjust dependencies for Windows
-      if: ${{ runner.os == 'Windows' }}
-      run: sed -e "s/scipy==.*/scipy==1.5.0/" -i'' ci/Current.txt
-
     - name: Install dependencies
       run: conda install --quiet --yes --file ci/doc_requirements.txt --file ci/extra_requirements.txt --file ci/Current.txt
 

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -54,10 +54,6 @@ jobs:
         # Needed for caching
         use-only-tar-bz2: true
 
-    - name: Adjust dependencies for Windows
-      if: ${{ runner.os == 'Windows' }}
-      run: sed -e "s/scipy==.*/scipy==1.5.0/" -i'' ci/Current.txt
-
     - name: Install dependencies
       run: conda install --quiet --yes --file ci/test_requirements.txt --file ci/extra_requirements.txt --file ci/Current.txt
 


### PR DESCRIPTION
Our `scipy==1.5.0` specification for conda tests and docs workflows on Windows is no longer necessary, and retaining it alongside strict channel priority causes conda to fail to solve the environment (reproducible locally.)