### PR TITLE
Interpret inverse_flattening = 0 as spherical datum in mapping.py

### DIFF
--- a/src/metpy/plots/mapping.py
+++ b/src/metpy/plots/mapping.py
@@ -47,7 +47,8 @@ class CFProjection:
     def cartopy_globe(self):
         """Initialize a `cartopy.crs.Globe` from the metadata."""
         if 'earth_radius' in self._attrs:
-            kwargs = {'ellipse': 'sphere', 'semimajor_axis': self._attrs['earth_radius'], 'semiminor_axis': self._attrs['earth_radius']}
+            kwargs = {'ellipse': 'sphere', 'semimajor_axis': self._attrs['earth_radius'],
+                      'semiminor_axis': self._attrs['earth_radius']}
 
         else:
             attr_mapping = [('semimajor_axis', 'semi_major_axis'),
@@ -55,10 +56,12 @@ class CFProjection:
                             ('inverse_flattening', 'inverse_flattening')]
             kwargs = self._map_arg_names(self._attrs, attr_mapping)
 
-            # Override CartoPy's default ellipse setting depending on whether we have any metadata to map about the spheroid.
+            # Override CartoPy's default ellipse setting depending on whether
+            # we have any metadata to map about the spheroid.
             kwargs['ellipse'] = None if kwargs else 'sphere'
 
-        # interpret the 0 inverse_flattening as a spherical datum and don't pass the value on.
+        # interpret the 0 inverse_flattening as a spherical datum
+        # and don't pass the value on.
         if kwargs.get('inverse_flattening', None) == 0:
             kwargs['ellipse'] = 'sphere'
             kwargs.pop('inverse_flattening', None)

--- a/src/metpy/plots/mapping.py
+++ b/src/metpy/plots/mapping.py
@@ -43,31 +43,25 @@ class CFProjection:
         return {cartopy_name: source[cf_name] for cartopy_name, cf_name in mapping
                 if cf_name in source}
 
-    ## issue 1844 deals with this block - changes made by lbunting
     @property
     def cartopy_globe(self):
         """Initialize a `cartopy.crs.Globe` from the metadata."""
         if 'earth_radius' in self._attrs:
-          #  kwargs['ellipse'] = 'sphere'
-          #  kwargs['semimajor_axis']=self._attrs['earth_radius']
-          #  kwargs['semiminor_axis']=self._attrs['earth_radius']
-            
-            kwargs = {'ellipse': 'sphere', 'semimajor_axis': self._attrs['earth_radius'],
-                      'semiminor_axis': self._attrs['earth_radius']}
+            kwargs = {'ellipse': 'sphere', 'semimajor_axis': self._attrs['earth_radius'], 'semiminor_axis': self._attrs['earth_radius']}
 
         else:
             attr_mapping = [('semimajor_axis', 'semi_major_axis'),
                             ('semiminor_axis', 'semi_minor_axis'),
                             ('inverse_flattening', 'inverse_flattening')]
             kwargs = self._map_arg_names(self._attrs, attr_mapping)
-        #kwargs.update(self._map_arg_names(self._attrs, attr_mapping))
-            
+
+            # Override CartoPy's default ellipse setting depending on whether we have any metadata to map about the spheroid.
+            kwargs['ellipse'] = None if kwargs else 'sphere'
+
+        # interpret the 0 inverse_flattening as a spherical datum and don't pass the value on.
         if kwargs.get('inverse_flattening', None) == 0:
             kwargs['ellipse'] = 'sphere'
             kwargs.pop('inverse_flattening', None)
-            # WGS84 with semi_major==semi_minor is NOT the same as spherical Earth
-            # Also need to handle the case where we're not given any spheroid
-            kwargs['ellipse'] = None if kwargs else 'sphere'
 
         return ccrs.Globe(**kwargs)
 

--- a/src/metpy/plots/mapping.py
+++ b/src/metpy/plots/mapping.py
@@ -43,18 +43,28 @@ class CFProjection:
         return {cartopy_name: source[cf_name] for cartopy_name, cf_name in mapping
                 if cf_name in source}
 
+    ## issue 1844 deals with this block - changes made by lbunting
     @property
     def cartopy_globe(self):
         """Initialize a `cartopy.crs.Globe` from the metadata."""
         if 'earth_radius' in self._attrs:
+          #  kwargs['ellipse'] = 'sphere'
+          #  kwargs['semimajor_axis']=self._attrs['earth_radius']
+          #  kwargs['semiminor_axis']=self._attrs['earth_radius']
+            
             kwargs = {'ellipse': 'sphere', 'semimajor_axis': self._attrs['earth_radius'],
                       'semiminor_axis': self._attrs['earth_radius']}
