### PR TITLE
Fix `.metpy.units` checking `.data` for units and loading data into memory

### DIFF
--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -128,8 +128,8 @@ class MetPyDataArrayAccessor:
     @property
     def units(self):
         """Return the units of this DataArray as a `pint.Unit`."""
-        if isinstance(self._data_array.data, units.Quantity):
-            return self._data_array.data.units
+        if isinstance(self._data_array.variable._data, units.Quantity):
+            return self._data_array.variable._data.units
         else:
             return units.parse_units(self._data_array.attrs.get('units', 'dimensionless'))
 

--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -747,7 +747,7 @@ class MetPyDatasetAccessor:
             else:
                 crs = CFProjection(proj_var.attrs)
 
-        if crs is None and not check_axis(var, 'latitude', 'longitude'):
+        if crs is None:
             # This isn't a lat or lon coordinate itself, so determine if we need to fall back
             # to creating a latitude_longitude CRS. We do so if there exists valid *at most
             # 1D* coordinates for latitude and longitude (usually dimension coordinates, but

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Test the operation of MetPy's XArray accessors."""
 from collections import OrderedDict
+from unittest.mock import patch, PropertyMock
 
 import numpy as np
 import pyproj
@@ -113,6 +114,13 @@ def test_unit_array(test_var):
 def test_units(test_var):
     """Test the units property on the accessor."""
     assert test_var.metpy.units == units.kelvin
+
+
+def test_units_data(test_var):
+    """Test units property fetching does not touch variable.data."""
+    with patch.object(xr.Variable, 'data', new_callable=PropertyMock) as mock_data_property:
+        test_var.metpy.units
+        mock_data_property.assert_not_called()
 
 
 def test_units_percent():


### PR DESCRIPTION
#### Description Of Changes
 - Removes `check_axis` check in no gridmapping fallback in `parse_cf` (unnecessary via #1651)
 - Points `.metpy.units` to `xarray.Variable._data` instead of `.data` in checking for quantity with units to avoid loading data into memory
 - Test to see if `.metpy.units` touches `.data`. If there are any thoughts on more thorough tests for this situation let me know

#### Checklist

- [ ] Closes #1748 
  - Not sure if we want to leave open for larger discussion
- [X] Tests added
- [X] Fully documented
