### PR TITLE
Windows development fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,7 @@
 * text=auto
+staticdata/*.txt text eol=lf
+staticdata/*.csv text eol=lf
+staticdata/*.tbl text eol=lf
 
 *.ipynb	diff=jupyternotebook
 talks/* linguist-documentation

--- a/src/metpy/_version.py
+++ b/src/metpy/_version.py
@@ -13,7 +13,7 @@ def get_version():
     try:
         from setuptools_scm import get_version
         return get_version(root='../..', relative_to=__file__,
-                           version_scheme='post-release', local_scheme='dirty-tag')
+                           version_scheme='post-release')
     except (ImportError, LookupError):
         try:
             from importlib.metadata import version, PackageNotFoundError


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
Fixes a couple things I ran into while trying to debug on Windows the other day:
* Ensure hashes for our test data files match on Windows by enforcing line endings
* Fix version numbering so that local builds appear as such--using "dirty tag" only appends "+dirty" if files have been changed, otherwise dev builds from git look like "1.0.0rc2.post68". This can lead to pooch trying to download static data from a tag matching it rather than master.

#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
