### PR TITLE
Remove any Pint objects from METAR parser output

### DIFF
--- a/src/metpy/io/metar.py
+++ b/src/metpy/io/metar.py
@@ -165,9 +165,11 @@ def parse_metar_to_dataframe(metar_text, *, year=None, month=None):
         df['air_pressure_at_sea_level'] = [np.nan]
 
     # Use get wind components and assign them to u and v variables
-    df['eastward_wind'], df['northward_wind'] = wind_components(
+    u, v = wind_components(
         units.Quantity(df.wind_speed.values, 'kts'),
         units.Quantity(df.wind_direction.values, 'degree'))
+    df['eastward_wind'] = u.m
+    df['northward_wind'] = v.m
 
     # Round the altimeter and sea-level pressure values
     df['altimeter'] = df.altimeter.round(2)
@@ -621,9 +623,11 @@ def parse_metar_file(filename, *, year=None, month=None):
         units.Quantity(temp, 'degC')).to('hPa').magnitude
 
     # Use get wind components and assign them to eastward and northward winds
-    df['eastward_wind'], df['northward_wind'] = wind_components(
+    u, v = wind_components(
         units.Quantity(df.wind_speed.values, 'kts'),
         units.Quantity(df.wind_direction.values, 'degree'))
+    df['eastward_wind'] = u.m
+    df['northward_wind'] = v.m
 
     # Drop duplicate values
     df = df.drop_duplicates(subset=['date_time', 'latitude', 'longitude'], keep='last')

--- a/tests/io/test_metar.py
+++ b/tests/io/test_metar.py
@@ -10,6 +10,7 @@ import pytest
 
 from metpy.cbook import get_test_data
 from metpy.io import parse_metar_file, parse_metar_to_dataframe
+from metpy.units import units
 
 
 def test_station_id_not_in_dictionary():
@@ -152,3 +153,14 @@ def test_parse_file_object():
     assert test.air_temperature.values == 21
     assert test.dew_point_temperature.values == 21
     assert test.altimeter.values == 30.03
+
+
+def test_parse_no_pint_objects_in_df():
+    """Test that there are no Pint quantities in dataframes created by parser."""
+    input_file = get_test_data('metar_20190701_1200.txt', mode='rt')
+    metar_str = ('KSLK 011151Z AUTO 21005KT 1/4SM FG VV002 14/13 A1013 RMK AO2 SLP151 70043 '
+                 'T01390133 10139 20094 53002=')
+
+    for df in (parse_metar_file(input_file), parse_metar_to_dataframe(metar_str)):
+        for column in df:
+            assert not isinstance(df[column][0], units.Quantity)


### PR DESCRIPTION
After further review of #1918 with @dopplershift, we determined that Pint quantities were being used in `eastward_wind` and `northward_wind` columns of dataframes coming out of the METAR parser functions, and this was causing problems down the road when it came to plotting wind barbs. In this PR, we change how `eastward_wind` and `northward_wind` are created so that they are floats instead of Pint objects. This should solve the original issue #1916 related to the nightly build failing.

This PR also adds a new test that makes sure that none of the columns in the dataframes created by METAR parsers contain Pint quantities.

#### Checklist

- [X] Closes #1916
- [X] Tests added
