### PR TITLE
use set_yticklabels in examples/meteogram_metpy

### DIFF
--- a/examples/meteogram_metpy.py
+++ b/examples/meteogram_metpy.py
@@ -79,7 +79,8 @@ class Meteogram:
         ln3 = ax7.plot(self.dates, wd, '.k', linewidth=0.5, label='Wind Direction')
         ax7.set_ylabel('Wind\nDirection\n(degrees)', multialignment='center')
         ax7.set_ylim(0, 360)
-        ax7.set_yticks(np.arange(45, 405, 90), ['NE', 'SE', 'SW', 'NW'])
+        ax7.set_yticks(np.arange(45, 405, 90))
+        ax7.set_yticklabels(['NE', 'SE', 'SW', 'NW'])
         lines = ln1 + ln2 + ln3
         labs = [line.get_label() for line in lines]
         ax7.xaxis.set_major_formatter(mpl.dates.DateFormatter('%d/%H UTC'))


### PR DESCRIPTION
#### Description Of Changes

Observed an error emitted with development matplotlib 3.4.0

```
   File "/home/runner/work/MetPy/MetPy/examples/meteogram_metpy.py", line 213, in <module>
   meteogram.plot_winds(data['wind_speed'], data['wind_direction'], data['wind_speed_max'])
   File "/home/runner/work/MetPy/MetPy/examples/meteogram_metpy.py", line 82, in plot_winds
   ax7.set_yticks(np.arange(45, 405, 90), ['NE', 'SE', 'SW', 'NW'])
   File "/opt/hostedtoolcache/Python/3.9.1/x64/lib/python3.9/site-packages/matplotlib/axes/_base.py", line 73, in wrapper
     return get_method(self)(*args, **kwargs)
 TypeError: set_ticks() takes 2 positional arguments but 3 were given
```

Just updated the example to use the more common `set_yticklabels` API