### PR TITLE
Make CartoPy import more robust

### DIFF
--- a/src/metpy/plots/cartopy_utils.py
+++ b/src/metpy/plots/cartopy_utils.py
@@ -4,11 +4,11 @@
 """Cartopy specific mapping utilities."""
 
 try:
-    import cartopy.feature as cfeature
+    from cartopy.feature import Feature, Scaler
 
     from ..cbook import get_test_data
 
-    class MetPyMapFeature(cfeature.Feature):
+    class MetPyMapFeature(Feature):
         """A simple interface to MetPy-included shapefiles."""
 
         def __init__(self, name, scale, **kwargs):
@@ -18,7 +18,7 @@ try:
             self.name = name
 
             if isinstance(scale, str):
-                scale = cfeature.Scaler(scale)
+                scale = Scaler(scale)
             self.scaler = scale
 
         def geometries(self):


### PR DESCRIPTION
#### Description Of Changes
Instead of just importing `cartopy.feature`, explicitly import the two names we need. The result is that on older Cartopy, where `Scaler` is unavailable, we fail cleanly (and not interrupting users) as if CartoPy is not installed rather than failing hard when creating our map features--which allows users with old CartoPy to still use e.g. SkewT.

No tests because there's no obvious way to do so.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1550
- [ ] Tests added
- [ ] Fully documented