### PR TITLE
Non-pressure weighted bunkers storm motion

### DIFF
--- a/src/metpy/calc/indices.py
+++ b/src/metpy/calc/indices.py
@@ -187,17 +187,17 @@ def bunkers_storm_motion(pressure, u, v, height):
 
     """
     # mean wind from sfc-6km
-    wind_mean = concatenate(mean_pressure_weighted(pressure, u, v, height=height,
-                                                   depth=6000 * units('meter')))
+    _, u_mean, v_mean = get_layer(pressure, u, v, height=height, depth=6000 * units('meter'))
+    wind_mean = [np.mean(u_mean).m, np.mean(v_mean).m] * u_mean.units
 
     # mean wind from sfc-500m
-    wind_500m = concatenate(mean_pressure_weighted(pressure, u, v, height=height,
-                                                   depth=500 * units('meter')))
+    _, u_500m, v_500m = get_layer(pressure, u, v, height=height, depth=500 * units('meter'))
+    wind_500m = [np.mean(u_500m).m, np.mean(v_500m).m] * u_500m.units
 
     # mean wind from 5.5-6km
-    wind_5500m = concatenate(mean_pressure_weighted(pressure, u, v, height=height,
-                                                    depth=500 * units('meter'),
-                                                    bottom=height[0] + 5500 * units('meter')))
+    _, u_5500m, v_5500m = get_layer(pressure, u, v, height=height, depth=500 * units('meter'),
+                                    bottom=height[0] + 5500 * units('meter'))
+    wind_5500m = [np.mean(u_5500m).m, np.mean(v_5500m).m] * u_5500m.units
 
     # Calculate the shear vector from sfc-500m to 5.5-6km
     shear = wind_5500m - wind_500m

--- a/tests/calc/test_indices.py
+++ b/tests/calc/test_indices.py
@@ -112,8 +112,8 @@ def test_bunkers_motion():
     motion = concatenate(bunkers_storm_motion(data['pressure'],
                          data['u_wind'], data['v_wind'],
                          data['height']))
-    truth = [1.4537892577864744, 2.0169333025630616, 10.587950761120482, 13.915130377372801,
-             6.0208700094534775, 7.9660318399679308] * units('m/s')
+    truth = [2.18346161, 0.86094706, 11.6006767, 12.53639395, 6.89206916,
+             6.69867051] * units('m/s')
     assert_almost_equal(motion.flatten(), truth, 8)
 
 


### PR DESCRIPTION
As I mentioned in issue #1361, the bunkers storm motion was using a pressure weighted mean wind for its calculations, making the output incorrect. I removed the concatenate(mean_pressure_weighted()) function calls and replaced them with the get_layer function and a simple numpy mean in the line below. I used the output to modify the testing function. I was originally going to use the values from sharppy with a larger range of error, however, after a decent amount of testing, I found out they use the 0-6 shear instead of the (0-500m mean wind) - (5500-6000m mean wind) shear. 

- [x] Closes #1361
- [x] Tests modified