### PR TITLE
More descriptive errors for precipitable_water

### DIFF
--- a/src/metpy/calc/indices.py
+++ b/src/metpy/calc/indices.py
@@ -66,11 +66,22 @@ def precipitable_water(pressure, dewpoint, *, bottom=None, top=None):
 
     pressure, dewpoint = _remove_nans(pressure, dewpoint)
 
+    min_pres = np.nanmin(pressure)
+    max_pres = np.nanmax(pressure)
+
     if top is None:
-        top = np.nanmin(pressure)
+        top = min_pres
+    elif not min_pres <= top <= max_pres:
+        raise ValueError(f'The pressure and dewpoint profile ranges from {max_pres} to '
+                         f'{min_pres}, after removing missing values. {top} is outside this '
+                         'range.')
 
     if bottom is None:
-        bottom = np.nanmax(pressure)
+        bottom = max_pres
+    elif not min_pres <= bottom <= max_pres:
+        raise ValueError(f'The pressure and dewpoint profile ranges from {max_pres} to '
+                         f'{min_pres}, after removing missing values. {bottom} is outside '
+                         'this range.')
 
     pres_layer, dewpoint_layer = get_layer(pressure, dewpoint, bottom=bottom,
                                            depth=bottom - top)


### PR DESCRIPTION
In issue #1549, `precipitable_water()` raises an error because the pressure passed to `top` is outside the bounds of the pressure and dewpoint profiles, only because missing values have been removed. This PR provides more descriptive error messages, which could save some time for users who run into the same issue in the future.

#### Checklist

- [X] Closes #1549
