### PR TITLE
BUG: Fix unit-handling in heat_index (Fixes #1867)

### DIFF
--- a/src/metpy/calc/basic.py
+++ b/src/metpy/calc/basic.py
@@ -306,8 +306,8 @@ def heat_index(temperature, relative_humidity, mask_undefined=True):
         rh15adj = ((13. - relative_humidity[sel] * 100.) / 4.
                    * np.sqrt((units.Quantity(17., 'delta_degF')
                               - np.abs(delta[sel] - units.Quantity(95., 'delta_degF')))
-                             / units.Quantity(17., 'delta_degF')))
-        hi[sel] = hi[sel] - units.Quantity(rh15adj, 'delta_degF')
+                             / units.Quantity(17., '1/delta_degF')))
+        hi[sel] = hi[sel] - rh15adj
 
     # Adjustment for RH > 85% and 80F <= T <= 87F
     sel = ((relative_humidity > units.Quantity(85., 'percent'))


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Was changed in c7b0b9b to remove multiplication by units and slightly change the operations used--this runs afoul of upstream changes in Pint where a Quantity is passed as the data in a constructor. Instead, change the units on a constant to produce the required dimensionality properly.
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #1867
- [x] Tests passing
- [x] Fully documented
