### PR TITLE
Drop our explicit pillow dependency for sphinx-gallery

### DIFF
--- a/ci/doc_requirements.txt
+++ b/ci/doc_requirements.txt
@@ -5,5 +5,3 @@ pydata-sphinx-theme==0.5.2
 sphinx-gallery==0.9.0
 myst-parser==0.14.0
 netCDF4==1.5.6
-# Needed for sphinx-gallery, which refuses to list dependencies
-pillow==8.1.2


### PR DESCRIPTION
We could roll this up into a larger PR of small docs changes, but we can also just kick this in and close #1797. sphinx-gallery has better specified its dependencies and so we no longer have to handle this pillow dependency in `docs_requirements` ourselves.
