### PR TITLE
Fix get_layer for float32 data again

### DIFF
--- a/src/metpy/calc/indices.py
+++ b/src/metpy/calc/indices.py
@@ -61,10 +61,10 @@ def precipitable_water(pressure, dewpoint, *, bottom=None, top=None):
     pressure, dewpoint = _remove_nans(pressure, dewpoint)
 
     if top is None:
-        top = np.nanmin(pressure.magnitude) * pressure.units
+        top = np.nanmin(pressure)
 
     if bottom is None:
-        bottom = np.nanmax(pressure.magnitude) * pressure.units
+        bottom = np.nanmax(pressure)
 
     pres_layer, dewpoint_layer = get_layer(pressure, dewpoint, bottom=bottom,
                                            depth=bottom - top)

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -818,7 +818,7 @@ def _parcel_profile_helper(pressure, temperature, dewpoint):
     temp_lower = dry_lapse(press_lower, temperature)
 
     # If the pressure profile doesn't make it to the lcl, we can stop here
-    if _greater_or_close(np.nanmin(pressure.m), press_lcl.m):
+    if _greater_or_close(np.nanmin(pressure), press_lcl):
         return (press_lower[:-1], press_lcl, units.Quantity(np.array([]), press_lower.units),
                 temp_lower[:-1], temp_lcl, units.Quantity(np.array([]), temp_lower.units))
 

--- a/src/metpy/calc/tools.py
+++ b/src/metpy/calc/tools.py
@@ -410,13 +410,11 @@ def _get_bound_pressure_height(pressure, bound, height=None, interpolate=True):
         raise ValueError('Bound must be specified in units of length or pressure.')
 
     # If the bound is out of the range of the data, we shouldn't extrapolate
-    if not (_greater_or_close(bound_pressure, np.nanmin(pressure.m) * pressure.units)
-            and _less_or_close(bound_pressure, np.nanmax(pressure.m) * pressure.units)):
+    if not (_greater_or_close(bound_pressure, np.nanmin(pressure))
+            and _less_or_close(bound_pressure, np.nanmax(pressure))):
         raise ValueError('Specified bound is outside pressure range.')
-    if height is not None and not (_less_or_close(bound_height,
-                                                  np.nanmax(height.m) * height.units)
-                                   and _greater_or_close(bound_height,
-                                                         np.nanmin(height.m) * height.units)):
+    if height is not None and not (_less_or_close(bound_height, np.nanmax(height))
+                                   and _greater_or_close(bound_height, np.nanmin(height))):
         raise ValueError('Specified bound is outside height range.')
 
     return bound_pressure, bound_height
@@ -571,13 +569,13 @@ def get_layer(pressure, *args, height=None, bottom=None, depth=100 * units.hPa,
 
     # If the bottom is not specified, make it the surface pressure
     if bottom is None:
-        bottom = np.nanmax(pressure.m) * pressure.units
+        bottom = np.nanmax(pressure)
 
     bottom_pressure, bottom_height = _get_bound_pressure_height(pressure, bottom,
                                                                 height=height,
                                                                 interpolate=interpolate)
 
-    # Calculate the top if whatever units depth is in
+    # Calculate the top in whatever units depth is in
     if depth.dimensionality == {'[length]': -1.0, '[mass]': 1.0, '[time]': -2.0}:
         top = bottom_pressure - depth
     elif depth.dimensionality == {'[length]': 1}:

--- a/src/metpy/calc/tools.py
+++ b/src/metpy/calc/tools.py
@@ -348,7 +348,10 @@ def _get_bound_pressure_height(pressure, bound, height=None, interpolate=True):
     if bound.dimensionality == {'[length]': -1.0, '[mass]': 1.0, '[time]': -2.0}:
         # If the bound is in the pressure data, we know the pressure bound exactly
         if bound in pressure:
-            bound_pressure = bound
+            # By making sure this is at least a 1D array we avoid the behavior in numpy
+            # (at least up to 1.19.4) that float32 scalar * Python float -> float64, which
+            # can wreak havok with floating point comparisons.
+            bound_pressure = np.atleast_1d(bound)
             # If we have heights, we know the exact height value, otherwise return standard
             # atmosphere height for the pressure
             if height is not None:

--- a/tests/calc/test_calc_tools.py
+++ b/tests/calc/test_calc_tools.py
@@ -297,6 +297,26 @@ def test_get_layer_float32(flip_order):
     assert_array_almost_equal(hgt_layer, true_hgt_layer, 4)
 
 
+def test_get_layer_float32_no_heights():
+    """Test that get_layer works with float32 data when not given heights."""
+    p = np.array([1017.695312, 1010.831787, 1002.137207, 991.189453, 977.536194, 960.655212,
+                  940.116455, 915.509521, 886.550415], dtype=np.float32) * units.hPa
+    u = np.array([0.205419, 0.206133, -0.354010, -1.586414, -2.660765, -3.740533,
+                  -3.297433, 1.049471, 5.610486], dtype=np.float32) * units('m/s')
+    v = np.array([6.491890, 8.920976, 13.959625, 18.398054, 21.416298, 23.190233,
+                  23.028181, 20.971205, 19.243179], dtype=np.float32) * units('m/s')
+
+    p_l, u_l, v_l = get_layer(p, u, v, depth=1000 * units.meter)
+    assert_array_equal(p_l[:-1], p[:-1])
+    assert_array_almost_equal(u_l[:-1], u[:-1], 7)
+    assert_almost_equal(u_l[-1], 3.0449828 * units('m/s'), 4)
+    assert_array_almost_equal(v_l[:-1], v[:-1], 7)
+    assert_almost_equal(v_l[-1], 20.215168 * units('m/s'), 4)
+    assert p_l.dtype == p.dtype
+    assert u_l.dtype == u.dtype
+    assert v_l.dtype == v.dtype
+
+
 def test_get_layer_ragged_data():
     """Test that an error is raised for unequal length pressure and data arrays."""
     p = np.arange(10) * units.hPa


### PR DESCRIPTION
#### Description Of Changes
We've fixed this before, but this case involves the paths taken when we have no heights provided. Also the culprit here is that while float32 * float -> float32 for arrays, for scalars this is float64. Apparently (See numpy/numpy#17816). The easiest workaround for now is to force it out of the scalar path.

Also remove some places where we had been working around the fact that `nanmin` and `nanmax` didn't support Quantities--this all works fine now.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [x] Tests added
