### PR TITLE
Move pre-release tests and docs builds out of PR CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,12 +13,11 @@ on:
 
 jobs:
   #
-  # Build our docs on Linux against multiple Pythons, including pre-releases
+  # Build our docs on Linux against multiple Pythons
   #
   Docs:
     name: ${{ matrix.python-version }} ${{ matrix.dep-versions }}
     runs-on: ubuntu-20.04
-    continue-on-error: ${{ matrix.experimental }}
     env:
       DOC_VERSION: dev
     strategy:
@@ -28,18 +27,9 @@ jobs:
           - python-version: 3.8
             check-links: false
             dep-versions: requirements.txt
-            git-versions: ''
-            experimental: false
           - python-version: 3.9
             check-links: true
             dep-versions: requirements.txt
-            git-versions: ''
-            experimental: false
-          - python-version: 3.9
-            check-links: false
-            dep-versions: Prerelease
-            git-versions: 'git+git://github.com/hgrecco/pint@master#egg=pint git+git://github.com/pydata/xarray@master#egg=xarray'
-            experimental: true
 
     steps:
     # We check out only a limited depth and then pull tags to save time
@@ -81,7 +71,7 @@ jobs:
         python -m pip install --upgrade pip setuptools
         python -m pip install --no-binary :all: shapely
         python -m pip install -c ci/${{ matrix.dep-versions }} numpy
-        python -m pip install -r ci/doc_requirements.txt -r ci/extra_requirements.txt -c ci/${{ matrix.dep-versions }} ${{ matrix.git-versions }}
+        python -m pip install -r ci/doc_requirements.txt -r ci/extra_requirements.txt -c ci/${{ matrix.dep-versions }}
 
     # This imports CartoPy to find its map data cache directory
     - name: Get CartoPy maps dir
@@ -134,7 +124,7 @@ jobs:
       run: echo "DOC_VERSION=v$(python -c 'import metpy,re; print(re.search(r"(\d+\.\d+)", metpy.__version__)[0])')" >> $GITHUB_ENV
 
     - name: Upload to GitHub Pages
-      if: ${{ github.event_name != 'pull_request' && matrix.experimental == false && matrix.python-version == '3.9' }}
+      if: ${{ github.event_name != 'pull_request' && matrix.python-version == '3.9' }}
       uses: peaceiris/actions-gh-pages@v3.8.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -1,20 +1,24 @@
 name: Nightly Checks
 
 on:
-  # Runs at 09Z (3am MDT)
   schedule:
-    - cron: "0 9 * * *"
+  # Runs at 09Z (3am MDT)
+  # - cron: "0 9 * * *"
+  # Run every 10 minutes for testing
+    - cron: "0/10 * * * *"
+
   # Allow a manual run
   workflow_dispatch:
 
 jobs:
   Tests:
-    name: ${{ matrix.python-version }}
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.9]
+    outputs:
+      log_available: ${{ steps.tests.outputs.LOG_AVAILABLE }}
 
     steps:
     # We check out only a limited depth and then pull tags to save time
@@ -85,12 +89,23 @@ jobs:
 
     - name: Run tests
       run: |
+        set -o pipefail
         export TEST_DATA_DIR=$GITHUB_WORKSPACE/staticdata
         export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
-        python -m pytest --mpl -W error::metpy.deprecation.MetpyDeprecationWarning tests/
+        python -m pytest --mpl -W error::metpy.deprecation.MetpyDeprecationWarning tests/ | tee tests-${{ matrix.python-version }}.log || (
+            echo '::set-output name=LOG_AVAILABLE::true' && false
+        )
+
+    - name: Upload test log
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: log-nightly-tests-${{ matrix.python-version }}
+        path: tests-${{ matrix.python-version }}.log
+        retention-days: 5
 
     - name: Upload test images
-      if: ${{ failure() }}
+      if: failure()
       uses: actions/upload-artifact@v2
       with:
         name: pypi-${{ matrix.python-version }}-nightly-images
@@ -98,12 +113,13 @@ jobs:
         retention-days: 5
 
   Docs:
-    name: ${{ matrix.python-version }}
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.9]
+    outputs:
+      log_available: ${{ steps.build.outputs.LOG_AVAILABLE }}
 
     steps:
     # We check out only a limited depth and then pull tags to save time
@@ -173,20 +189,21 @@ jobs:
 
     - name: Build docs
       run: |
+        set -o pipefail
         export TEST_DATA_DIR=$GITHUB_WORKSPACE/staticdata
         pushd docs
-        make overridecheck html O=-W
+        make overridecheck html O=-W | tee build-${{ matrix.python-version }}.log || (
+            echo '::set-output name=LOG_AVAILABLE::true' && false
+        )
         popd
 
