### PR TITLE
lazy load station_info only when used #1320

### DIFF
--- a/src/metpy/io/station_data.py
+++ b/src/metpy/io/station_data.py
@@ -126,12 +126,18 @@ class StationLookup:
     """Look up station information from multiple sources."""
 
     def __init__(self):
-        """Initialize different files."""
-        self._sources = [dict(_read_station_table()), dict(_read_master_text_file()),
-                         dict(_read_station_text_file()), dict(_read_airports_file())]
+        """Construct placeholder list to be loaded when needed later."""
+        self._sources = []
 
     def __getitem__(self, stid):
         """Lookup station information from the ID."""
+        if not self._sources:
+            self._sources = [
+                dict(_read_station_table()),
+                dict(_read_master_text_file()),
+                dict(_read_station_text_file()),
+                dict(_read_airports_file()),
+            ]
         for table in self._sources:
             if stid in table:
                 return table[stid]


### PR DESCRIPTION
#### Description Of Changes

Presently, the import of `metpy.io.station_data` causes four station tables to always be loaded, which cascades into making POOCH requests if necessary.  This change makes the loading of station table data lazy and only when necessary to fulfill a lookup request.  No functional change.

#### Checklist

- [x] refs #1320
- Tests added
- [x] Fully documented
