### PR TITLE
address numpy 1.20 deprecation of np.{bool,int,float}

### DIFF
--- a/src/metpy/calc/tools.py
+++ b/src/metpy/calc/tools.py
@@ -295,7 +295,7 @@ def reduce_point_density(points, radius, priority=None):
         sorted_indices = range(len(points))
 
     # Keep all points initially
-    keep = np.ones(len(points), dtype=np.bool)
+    keep = np.ones(len(points), dtype=bool)
 
     # Loop over all the potential points
     for ind in sorted_indices:
@@ -672,8 +672,8 @@ def find_bounding_indices(arr, values, axis, from_below=True):
     indices_shape[axis] = len(values)
 
     # Storage for the found indices and the mask for good locations
-    indices = np.empty(indices_shape, dtype=np.int)
-    good = np.empty(indices_shape, dtype=np.bool)
+    indices = np.empty(indices_shape, dtype=int)
+    good = np.empty(indices_shape, dtype=bool)
 
     # Used to put the output in the proper location
     take = make_take(arr.ndim, axis)
@@ -683,7 +683,7 @@ def find_bounding_indices(arr, values, axis, from_below=True):
     for level_index, value in enumerate(values):
         # Look for changes in the value of the test for <= value in consecutive points
         # Taking abs() because we only care if there is a flip, not which direction.
-        switches = np.abs(np.diff((arr <= value).astype(np.int), axis=axis))
+        switches = np.abs(np.diff((arr <= value).astype(int), axis=axis))
 
         # Good points are those where it's not just 0's along the whole axis
         good_search = np.any(switches, axis=axis)

--- a/src/metpy/io/nexrad.py
+++ b/src/metpy/io/nexrad.py
@@ -780,7 +780,7 @@ class DataMapper:
     MISSING = float('nan')
 
     def __init__(self, num=256):
-        self.lut = np.full(num, self.MISSING, dtype=np.float)
+        self.lut = np.full(num, self.MISSING, dtype=float)
 
     def __call__(self, data):
         """Convert the values."""

--- a/tests/calc/test_calc_tools.py
+++ b/tests/calc/test_calc_tools.py
@@ -138,13 +138,13 @@ def thin_point_data():
 
 @pytest.mark.parametrize('radius, truth',
                          [(2.0, np.array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=np.bool)),
+                                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=bool)),
                           (1.0, np.array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                          0, 0, 0, 0, 0, 0, 0, 0, 1, 0], dtype=np.bool)),
+                                          0, 0, 0, 0, 0, 0, 0, 0, 1, 0], dtype=bool)),
                           (0.3, np.array([1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0,
-                                          0, 0, 0, 0, 0, 1, 0, 0, 0, 0], dtype=np.bool)),
+                                          0, 0, 0, 0, 0, 1, 0, 0, 0, 0], dtype=bool)),
                           (0.1, np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1,
-                                          0, 1, 1, 1, 1, 1, 1, 1, 1, 1], dtype=np.bool))
+                                          0, 1, 1, 1, 1, 1, 1, 1, 1, 1], dtype=bool))
                           ])
 def test_reduce_point_density(thin_point_data, radius, truth):
     r"""Test that reduce_point_density works."""
@@ -153,13 +153,13 @@ def test_reduce_point_density(thin_point_data, radius, truth):
 
 @pytest.mark.parametrize('radius, truth',
                          [(2.0, np.array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=np.bool)),
+                                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=bool)),
                           (1.0, np.array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                          0, 0, 0, 0, 0, 0, 0, 0, 1, 0], dtype=np.bool)),
+                                          0, 0, 0, 0, 0, 0, 0, 0, 1, 0], dtype=bool)),
                           (0.3, np.array([1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0,
-                                          0, 0, 0, 0, 0, 1, 0, 0, 0, 0], dtype=np.bool)),
+                                          0, 0, 0, 0, 0, 1, 0, 0, 0, 0], dtype=bool)),
                           (0.1, np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1,
-                                          0, 1, 1, 1, 1, 1, 1, 1, 1, 1], dtype=np.bool))
+                                          0, 1, 1, 1, 1, 1, 1, 1, 1, 1], dtype=bool))
                           ])
 def test_reduce_point_density_units(thin_point_data, radius, truth):
     r"""Test that reduce_point_density works with units."""
@@ -169,13 +169,13 @@ def test_reduce_point_density_units(thin_point_data, radius, truth):
 
 @pytest.mark.parametrize('radius, truth',
                          [(2.0, np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                          0, 0, 0, 0, 0, 0, 0, 0, 0, 1], dtype=np.bool)),
+                                          0, 0, 0, 0, 0, 0, 0, 0, 0, 1], dtype=bool)),
                           (0.7, np.array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                          0, 0, 0, 1, 0, 0, 0, 0, 0, 1], dtype=np.bool)),
+                                          0, 0, 0, 1, 0, 0, 0, 0, 0, 1], dtype=bool)),
                           (0.3, np.array([1, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0,
-                                          0, 0, 0, 1, 0, 0, 0, 1, 0, 1], dtype=np.bool)),
+                                          0, 0, 0, 1, 0, 0, 0, 1, 0, 1], dtype=bool)),
                           (0.1, np.array([1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1,
-                                          0, 1, 1, 1, 1, 1, 1, 1, 1, 1], dtype=np.bool))
+                                          0, 1, 1, 1, 1, 1, 1, 1, 1, 1], dtype=bool))
                           ])
 def test_reduce_point_density_priority(thin_point_data, radius, truth):
     r"""Test that reduce_point_density works properly with priority."""
@@ -187,7 +187,7 @@ def test_reduce_point_density_1d():
     r"""Test that reduce_point_density works with 1D points."""
     x = np.array([1, 3, 4, 8, 9, 10])
     assert_array_equal(reduce_point_density(x, 2.5),
-                       np.array([1, 0, 1, 1, 0, 0], dtype=np.bool))
+                       np.array([1, 0, 1, 1, 0, 0], dtype=bool))
 
 
 def test_delete_masked_points():


### PR DESCRIPTION
### Description Of Changes

Updates MetPy code to not use the now deprecated numpy.{bool,int,float} aliases of builtin python types.

#### Checklist

- [x] Closes #1737
- Tests added
- Fully documented
