### PR TITLE
Copy method for declarative interface

### DIFF
--- a/src/metpy/plots/declarative.py
+++ b/src/metpy/plots/declarative.py
@@ -4,6 +4,7 @@
 """Declarative plotting tools."""
 
 import contextlib
+import copy
 from datetime import datetime, timedelta
 
 import matplotlib.pyplot as plt
@@ -568,6 +569,10 @@ class PanelContainer(HasTraits):
         self.draw()
         plt.show()
 
+    def copy(self):
+        """Return a copy of the panel container."""
+        return copy.copy(self)
+
 
 @exporter.export
 class MapPanel(Panel):
@@ -579,7 +584,7 @@ class MapPanel(Panel):
     projection, graphics area, and title.
     """
 
-    parent = Instance(PanelContainer)
+    parent = Instance(PanelContainer, allow_none=True)
 
     layout = Tuple(Int(), Int(), Int(), default_value=(1, 1, 1))
     layout.__doc__ = """A tuple that contains the description (nrows, ncols, index) of the
@@ -754,6 +759,27 @@ class MapPanel(Panel):
             self.ax.set_title(title)
             self._need_redraw = False
 
+    def __copy__(self):
+        """Return a copy of this MapPanel."""
+        # Create new, blank instance of MapPanel
+        cls = self.__class__
+        obj = cls.__new__(cls)
+
+        # Copy each attribute from current MapPanel to new MapPanel
+        for name in self.trait_names():
+            # The 'plots' attribute is a list.
+            # A copy must be made for each plot in the list.
+            if name == 'plots':
+                obj.plots = [copy.copy(plot) for plot in self.plots]
+            else:
+                setattr(obj, name, getattr(self, name))
+
+        return obj
+
+    def copy(self):
+        """Return a copy of the panel."""
+        return copy.copy(self)
+
 
 @exporter.export
 class Plots2D(HasTraits):
@@ -879,6 +905,10 @@ class Plots2D(HasTraits):
         if self.level is not None:
             ret += f'@{self.level:d}'
         return ret
+
+    def copy(self):
+        """Return a copy of the plot."""
+        return copy.copy(self)
 
 
 @exporter.export
@@ -1604,3 +1634,7 @@ class PlotObs(HasTraits):
             if self.vector_field_length is not None:
                 vector_kwargs['length'] = self.vector_field_length
             self.handle.plot_barb(u, v, **vector_kwargs)
+
+    def copy(self):
+        """Return a copy of the plot."""
+        return copy.copy(self)

--- a/tests/plots/test_declarative.py
+++ b/tests/plots/test_declarative.py
@@ -1184,3 +1184,37 @@ def test_panel():
 
     pc.panel = panel
     assert pc.panel is panel
+
+
+@needs_cartopy
+def test_copy():
+    """Test that the copy method works for all classes in `declarative.py`."""
+    # Copies of plot objects
+    objects = [ImagePlot(), ContourPlot(), FilledContourPlot(), BarbPlot(), PlotObs()]
+
+    for obj in objects:
+        obj.time = datetime.now()
+        copied_obj = obj.copy()
+        assert obj is not copied_obj
+        assert obj.time == copied_obj.time
+
+    # Copies of MapPanel and PanelContainer
+    obj = MapPanel()
+    obj.title = 'Sample Text'
+    copied_obj = obj.copy()
+    assert obj is not copied_obj
+    assert obj.title == copied_obj.title
+
+    obj = PanelContainer()
+    obj.size = (10, 10)
+    copied_obj = obj.copy()
+    assert obj is not copied_obj
+    assert obj.size == copied_obj.size
+
+    # Copies of plots in MapPanels should not point to same location in memory
+    obj = MapPanel()
+    obj.plots = [PlotObs(), BarbPlot(), FilledContourPlot(), ContourPlot(), ImagePlot()]
+    copied_obj = obj.copy()
+
+    for i in range(len(obj.plots)):
+        assert obj.plots[i] is not copied_obj.plots[i]


### PR DESCRIPTION
#### Description Of Changes

Adds a `.copy()` method to just about every class in `declarative.py`. This includes `Plots2D` (and hence all of its subclasses), `MapPanel`, `PanelContainer`, and `PlotObs`. The only class excluded is `Panel`, since it is currently empty.

This `obj.copy()` is equivalent to using `import copy` and `copy.copy(obj)`, expect when `obj` is a MapPanel.

The `.copy()` method for MapPanel required some additional changes in order to get it working. @dopplershift and I found that we needed to set `allow_none=True` for the `parent` trait of `MapPanel` in order to accommodate the process of copying a MapPanel that may not have been assigned a parent yet. A `__copy__()` method was written explicitly for MapPanel since a deeper copy of MapPanel's `plots` trait is needed in order for the copy to work correctly.

Test function `test_copy()` was added in `test_declarative.py`

#### Checklist

- [x] Closes #1719
- [X] Tests added
- [X] Fully documented
