### PR TITLE
Python 3.9 support

### DIFF
--- a/.github/workflows/docs-conda.yml
+++ b/.github/workflows/docs-conda.yml
@@ -55,6 +55,11 @@ jobs:
         # Needed for caching
         use-only-tar-bz2: true
 
+    # TODO: Remove this when we drop Python 3.6
+    - name: Adjust traitlets dependency for Python 3.6
+      if: ${{ matrix.python-version == 3.6 }}
+      run: sed -e "s/traitlets==.*/traitlets==4.3.3/" -i.bak ci/Current.txt
+
     - name: Install dependencies
       run: conda install --quiet --yes --file ci/doc_requirements.txt --file ci/extra_requirements.txt --file ci/Current.txt
 

--- a/.github/workflows/docs-conda.yml
+++ b/.github/workflows/docs-conda.yml
@@ -45,7 +45,7 @@ jobs:
           conda-docs-
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: goanpeca/setup-miniconda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         miniconda-version: "latest"
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/docs-conda.yml
+++ b/.github/workflows/docs-conda.yml
@@ -60,6 +60,10 @@ jobs:
       if: ${{ matrix.python-version == 3.6 }}
       run: sed -e "s/traitlets==.*/traitlets==4.3.3/" -i.bak ci/Current.txt
 
