### PR TITLE
BUG: Fix for xarray master

### DIFF
--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -922,7 +922,7 @@ class MetPyDatasetAccessor:
         # Apply across all variables and coordinates
         return (
             self._dataset
-            .map(mapping_func, keep_attrs=True)
+            .map(mapping_func)
             .assign_coords({
                 coord_name: mapping_func(coord_var)
                 for coord_name, coord_var in self._dataset.coords.items()
@@ -931,11 +931,11 @@ class MetPyDatasetAccessor:
 
     def quantify(self):
         """Return new dataset with all numeric variables quantified and cached data loaded."""
-        return self._dataset.map(lambda da: da.metpy.quantify(), keep_attrs=True)
+        return self._dataset.map(lambda da: da.metpy.quantify())
 
     def dequantify(self):
         """Return new dataset with variables cast to magnitude and units on attribute."""
-        return self._dataset.map(lambda da: da.metpy.dequantify(), keep_attrs=True)
+        return self._dataset.map(lambda da: da.metpy.dequantify())
 
 
 def _assign_axis(attributes, axis):

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -169,11 +169,13 @@ def test_quantify(test_ds_generic):
 
 def test_dequantify():
     """Test dequantify method for converting data away from Quantity."""
-    original = xr.DataArray(units.Quantity([280, 290, 300], 'K'))
+    original = xr.DataArray(units.Quantity([280, 290, 300], 'K'),
+                            attrs={'standard_name': 'air_temperature'})
     result = original.metpy.dequantify()
     assert isinstance(result.data, np.ndarray)
     assert result.attrs['units'] == 'kelvin'
     np.testing.assert_array_almost_equal(result.data, original.data.magnitude)
+    assert result.attrs['standard_name'] == 'air_temperature'
 
 
 def test_dataset_quantify(test_ds_generic):
@@ -1026,6 +1028,8 @@ def test_update_attribute_dictionary(test_ds_generic):
         'test': 'Filler data',
         'c': 'The third coordinate'
     }
+    test_ds_generic.c.attrs['units'] = 'K'
+    test_ds_generic.a.attrs['standard_name'] = 'air_temperature'
     result = test_ds_generic.metpy.update_attribute('description', descriptions)
 
     # Test attribute updates
@@ -1035,6 +1039,10 @@ def test_update_attribute_dictionary(test_ds_generic):
     assert 'description' not in result['d'].attrs
     assert 'description' not in result['e'].attrs
     assert result['test'].attrs['description'] == 'Filler data'
+
+    # Test that other attributes remain
+    assert result['c'].attrs['units'] == 'K'
+    assert result['a'].attrs['standard_name'] == 'air_temperature'
 
     # Test for no side effects
     assert 'description' not in test_ds_generic['c'].attrs


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
Passing keep_attrs=True to Dataset.map on xarray master is causing us to
lose needed attribute updates. Not passing it causes the tests to pass
on master and seems to work with the last release as well.

Tests added to validate other attributes are preserved.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Tests added
- [ ] Fully documented