### PR TITLE
Remove misleading fallback to lat/lon CRS when only 2D lat/lon present

### DIFF
--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -220,8 +220,8 @@ def test_radian_projection_coords():
     assert data_var.coords['y'].metpy.unit_array[1] == 3 * units.meter
 
 
-def test_missing_grid_mapping():
-    """Test falling back to implicit lat/lon projection."""
+def test_missing_grid_mapping_valid():
+    """Test falling back to implicit lat/lon projection when valid."""
     lon = xr.DataArray(-np.arange(3),
                        attrs={'standard_name': 'longitude', 'units': 'degrees_east'})
     lat = xr.DataArray(np.arange(2),
@@ -230,7 +230,16 @@ def test_missing_grid_mapping():
     ds = xr.Dataset({'data': data})
 
     data_var = ds.metpy.parse_cf('data')
-    assert 'metpy_crs' in data_var.coords
+    assert (
+        'metpy_crs' in data_var.coords
+        and data_var.metpy.crs['grid_mapping_name'] == 'latitude_longitude'
+    )
+
+
+def test_missing_grid_mapping_invalid(test_var_multidim_no_xy):
+    """Test not falling back to implicit lat/lon projection when invalid."""
+    data_var = test_var_multidim_no_xy.to_dataset(name='data').metpy.parse_cf('data')
+    assert 'metpy_crs' not in data_var.coords
 
 
 def test_missing_grid_mapping_var(caplog):


### PR DESCRIPTION
As reported on StackOverflow and in https://github.com/Unidata/MetPy/issues/1648, it is incorrect to fallback to a lat/lon CRS when a CF grid mapping is missing and 2D lat/lons are present (as this means we instead have data on a projected grid of unknown CRS and not data on a lat/lon grid). This PR changes the lat/lon fallback to only occur when the identified latitude coordinate is also considered a y coordinate and likewise longitude is considered x (so that we truly have a lat/lon grid represented).

This did require some additional tweaks to the `grid_deltas_from_dataarray` utility, which assumed that a `metpy_crs` was always present (which never was really the case, but is especially important to not assume now since we no longer [mistakenly] inject a lat/lon CRS in the 2D lat/lon case).

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #1648
- [x] Tests added
- [x] Fully documented