+    # TODO: Remove this when scipy>1.5.3 is available on conda-forge
+    - name: Adjust scipy dependency for Conda
+      run: sed -e "s/scipy==.*/scipy==1.5.3/" -i.bak ci/Current.txt
+
     - name: Install dependencies
       run: conda install --quiet --yes --file ci/doc_requirements.txt --file ci/extra_requirements.txt --file ci/Current.txt
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
   #
   Docs:
     name: ${{ matrix.python-version }} ${{ matrix.dep-versions }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     continue-on-error: ${{ matrix.experimental }}
     env:
       DOC_VERSION: dev
@@ -76,7 +76,7 @@ jobs:
     - name: Install dependencies (PyPI)
       if: ${{ runner.os == 'Linux' }}
       run: |
-        sudo apt-get install libgeos-dev libproj-dev
+        sudo apt-get install libgeos-dev libproj-dev proj-bin
         python -m pip install --upgrade pip setuptools
         python -m pip install --no-binary :all: shapely
         python -m pip install -c ci/${{ matrix.dep-versions }} numpy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,11 +25,16 @@ jobs:
       matrix:
         include:
           - python-version: 3.8
+            check-links: false
+            dep-versions: Current.txt
+            git-versions: ''
+            experimental: false
+          - python-version: 3.9
             check-links: true
             dep-versions: Current.txt
             git-versions: ''
             experimental: false
-          - python-version: 3.8
+          - python-version: 3.9
             check-links: false
             dep-versions: Prerelease
             git-versions: 'git+git://github.com/hgrecco/pint@master#egg=pint git+git://github.com/pydata/xarray@master#egg=xarray'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.x
 
     - name: Install build tools
       run: |

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -44,7 +44,7 @@ jobs:
           conda-tests-
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: goanpeca/setup-miniconda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         miniconda-version: "latest"
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -54,6 +54,10 @@ jobs:
         # Needed for caching
         use-only-tar-bz2: true
 
+    # TODO: Remove this when scipy>1.5.3 is available on conda-forge
+    - name: Adjust scipy dependency for Conda
+      run: sed -e "s/scipy==.*/scipy==1.5.3/" -i.bak ci/Current.txt
+
     - name: Install dependencies
       run: conda install --quiet --yes --file ci/test_requirements.txt --file ci/extra_requirements.txt --file ci/Current.txt
 

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         os: [macOS, Windows]
 
     steps:

--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -13,7 +13,7 @@ jobs:
   #
   PyPITests:
     name: ${{ matrix.python-version }} ${{ matrix.dep-versions }} ${{ matrix.no-extras }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     continue-on-error: ${{ matrix.dep-versions == 'Prerelease' }}
     strategy:
       fail-fast: false
@@ -77,7 +77,7 @@ jobs:
     # Need to install numpy first to make CartoPy happy.
     - name: Install dependencies
       run: |
-        sudo apt-get install libgeos-dev libproj-dev
+        sudo apt-get install libgeos-dev libproj-dev proj-bin
         python -m pip install --upgrade pip setuptools
         python -m pip install --no-binary :all: shapely
         python -m pip install -c ci/${{ matrix.dep-versions }} numpy

--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -18,17 +18,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         dep-versions: [Current.txt]
         no-extras: ['']
         include:
           - python-version: 3.6
             dep-versions: Minimum
             no-extras: ''
-          - python-version: 3.8
+          - python-version: 3.9
             dep-versions: Current.txt
             no-extras: 'No Extras'
-          - python-version: 3.8
+          - python-version: 3.9
             dep-versions: Prerelease
             no-extras: ''
 

--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -63,6 +63,11 @@ jobs:
           pip-tests-${{ runner.os }}-
           pip-tests-
 
+    # TODO: Remove this when we drop Python 3.6
+    - name: Adjust traitlets dependency for Python 3.6
+      if: ${{ matrix.python-version == 3.6 }}
+      run: sed -e "s/traitlets==.*/traitlets==4.3.3/" -i.bak ci/Current.txt
+
     - name: Add extras to requirements
       if: ${{ matrix.no-extras != 'No Extras' }}
       run: cat ci/extra_requirements.txt >> ci/test_requirements.txt

--- a/ci/Current.txt
+++ b/ci/Current.txt
@@ -6,6 +6,6 @@ pandas==1.1.4
 pooch==1.2.0
 pint==0.16.1
 pyproj==2.6.1.post1
-scipy==1.5.2
+scipy==1.5.4
 traitlets==5.0.5
 xarray==0.16.1

--- a/ci/Current.txt
+++ b/ci/Current.txt
@@ -7,5 +7,5 @@ pooch==1.2.0
 pint==0.16.1
 pyproj==2.6.1.post1
 scipy==1.5.2
-traitlets==4.3.3
+traitlets==5.0.5
 xarray==0.16.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Atmospheric Science
     Intended Audience :: Science/Research

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,8 +57,8 @@ where = src
 
 [options.extras_require]
 doc = sphinx; sphinx-gallery>=0.4; myst-parser; netCDF4
-examples = cartopy>=0.15.0; matplotlib>=2.2.0; pyproj>=1.9.4,!=2.0.0
-test = pytest>=2.4; pytest-mpl; cartopy>=0.16.0; netCDF4; pyproj>=1.9.4,!=2.0.0
+examples = cartopy>=0.15.0; matplotlib>=2.2.0
+test = pytest>=2.4; pytest-mpl; cartopy>=0.16.0; netCDF4
 
 [build_sphinx]
 source-dir = docs/source

--- a/src/metpy/plots/skewt.py
+++ b/src/metpy/plots/skewt.py
@@ -705,7 +705,7 @@ class SkewT:
         r"""Shade areas of Convective INhibition (CIN).
 
         Shades areas where the parcel is cooler than the environment (areas of negative
-        buoyancy. If `dewpoint` is passed in, negative area below the lifting condensation
+        buoyancy). If `dewpoint` is passed in, negative area below the lifting condensation
         level or above the equilibrium level is not shaded.
 
         Parameters


### PR DESCRIPTION
#### Description Of Changes
Formalize support for Python 3.9. Local testing suggests that we already work.
* Add 3.9 to testing matrix
* Add 3.9 to versions in `setup.cfg`
* A bit of cleanup (things I had hanging around)
* Fix GitHub Actions problems with `setup-miniconda` due to its use of removed functionality. Turns out that action we're using has a new canonical home, and a new version that already fixes it for us.
* Fix building PyProj (since there are not 2.6.1 wheels for Python 3.9) by bumping to Ubuntu 20.04 (which is a "preview" image 😬 ) and installing `proj-bin`
* Go ahead and bump ci traitlets to 5.0.5 (as in #1538). This is the only sane thing we can do to get the packages for conda-forge; just add a hack for Python 3.6 that goes away when we drop it
* Also bump scipy on ci to 1.5.4 (as in #1562). This allows us to get Python 3.9 wheels from PyPI rather than build scipy on Linux--but it means that since 1.5.3 is the latest in conda-forge right now (because of course some random test failures occurred when 1.5.4 appeared) we need some more hacks.

I'm not happy about all the version hacks we have in the workflow files, but I don't really know a better way to deal with it. Dependabot does *not* like files with different versions (which makes sense).

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Tests added