+
         else:
             attr_mapping = [('semimajor_axis', 'semi_major_axis'),
                             ('semiminor_axis', 'semi_minor_axis'),
                             ('inverse_flattening', 'inverse_flattening')]
             kwargs = self._map_arg_names(self._attrs, attr_mapping)
-
+        #kwargs.update(self._map_arg_names(self._attrs, attr_mapping))
+            
+        if kwargs.get('inverse_flattening', None) == 0:
+            kwargs['ellipse'] = 'sphere'
+            kwargs.pop('inverse_flattening', None)
             # WGS84 with semi_major==semi_minor is NOT the same as spherical Earth
             # Also need to handle the case where we're not given any spheroid
             kwargs['ellipse'] = None if kwargs else 'sphere'

--- a/tests/plots/test_mapping.py
+++ b/tests/plots/test_mapping.py
@@ -10,7 +10,7 @@ ccrs = pytest.importorskip('cartopy.crs')
 from metpy.plots.mapping import CFProjection  # noqa: E402
 
 def test_inverse_flattening_0():
-    """Test new code for dealing the case where inverse_flattening = 0"""
+    """Test new code for dealing the case where inverse_flattening = 0."""
     attrs = {'grid_mapping_name': 'lambert_conformal_conic', 'earth_radius': 6367000,
              'standard_parallel': 25, 'inverse_flattening': 0}
     proj = CFProjection(attrs)
@@ -21,6 +21,7 @@ def test_inverse_flattening_0():
     assert globe_params['ellps'] == 'sphere'
     assert globe_params['a'] == 6367000
     assert globe_params['b'] == 6367000
+
 
 def test_cfprojection_arg_mapping():
     """Test the projection mapping arguments."""

--- a/tests/plots/test_mapping.py
+++ b/tests/plots/test_mapping.py
@@ -9,6 +9,7 @@ ccrs = pytest.importorskip('cartopy.crs')
 
 from metpy.plots.mapping import CFProjection  # noqa: E402
 
+
 def test_inverse_flattening_0():
     """Test new code for dealing the case where inverse_flattening = 0."""
     attrs = {'grid_mapping_name': 'lambert_conformal_conic', 'earth_radius': 6367000,

--- a/tests/plots/test_mapping.py
+++ b/tests/plots/test_mapping.py
@@ -9,6 +9,11 @@ ccrs = pytest.importorskip('cartopy.crs')
 
 from metpy.plots.mapping import CFProjection  # noqa: E402
 
+def test_inverse_flattening_0():
+    """Test new code for dealing the case where inverse_flattening = 0"""
+
+    attrs = {'inverse_flattening': 0}
+
 
 def test_cfprojection_arg_mapping():
     """Test the projection mapping arguments."""

--- a/tests/plots/test_mapping.py
+++ b/tests/plots/test_mapping.py
@@ -12,8 +12,8 @@ from metpy.plots.mapping import CFProjection  # noqa: E402
 
 def test_inverse_flattening_0():
     """Test new code for dealing the case where inverse_flattening = 0."""
-    attrs = {'grid_mapping_name': 'lambert_conformal_conic', 'earth_radius': 6367000,
-             'standard_parallel': 25, 'inverse_flattening': 0}
+    attrs = {'grid_mapping_name': 'lambert_conformal_conic', 'semi_major_axis': 6367000,
+             'semi_minor_axis': 6367000, 'inverse_flattening': 0}
     proj = CFProjection(attrs)
 
     crs = proj.to_cartopy()

--- a/tests/plots/test_mapping.py
+++ b/tests/plots/test_mapping.py
@@ -11,9 +11,16 @@ from metpy.plots.mapping import CFProjection  # noqa: E402
 
 def test_inverse_flattening_0():
     """Test new code for dealing the case where inverse_flattening = 0"""
+    attrs = {'grid_mapping_name': 'lambert_conformal_conic', 'earth_radius': 6367000,
+             'standard_parallel': 25, 'inverse_flattening': 0}
+    proj = CFProjection(attrs)
 
-    attrs = {'inverse_flattening': 0}
+    crs = proj.to_cartopy()
+    globe_params = crs.globe.to_proj4_params()
 
+    assert globe_params['ellps'] == 'sphere'
+    assert globe_params['a'] == 6367000
+    assert globe_params['b'] == 6367000
 
 def test_cfprojection_arg_mapping():
     """Test the projection mapping arguments."""


### PR DESCRIPTION
Currently, pyproj CF output is not accepted by metpy.assign_crs(). The relevant logic in in /metpy/plot/mapping.py, property cartopy_globe. The error is occuring because the conversion from PyProj to CF produces a value of 0 for inverse_flattening. 

This PR updates mapping.py to not pass on a value of 0 for inverse_flattening by interpreting it as a spherical datum. Currently, it passes all tests except for test_globe_spheroid() in test_mapping.py.

