### PR TITLE
Minor simplifications for the IO code

### DIFF
--- a/src/metpy/io/_tools.py
+++ b/src/metpy/io/_tools.py
@@ -343,7 +343,7 @@ def zlib_decompress_all_frames(data):
     while data:
         decomp = zlib.decompressobj()
         try:
-            frames.extend(decomp.decompress(data))
+            frames += decomp.decompress(data)
             data = decomp.unused_data
             log.debug('Decompressed zlib frame. %d bytes remain.', len(data))
         except zlib.error:

--- a/src/metpy/io/nexrad.py
+++ b/src/metpy/io/nexrad.py
@@ -60,11 +60,10 @@ def bzip_blocks_decompress_all(data):
     frames = bytearray()
     offset = 0
     while offset < len(data):
-        size_bytes = data[offset:offset + 4]
+        block_cmp_bytes = abs(int.from_bytes(data[offset:offset + 4], 'big', signed=True))
         offset += 4
-        block_cmp_bytes = abs(Struct('>l').unpack(size_bytes)[0])
         try:
-            frames.extend(bz2.decompress(data[offset:offset + block_cmp_bytes]))
+            frames += bz2.decompress(data[offset:offset + block_cmp_bytes])
             offset += block_cmp_bytes
         except OSError:
             # If we've decompressed any frames, this is an error mid-stream, so warn, stop


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
It turns out that `+=` for `bytearray` is implemented efficiently (unlike strings)--originally this was even faster than `extend()` (See [this video](https://youtu.be/z9Hmys8ojno?t=2325). Also update one last use of `Struct()` to unpack a single integer.

I was kinda hoping this might get some minor performance gain, but alas, no such luck. The code is still better this way, though.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->