-    - name: Enable linkchecker for PRs
-      # Doing the linkchecker separately so that we avoid problems with vendored LICENSE
-      # files in the build directory
-      if: ${{ github.event_name == 'pull_request' && matrix.check-links == true }}
-      run: |
-        pushd docs
-        find build/html/_static -name LICENSE.md -delete
-        make linkcheck
-        popd
+    - name: Upload build log
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: log-nightly-docs-${{ matrix.python-version }}
+        path: build-${{ matrix.python-version }}.log
+        retention-days: 5
 
     - name: Upload docs as artifact
       if: ${{ github.event_name == 'pull_request' }}
@@ -197,3 +214,51 @@ jobs:
           docs/build/html
           !docs/_static/*.pdf
         retention-days: 5
+
+  Report:
+    name: Report
+    needs: [Tests, Docs]
+    if: always() && (needs.Tests.outputs.log_available == 'true' || needs.Docs.outputs.log_available == 'true')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download logs
+        uses: actions/download-artifact@v2
+        with:
+          path: /tmp/workspace/logs
+
+      - name: Group logs
+        run: cat /tmp/workspace/logs/log-*/*.log > logs.txt
+
+      - name: Report failures
+        uses: actions/github-script@v4.0.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const logs = fs.readFileSync('logs.txt', 'utf8');
+            const title = "Nightly build is failing"
+            const workflow_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+
+            // See if we have an existing issue
+            const items = await github.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              creator: 'github-actions[bot]'
+            });
+            existing = items.data.filter(i => i.title === title);
+
+            params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "The [Nightly workflow](${workflow_url}) is failing.\n```${logs}```",
+              title: title
+              labels: ['Type: Maintenance']
+            }
+            if (existing.length === 0) {
+                github.issues.create(params)
+            } else {
+                params.issue_number = existing[0].number
+                github.issues.update(params)
+            }

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -96,3 +96,104 @@ jobs:
         name: pypi-${{ matrix.python-version }}-nightly-images
         path: test_output/
         retention-days: 5
