### PR TITLE
Refactor dimensionality comparisons to check()

### DIFF
--- a/src/metpy/calc/tools.py
+++ b/src/metpy/calc/tools.py
@@ -345,7 +345,7 @@ def _get_bound_pressure_height(pressure, bound, height=None, interpolate=True):
         height = height[sort_inds]
 
     # Bound is given in pressure
-    if bound.dimensionality == {'[length]': -1.0, '[mass]': 1.0, '[time]': -2.0}:
+    if bound.check('[length]**-1 * [mass] * [time]**-2'):
         # If the bound is in the pressure data, we know the pressure bound exactly
         if bound in pressure:
             # By making sure this is at least a 1D array we avoid the behavior in numpy
@@ -375,7 +375,7 @@ def _get_bound_pressure_height(pressure, bound, height=None, interpolate=True):
                     bound_height = pressure_to_height_std(bound_pressure)
 
     # Bound is given in height
-    elif bound.dimensionality == {'[length]': 1.0}:
+    elif bound.check('[length]'):
         # If there is height data, see if we have the bound or need to interpolate/find nearest
         if height is not None:
             if bound in height:  # Bound is in the height data
@@ -581,9 +581,9 @@ def get_layer(pressure, *args, height=None, bottom=None, depth=None, interpolate
                                                                 interpolate=interpolate)
 
     # Calculate the top in whatever units depth is in
-    if depth.dimensionality == {'[length]': -1.0, '[mass]': 1.0, '[time]': -2.0}:
+    if depth.check('[length]**-1 * [mass] * [time]**-2'):
         top = bottom_pressure - depth
-    elif depth.dimensionality == {'[length]': 1}:
+    elif depth.check('[length]'):
         top = bottom_height + depth
     else:
         raise ValueError('Depth must be specified in units of length or pressure')

--- a/src/metpy/plots/skewt.py
+++ b/src/metpy/plots/skewt.py
@@ -929,7 +929,7 @@ class Hodograph:
         if colors:
             cmap = mcolors.ListedColormap(colors)
             # If we are segmenting by height (a length), interpolate the contour intervals
-            if intervals.dimensionality == {'[length]': 1.0}:
+            if intervals.check('[length]'):
 
                 # Find any intervals not in the data and interpolate them
                 interpolation_heights = np.array([bound.m for bound in intervals


### PR DESCRIPTION
Found 5 places in MetPy where we use `.dimensionality ==` to check the dimensionality of a quantity. Pint offers `.check()` to accomplish the same task, which we first used in #1912, and @dopplershift suggested we replace `.dimensionality ==` to `.check()` across the project where possible.