### PR TITLE
fixes bug in issue 1758

### DIFF
--- a/examples/plots/Station_Plot.py
+++ b/examples/plots/Station_Plot.py
@@ -99,7 +99,7 @@ stationplot.plot_symbol('C', data['cloud_coverage'].values, sky_cover)
 
 # Same this time, but plot current weather to the left of center, using the
 # `current_weather` mapper to convert symbols to the right glyphs.
-stationplot.plot_symbol('W', data['present_weather'].values, current_weather)
+stationplot.plot_symbol('W', data['current_wx1_symbol'].values, current_weather)
 
 # Add wind barbs
 stationplot.plot_barb(data['eastward_wind'].values, data['northward_wind'].values)

--- a/examples/plots/Station_Plot_with_Layout.py
+++ b/examples/plots/Station_Plot_with_Layout.py
@@ -102,7 +102,7 @@ data['cloud_coverage'] = (8 * data_arr['cloud_fraction']).fillna(10).values.asty
 # Map weather strings to WMO codes, which we can use to convert to symbols
 # Only use the first symbol if there are multiple
 wx_text = data_arr['weather'].fillna('')
-data['present_weather'] = [wx_code_map[s.split()[0] if ' ' in s else s] for s in wx_text]
+data['current_wx1_symbol'] = [wx_code_map[s.split()[0] if ' ' in s else s] for s in wx_text]
 
 ###########################################
 # All the data wrangling is finished, just need to set up plotting and go:

--- a/src/metpy/io/metar.py
+++ b/src/metpy/io/metar.py
@@ -609,9 +609,9 @@ def parse_metar_file(filename, *, year=None, month=None):
                        'air_temperature': temp,
                        'dew_point_temperature': dewp,
                        'altimeter': altim,
-                       'present_weather': current_wx1_symbol,
-                       'past_weather': current_wx2_symbol,
-                       'past_weather2': current_wx3_symbol},
+                       'current_wx1_symbol': current_wx1_symbol,
+                       'current_wx2_symbol': current_wx2_symbol,
+                       'current_wx3_symbol': current_wx3_symbol},
                       index=station_id)
 
     # Calculate sea-level pressure from function in metpy.calc

--- a/src/metpy/plots/station_plot.py
+++ b/src/metpy/plots/station_plot.py
@@ -631,7 +631,7 @@ with exporter:
     simple_layout.add_value('NE', 'air_pressure_at_sea_level', units='mbar',
                             fmt=lambda v: format(10 * v, '03.0f')[-3:])
     simple_layout.add_symbol('C', 'cloud_coverage', sky_cover)
-    simple_layout.add_symbol('W', 'present_weather', current_weather)
+    simple_layout.add_symbol('W', 'current_wx1_symbol', current_weather)
 
     #: Full NWS station plot `layout`__
     #:
@@ -644,7 +644,7 @@ with exporter:
     nws_layout.add_value((1, 1), 'air_pressure_at_sea_level', units='mbar',
                          fmt=lambda v: format(10 * v, '03.0f')[-3:])
     nws_layout.add_value((-2, 0), 'visibility_in_air', fmt='.0f', units='miles')
-    nws_layout.add_symbol((-1, 0), 'present_weather', current_weather)
+    nws_layout.add_symbol((-1, 0), 'current_wx1_symbol', current_weather)
     nws_layout.add_symbol((0, 0), 'cloud_coverage', sky_cover)
     nws_layout.add_value((1, 0), 'tendency_of_air_pressure', units='mbar',
                          fmt=lambda v: ('-' if v < 0 else '') + format(10 * abs(v), '02.0f'))
@@ -653,4 +653,4 @@ with exporter:
     nws_layout.add_value((-1, -1), 'dew_point_temperature', units='degF')
 
     # TODO: Fix once we have the past weather symbols converted
-    nws_layout.add_symbol((1, -1), 'past_weather', current_weather)
+    nws_layout.add_symbol((1, -1), 'current_wx2_symbol', current_weather)

--- a/tests/plots/test_station_plot.py
+++ b/tests/plots/test_station_plot.py
@@ -187,7 +187,7 @@ def test_simple_layout():
             'air_pressure_at_sea_level': np.array([29.92, 28.00]) * units.inHg,
             'eastward_wind': np.array([2, 0]) * units.knots,
             'northward_wind': np.array([0, 5]) * units.knots, 'cloud_coverage': [3, 8],
-            'present_weather': [65, 75], 'unused': [1, 2]}
+            'current_wx1_symbol': [65, 75], 'unused': [1, 2]}
 
     # Make the plot
     sp = StationPlot(fig.add_subplot(1, 1, 1), x, y, fontsize=12)
@@ -212,7 +212,7 @@ def test_nws_layout():
             'air_pressure_at_sea_level': np.array([999.8]) * units('mbar'),
             'eastward_wind': np.array([15.]) * units.knots,
             'northward_wind': np.array([15.]) * units.knots, 'cloud_coverage': [7],
-            'present_weather': [80], 'high_cloud_type': [1], 'medium_cloud_type': [3],
+            'current_wx1_symbol': [80], 'high_cloud_type': [1], 'medium_cloud_type': [3],
             'low_cloud_type': [2], 'visibility_in_air': np.array([5.]) * units.mile,
             'tendency_of_air_pressure': np.array([-0.3]) * units('mbar'),
             'tendency_of_air_pressure_symbol': [8]}

--- a/tutorials/declarative_tutorial.py
+++ b/tutorials/declarative_tutorial.py
@@ -285,7 +285,7 @@ obs.time = obs_time
 obs.time_window = timedelta(minutes=15)
 obs.level = None
 obs.fields = ['cloud_coverage', 'air_temperature', 'dew_point_temperature',
-              'air_pressure_at_sea_level', 'present_weather']
+              'air_pressure_at_sea_level', 'current_wx1_symbol']
 obs.plot_units = [None, 'degF', 'degF', None, None]
 obs.locations = ['C', 'NW', 'SW', 'NE', 'W']
 obs.formats = ['sky_cover', None, None, lambda v: format(v * 10, '.0f')[-3:],


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This PR is set to address issue #1758 where we do already distribute the weather codes via the metar_parse_file function. This issue is a bug that resides between the documentation, which states a different name, and the variable name generated in the function. This PR chooses to go with the naming convention of the documentation, which is more appropriate for what the those values actually are. In METAR, there is not a present and past configuration to the weather being reported. It is all current wx as there can be multiple phenomenon happening at one time.

There would still need to be some work on the documentation end for how the notes of the function display on the MetPy webpage. The current format is nearly unreadable.

https://unidata.github.io/MetPy/latest/api/generated/metpy.io.parse_metar_file.html#metpy.io.parse_metar_file
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #1758