+
+  Docs:
+    name: ${{ matrix.python-version }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.9]
+
+    steps:
+    # We check out only a limited depth and then pull tags to save time
+    - name: Checkout source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 100
+
+    - name: Get tags
+      run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    # This uses pip to find the right cache dir and then sets up caching for it
+    - name: Get pip cache dir
+      id: pip-cache
+      run: echo "::set-output name=dir::$(pip cache dir)"
+
+    - name: Setup pip cache
+      uses: actions/cache@v2.1.5
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: pip-docs-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('ci/*') }}
+        restore-keys: |
+          pip-docs-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('ci/*') }}
+          pip-docs-${{ runner.os }}-${{ matrix.python-version }}-
+          pip-docs-${{ runner.os }}-
+          pip-docs-
+
+    - name: Assemble doc requirements
+      run: |
+        cat ci/extra_requirements.txt >> ci/doc_requirements.txt
+        echo git+git://github.com/hgrecco/pint@master#egg=pint >> ci/doc_requirements.txt
+        echo git+git://github.com/pydata/xarray@master#egg=xarray >> ci/doc_requirements.txt
+
+    # This installs the stuff needed to build and install Shapely and CartoPy from source.
+    # Need to install numpy first to make CartoPy happy.
+    - name: Install dependencies (PyPI)
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        sudo apt-get install libgeos-dev libproj-dev proj-bin
+        python -m pip install --upgrade pip setuptools
+        python -m pip install --no-binary :all: shapely
+        python -m pip install -c ci/Prerelease numpy
+        python -m pip install -r ci/doc_requirements.txt -c ci/Prerelease
+
+    # This imports CartoPy to find its map data cache directory
+    - name: Get CartoPy maps dir
+      id: cartopy-cache
+      run: echo "::set-output name=dir::$(python -c 'import cartopy;print(cartopy.config["data_dir"])')"
+
+    - name: Setup mapdata caching
+      uses: actions/cache@v2.1.5
+      env:
+        # Increase to reset cache of map data
+        CACHE_NUMBER: 0
+      with:
+        path: ${{ steps.cartopy-cache.outputs.dir }}
+        key: docs-cartopy-${{ env.CACHE_NUMBER }}
+        restore-keys: docs-cartopy-
+
+    - name: Install self
+      run: python -m pip install -c ci/Prerelease .
+
+    - name: Build docs
+      run: |
+        export TEST_DATA_DIR=$GITHUB_WORKSPACE/staticdata
+        pushd docs
+        make overridecheck html O=-W
+        popd
+
+    - name: Enable linkchecker for PRs
+      # Doing the linkchecker separately so that we avoid problems with vendored LICENSE
+      # files in the build directory
+      if: ${{ github.event_name == 'pull_request' && matrix.check-links == true }}
+      run: |
+        pushd docs
+        find build/html/_static -name LICENSE.md -delete
+        make linkcheck
+        popd
+
+    - name: Upload docs as artifact
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.python-version }}-nightly-docs
+        path: |
+          docs/build/html
+          !docs/_static/*.pdf
+        retention-days: 5

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -1,32 +1,20 @@
-name: PyPI Tests
+name: Nightly Checks
 
-# We don't want pushes (or PRs) to gh-pages to kick anything off
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  # Runs at 09Z (3am MDT)
+  schedule:
+    - cron: "0 9 * * *"
+  # Allow a manual run
+  workflow_dispatch:
 
 jobs:
-  #
-  # Run all tests on Linux using standard PyPI packages, including minimum requirements
-  #
-  PyPITests:
-    name: ${{ matrix.python-version }} ${{ matrix.dep-versions }} ${{ matrix.no-extras }}
+  Tests:
+    name: ${{ matrix.python-version }}
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
-        dep-versions: [requirements.txt]
-        no-extras: ['']
-        include:
-          - python-version: 3.7
-            dep-versions: Minimum
-            no-extras: ''
-          - python-version: 3.9
-            dep-versions: requirements.txt
-            no-extras: 'No Extras'
+        python-version: [3.9]
 
     steps:
     # We check out only a limited depth and then pull tags to save time
@@ -59,28 +47,11 @@ jobs:
           pip-tests-${{ runner.os }}-
           pip-tests-
 
-    - name: Add extras to requirements
-      if: ${{ matrix.no-extras != 'No Extras' }}
-      run: cat ci/extra_requirements.txt >> ci/test_requirements.txt
-
-    - name: Generate minimum dependencies
-      if: ${{ matrix.dep-versions == 'Minimum' }}
+    - name: Assemble test requirements
       run: |
-        python << EOF
-        import configparser
-        from pathlib import Path
-
-        # Read our setup.cfg
-        config = configparser.ConfigParser()
-        config.read('setup.cfg')
-
-        # Generate a Minimum dependency file
-        with (Path('ci') / 'Minimum').open('wt') as out:
-          for dep in config['options']['install_requires'].split('\n'):
-            if dep:
-              dep = dep.split(';')[0]
-              out.write(dep.replace('>=', '==') + '\n')
-        EOF
+        cat ci/extra_requirements.txt >> ci/test_requirements.txt
+        echo git+git://github.com/hgrecco/pint@master#egg=pint >> ci/test_requirements.txt
+        echo git+git://github.com/pydata/xarray@master#egg=xarray >> ci/test_requirements.txt
 
     # This installs the stuff needed to build and install Shapely and CartoPy from source.
     # Need to install numpy first to make CartoPy happy.
@@ -89,8 +60,8 @@ jobs:
         sudo apt-get install libgeos-dev libproj-dev proj-bin
         python -m pip install --upgrade pip setuptools
         python -m pip install --no-binary :all: shapely
-        python -m pip install -c ci/${{ matrix.dep-versions }} numpy
-        python -m pip install -r ci/test_requirements.txt -c ci/${{ matrix.dep-versions }}
+        python -m pip install -c ci/Prerelease numpy
+        python -m pip install -r ci/test_requirements.txt -c ci/Prerelease
 
     # This imports CartoPy to find its map data cache directory
     - name: Get CartoPy maps dir
@@ -110,32 +81,18 @@ jobs:
         restore-keys: cartopy-
 
     - name: Install
-      run: python -m pip install -c ci/${{ matrix.dep-versions }} .
+      run: python -m pip install -c ci/Prerelease .
 
     - name: Run tests
       run: |
         export TEST_DATA_DIR=$GITHUB_WORKSPACE/staticdata
         export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
-        python -m coverage run -p -m pytest --mpl -W error::metpy.deprecation.MetpyDeprecationWarning tests/
-        python -m coverage combine
-        python -m coverage report
-        python -m coverage xml
-
-    - name: Run doctests
-      if: ${{ matrix.dep-versions == 'requirements.txt' && matrix.no-extras != 'No Extras' }}
-      env:
-        PY_IGNORE_IMPORTMISMATCH: 1
-      run: python -m pytest --doctest-modules -k "not test" src;
+        python -m pytest --mpl -W error::metpy.deprecation.MetpyDeprecationWarning tests/
 
     - name: Upload test images
       if: ${{ failure() }}
       uses: actions/upload-artifact@v2
       with:
-        name: pypi-${{ matrix.python-version }}-${{ matrix.dep-versions }}-images
+        name: pypi-${{ matrix.python-version }}-nightly-images
         path: test_output/
-
-    - name: Upload coverage
-      if: ${{ always() }}
-      uses: codecov/codecov-action@v1
-      with:
-        name: pypi-${{ matrix.python-version }}-${{ matrix.dep-versions }}-${{ matrix.no-extras }}-${{ runner.os }}
+        retention-days: 5


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

This addresses part of #1843 by moving pre-release testing and doc builds to a nightly CI job. It removes that portion of the testing from the regular PR matrix, and adds a nightly workflow. This workflow runs on a schedule, does the runs, and if they fail should open an issue, making sure to re-use an existing open issue if one exists.

For obvious reasons, this is going to need some testing once merged. Success here only means that the we're no longer running in the CI for the pull request, but haven't broken the rest of the workflow.

For testing I've got this set to run every 10 minutes (so only click merge if I'm available to observe it). Once I'm convinced it's working properly, it's ready to go to run overnight (3am MDT).

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Addresses some of #1843
- [x] Tests added