### PR TITLE
Enable flake8 simplify

### DIFF
--- a/ci/linting_requirements.txt
+++ b/ci/linting_requirements.txt
@@ -11,6 +11,7 @@ flake8-mutable==1.2.0
 flake8-pep3101==1.3.0
 flake8-print==4.0.0
 flake8-quotes==3.2.0
+flake8-simplify==0.11.0
 pep8-naming==0.11.1
 
 flake8-rst-docstrings==0.0.14

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ rst-directives = plot
 docstring-convention = numpy
 exclude = docs build src/metpy/io/metar_parser.py
 select = A B C D E F H I M Q RST S T W B902
-ignore = F405 W503 RST902
+ignore = F405 W503 RST902 SIM106
 per-file-ignores = examples/*.py: D T003 T001
                    tutorials/*.py: D T003 T001
                    tutorials/xarray_tutorial.py: D RST304

--- a/src/metpy/calc/basic.py
+++ b/src/metpy/calc/basic.py
@@ -9,6 +9,7 @@ These include:
 * heat index
 * windchill
 """
+import contextlib
 from itertools import product
 import warnings
 
@@ -1182,10 +1183,8 @@ def _check_radians(value, max_radians=2 * np.pi):
         Input value
 
     """
-    try:
+    with contextlib.suppress(AttributeError):
         value = value.to('radians').m
-    except AttributeError:
-        pass
     if np.any(np.greater(np.abs(value), max_radians)):
         warnings.warn('Input over {} radians. '
                       'Ensure proper units are given.'.format(np.nanmax(max_radians)))

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Contains a collection of thermodynamic calculations."""
+import contextlib
 import warnings
 
 import numpy as np
@@ -1550,10 +1551,8 @@ def mixing_ratio_from_specific_humidity(specific_humidity):
     mixing_ratio, specific_humidity_from_mixing_ratio
 
     """
-    try:
+    with contextlib.suppress(AttributeError):
         specific_humidity = specific_humidity.to('dimensionless')
-    except AttributeError:
-        pass
     return specific_humidity / (1 - specific_humidity)
 
 
@@ -1587,10 +1586,8 @@ def specific_humidity_from_mixing_ratio(mixing_ratio):
     mixing_ratio, mixing_ratio_from_specific_humidity
 
     """
-    try:
+    with contextlib.suppress(AttributeError):
         mixing_ratio = mixing_ratio.to('dimensionless')
-    except AttributeError:
-        pass
     return mixing_ratio / (1 + mixing_ratio)
 
 

--- a/src/metpy/io/_tools.py
+++ b/src/metpy/io/_tools.py
@@ -5,6 +5,7 @@
 
 import bz2
 from collections import namedtuple
+import contextlib
 import gzip
 from io import BytesIO
 import logging
@@ -35,10 +36,8 @@ def open_as_needed(filename, mode='rb'):
             filename = BytesIO(lead + filename.read())
 
         # If the leading bytes match one of the signatures, pass into the appropriate class.
-        try:
+        with contextlib.suppress(AttributeError):
             lead = lead.encode('ascii')
-        except AttributeError:
-            pass
         if lead.startswith(b'\x1f\x8b'):
             filename = gzip.GzipFile(fileobj=filename)
         elif lead.startswith(b'BZh'):

--- a/src/metpy/plots/declarative.py
+++ b/src/metpy/plots/declarative.py
@@ -3,6 +3,7 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 """Declarative plotting tools."""
 
+import contextlib
 from datetime import datetime, timedelta
 
 import matplotlib.pyplot as plt
@@ -544,10 +545,8 @@ class PanelContainer(HasTraits):
         self.figure.canvas.draw()
 
         # Flush out interactive events--only ok on Agg for newer matplotlib
-        try:
+        with contextlib.suppress(NotImplementedError):
             self.figure.canvas.flush_events()
-        except NotImplementedError:
-            pass
 
     def draw(self):
         """Draw the collection of panels."""

--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -15,6 +15,7 @@ Dataset.
 
 See Also: :doc:`xarray with MetPy Tutorial </tutorials/xarray_tutorial>`.
 """
+import contextlib
 import functools
 from inspect import signature
 import logging
@@ -1039,7 +1040,7 @@ def check_axis(var, *axes):
                 return True
 
         # Check for units, either by dimensionality or name
-        try:
+        with contextlib.suppress(UndefinedUnitError):
             if (axis in coordinate_criteria['units'] and (
                     (
                         coordinate_criteria['units'][axis]['match'] == 'dimensionality'
@@ -1052,8 +1053,6 @@ def check_axis(var, *axes):
                         in coordinate_criteria['units'][axis]['units']
                     ))):
                 return True
-        except UndefinedUnitError:
-            pass
 
         # Check if name matches regular expression (non-CF failsafe)
         if re.match(coordinate_criteria['regular_expression'][axis], var.name.lower()):

--- a/tests/io/test_gini.py
+++ b/tests/io/test_gini.py
@@ -171,7 +171,7 @@ def test_unidata_composite():
     assert datetime(2018, 3, 9, 22, 25) == f.prod_desc.datetime
 
     # Check data value
-    assert 66 == f.data[2160, 2130]
+    assert f.data[2160, 2130] == 66
 
 
 def test_percent_normal():

--- a/tests/plots/test_cartopy_utils.py
+++ b/tests/plots/test_cartopy_utils.py
@@ -2,15 +2,14 @@
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Test the cartopy utilities."""
+import contextlib
 
 import matplotlib
 import matplotlib.pyplot as plt
 import pytest
 
-try:
+with contextlib.suppress(ImportError):
     from metpy.plots import USCOUNTIES, USSTATES
-except ImportError:
-    pass  # No CartoPy
 from metpy.plots.cartopy_utils import import_cartopy
 # Fixture to make sure we have the right backend
 from metpy.testing import set_agg_backend  # noqa: F401, I202


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
This adds flake8-simplify to our suite of linting plugins. This catches various miscellaneous things, like those I'm fixing here:
* Use `contextlib.suppress` to ignore a certain exception
* Yoda conditions (e.g. `if 3 == b:`)
* Using `enumerate` instead of incrementing a separate counter in a loop
* Using `all`/`any`
* And many others

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

