### PR TITLE
Misc release items

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,7 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
   pull_request:
+  release:
 
 jobs:
   #

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -133,7 +133,7 @@ jobs:
       run: echo "DOC_VERSION=v$(python -c 'import metpy; print(metpy.__version__.rsplit(".", maxsplit=2)[0])')" >> $GITHUB_ENV
 
     - name: Upload to GitHub Pages
-      if: ${{ github.event_name != 'pull_request' && matrix.experimental == false }}
+      if: ${{ github.event_name != 'pull_request' && matrix.experimental == false && matrix.python-version == '3.9' }}
       uses: peaceiris/actions-gh-pages@v3.8.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -52,7 +52,8 @@ jobs:
               tag_name: 'v' + milestone.title,
               name: milestone.title,
               draft: true,
-              body: body
+              body: body,
+              discussion_category_name: 'Announcements'
             };
             const match = milestone.description.match(/branch:\s*([^\s]+)/);
             if (!!match) {

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -31,6 +31,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -o pipefail
           flake8 | reviewdog -f=pep8 -name=flake8 -reporter=github-check -filter-mode=nofilter
 
       - name: Run doc8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,14 @@ on:
 jobs:
   packages:
     name: Release Packages
+    environment:
+      name: PyPI
+      url: https://pypi.org/project/MetPy/
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 150
+        fetch-depth: 10
 
     - name: Get tags
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*

--- a/docs/devel/infrastructureguide.rst
+++ b/docs/devel/infrastructureguide.rst
@@ -33,10 +33,13 @@ extension also makes these scripts available as Jupyter notebooks.
 The documentation is hosted on `GitHub Pages <https://unidata.github.io/MetPy>`_. The docs are
 built automatically and uploaded upon pushes or merges to GitHub. Commits to ``main`` end up
 in our development version docs, while commits to versioned branches will update the
-docs for the corresponding version, which are located in the appropriately named subidrectory
+docs for the corresponding version, which are located in the appropriately named subdirectory
 on the ``gh-pages`` branch. We only maintain docs at the minor level, not the bugfix one.
 The docs rely on the ``pydata-sphinx-theme`` package for styling the docs, which needs to be
-installed for any local doc builds.
+installed for any local doc builds. The ``gh-pages`` branch has a GitHub Actions workflow that
+handles generating a ``versions.json`` file that controls what versions are displayed in the
+selector on the website, as well as update the ``latest`` symlink that points to the latest
+version of the docs.
 
 -----------
 Other Tools

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,7 +96,7 @@ per-file-ignores = examples/*.py: D MPY001 T003 T001
 
 [flake8:local-plugins]
 extension = MPY = flake8_metpy:MetPyChecker
-paths = ./tools/flake8_metpy
+paths = ./tools/flake8-metpy
 
 [tool:pytest]
 # https://github.com/matplotlib/pytest-mpl/issues/69

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -1542,10 +1542,10 @@ def mixing_ratio_from_relative_humidity(pressure, temperature, relative_humidity
     -----
     Formula adapted from [Hobbs1977]_ pg. 74.
 
-    .. math:: w = (relative_humidity)(w_s)
+    .. math:: w = (rh)(w_s)
 
     * :math:`w` is mixing ratio
-    * :math:`relative_humidity` is relative humidity as a unitless ratio
+    * :math:`rh` is relative humidity as a unitless ratio
     * :math:`w_s` is the saturation mixing ratio
 
     .. versionchanged:: 1.0
@@ -1589,9 +1589,9 @@ def relative_humidity_from_mixing_ratio(pressure, temperature, mixing_ratio):
     -----
     Formula based on that from [Hobbs1977]_ pg. 74.
 
-    .. math:: relative_humidity = \frac{w}{w_s}
+    .. math:: rh = \frac{w}{w_s}
 
-    * :math:`relative_humidity` is relative humidity as a unitless ratio
+    * :math:`rh` is relative humidity as a unitless ratio
     * :math:`w` is mixing ratio
     * :math:`w_s` is the saturation mixing ratio
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Started out to fix the handling of docs on release, but has a few other things:
* Only deploy docs from Python 3.9 build
* Make sure we deploy docs explicitly when a release is made (to take `main` and put in a versioned directory)
* Tweak draft release announcement to set that we want to [automatically create a discussion item](https://github.blog/changelog/2021-04-06-releases-support-comments-and-reactions-with-discussion-linking/) for the release
* Sets our release action to use the PyPI environment, which is the only environment now that has access to our PyPI upload token
* Tweak linting workflow to make sure a failure by `flake8` fails the workflow
* Fix a problem with formula rendering in a couple docstrings
* Update the infrastructure guide for the workflow added to `gh-pages` in #1836

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Addresses part of #1628
- [x] Fully documented
