### PR TITLE
fix bug in issue 1635

### DIFF
--- a/src/metpy/calc/indices.py
+++ b/src/metpy/calc/indices.py
@@ -134,11 +134,11 @@ def mean_pressure_weighted(pressure, *args, height=None, bottom=None, depth=None
     layer_arg = layer_arg[1:]
     # Taking the integral of the weights (pressure) to feed into the weighting
     # function. Said integral works out to this function:
-    pres_int = 0.5 * (layer_p[-1].magnitude**2 - layer_p[0].magnitude**2)
-    for i, datavar in enumerate(args):
-        arg_mean = np.trapz((layer_arg[i] * layer_p).magnitude,
-                            x=layer_p.magnitude) / pres_int
-        ret.append(arg_mean * datavar.units)
+    pres_int = 0.5 * (layer_p[-1]**2 - layer_p[0]**2)
+    for i, _datavar in enumerate(args):
+        arg_mean = np.trapz((layer_arg[i] * layer_p),
+                            x=layer_p) / pres_int
+        ret.append(arg_mean)
 
     return ret
 

--- a/tests/calc/test_indices.py
+++ b/tests/calc/test_indices.py
@@ -73,6 +73,16 @@ def test_mean_pressure_weighted():
     assert_almost_equal(v, 7.966031839967931 * units('m/s'), 7)
 
 
+def test_mean_pressure_weighted_temperature():
+    """Test pressure-weighted mean temperature function with vertical interpolation."""
+    data = get_upper_air_data(datetime(2016, 5, 22, 0), 'DDC')
+    T, = mean_pressure_weighted(data['pressure'],
+                                data['temperature'],
+                                height=data['height'],
+                                depth=6000 * units('meter'))
+    assert_almost_equal(T, 281.535035296836 * units('kelvin'), 7)
+
+
 def test_mean_pressure_weighted_elevated():
     """Test pressure-weighted mean wind function with a base above the surface."""
     data = get_upper_air_data(datetime(2016, 5, 22, 0), 'DDC')


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
This PR is a fix to the bug reported in issue #1635. The issue revolved around the use of a temperature variable in generating a weighted mean value. The fact that the `np.trapz` function now accepts unit arrays this fix simply allows the units to pass through the function and yield proper units at the end instead of stripping and reapplying units.

A test has been added to account for using temperatures to compute a mean weighted value. The input is in Celsius with the output in Kelvin.

The only question, which I raised in a comment on the issue, is whether we desire to have the output come back this way, or force it back to the input units. The current behavior in this PR is similar to that of the `parcel_profile` function.
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #1635
- [x] Tests added
- [x] Fully documented