### PR TITLE
Fix xarray support in advection

### DIFF
--- a/src/metpy/calc/kinematics.py
+++ b/src/metpy/calc/kinematics.py
@@ -235,6 +235,7 @@ def total_deformation(u, v, dx=None, dy=None, x_dim=-1, y_dim=-2):
 
 
 @exporter.export
+@add_grid_arguments_from_xarray
 @preprocess_and_wrap(wrap_like='scalar', broadcast=('scalar', 'u', 'v', 'w'))
 def advection(
     scalar,

--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -1390,7 +1390,7 @@ def add_grid_arguments_from_xarray(func):
             try:
                 vertical_coord = grid_prototype.metpy.vertical
                 bound_args.arguments['dz'] = np.diff(vertical_coord.metpy.unit_array)
-            except AttributeError:
+            except (AttributeError, ValueError):
                 # Skip, since this only comes up in advection, where dz is optional (may not
                 # need vertical at all)
                 pass


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
Fixes passing just `DataArray` instances to `advection`. 

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1548
- [x] Tests added
- [x] Fully documented