### PR TITLE
Fixes and improvements for wet_bulb_temperature

### DIFF
--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -141,6 +141,18 @@ def test_moist_lapse_ref_pres():
     assert_array_almost_equal(temp, true_temp, 2)
 
 
+def test_moist_lapse_scalar():
+    """Test moist_lapse when given a scalar desired pressure and a reference pressure."""
+    temp = moist_lapse(np.array([800.]) * units.mbar, 19.85 * units.degC, 1000. * units.mbar)
+    assert_almost_equal(temp, 284.64 * units.kelvin, 2)
+
+
+def test_moist_lapse_uniform():
+    """Test moist_lapse when given a uniform array of pressures."""
+    temp = moist_lapse(np.array([900., 900., 900.]) * units.hPa, 20. * units.degC)
+    assert_almost_equal(temp, np.array([20., 20., 20.]) * units.degC, 7)
+
+
 def test_parcel_profile():
     """Test parcel profile calculation."""
     levels = np.array([1000., 900., 800., 700., 600., 500., 400.]) * units.mbar
@@ -1401,6 +1413,12 @@ def test_wet_bulb_temperature():
     val = wet_bulb_temperature(1000 * units.hPa, 25 * units.degC, 15 * units.degC)
     truth = 18.34345936 * units.degC  # 18.59 from NWS calculator
     assert_almost_equal(val, truth, 5)
+
+
+def test_wet_bulb_temperature_saturated():
+    """Test wet bulb calculation works properly with saturated conditions."""
+    val = wet_bulb_temperature(850. * units.hPa, 17.6 * units.degC, 17.6 * units.degC)
+    assert_almost_equal(val, 17.6 * units.degC, 7)
 
 
 def test_wet_bulb_temperature_1d():


### PR DESCRIPTION
#### Description Of Changes

This fixes `wet_bulb_temperature` to no longer error out on saturated conditions. This was caused by some corner cases in moist_lapse (not handling inputs of uniform pressures due to strict > and < checks). The best fix is to use the fact that `moist_lapse` (now) supports passing in explicitly the starting pressure, separate from the desired pressure(s). Also fix `moist_lapse` to work with all scalars.

While here, refactor `wet_bulb_temperature` for performance. Use the fact that `lcl` works on grids to pull that calculation out of the loop. Improves performance by ~10% for a profile with 120 levels.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Closes #1332
- [x] Tests added
- [x] Fully documented