### PR TITLE
Improve some import handling

### DIFF
--- a/src/metpy/io/metar.py
+++ b/src/metpy/io/metar.py
@@ -13,9 +13,7 @@ import pandas as pd
 from ._tools import open_as_needed
 from .metar_parser import parse, ParseError
 from .station_data import station_info
-from ..calc import altimeter_to_sea_level_pressure, wind_components
 from ..package_tools import Exporter
-from ..plots.wx_symbols import wx_code_map
 from ..units import units
 
 exporter = Exporter(globals())
@@ -122,6 +120,8 @@ def parse_metar_to_dataframe(metar_text, *, year=None, month=None):
     * 'northward_wind': Northward component (v-compoment) of the wind vector, measured in knots
 
     """
+    from ..calc import altimeter_to_sea_level_pressure, wind_components
+
     # Defaults year and/or month to present reported date if not provided
     if year is None or month is None:
         now = datetime.now()
@@ -242,6 +242,8 @@ def parse_metar_to_named_tuple(metar_text, station_metadata, year, month):
       Attachment IV
 
     """
+    from ..plots.wx_symbols import wx_code_map
+
     # Decode the data using the parser (built using Canopy) the parser utilizes a grammar
     # file which follows the format structure dictated by the WMO Handbook, but has the
     # flexibility to decode the METAR text when there are missing or incorrectly
@@ -498,6 +500,8 @@ def parse_metar_file(filename, *, year=None, month=None):
     * 'northward_wind': Northward component (v-compoment) of the wind vector, measured in knots
 
     """
+    from ..calc import altimeter_to_sea_level_pressure, wind_components
+
     # Defaults year and/or month to present reported date if not provided
     if year is None or month is None:
         now = datetime.now()

--- a/src/metpy/plots/__init__.py
+++ b/src/metpy/plots/__init__.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 r"""Contains functionality for making meteorological plots."""
 
-import logging
-
 # Trigger matplotlib wrappers
 from . import _mpl  # noqa: F401
+from . import cartopy_utils
 from ._util import (add_metpy_logo, add_timestamp, add_unidata_logo,  # noqa: F401
                     convert_gempak_color)
 from .ctables import *  # noqa: F403
@@ -16,8 +15,6 @@ from .station_plot import *  # noqa: F403
 from .wx_symbols import *  # noqa: F403
 from ..package_tools import set_module
 
-logger = logging.getLogger(__name__)
-
 __all__ = ctables.__all__[:]  # pylint: disable=undefined-variable
 __all__.extend(declarative.__all__)  # pylint: disable=undefined-variable
 __all__.extend(skewt.__all__)  # pylint: disable=undefined-variable
@@ -25,10 +22,20 @@ __all__.extend(station_plot.__all__)  # pylint: disable=undefined-variable
 __all__.extend(wx_symbols.__all__)  # pylint: disable=undefined-variable
 __all__.extend(['add_metpy_logo', 'add_timestamp', 'add_unidata_logo',
                 'convert_gempak_color'])
-try:
-    from .cartopy_utils import USCOUNTIES, USSTATES  # noqa: F401
-    __all__.extend(['USCOUNTIES', 'USSTATES'])
-except ImportError:
-    logger.warning('Cannot import USCOUNTIES and USSTATES without Cartopy installed.')
 
 set_module(globals())
+
+
+def __getattr__(name):
+    """Handle warning if Cartopy map features are not available."""
+    if name in cartopy_utils.__all__:
+        try:
+            return getattr(cartopy_utils, name)
+        except AttributeError:
+            raise AttributeError(f'Cannot use {name} without Cartopy installed.') from None
+
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
+
+
+def __dir__():
+    return __all__ + cartopy_utils.__all__

--- a/src/metpy/plots/cartopy_utils.py
+++ b/src/metpy/plots/cartopy_utils.py
@@ -54,7 +54,10 @@ try:
 
     USSTATES = MetPyMapFeature('us_states', '20m', facecolor='None', edgecolor='black')
 except ImportError:
+    # If no Cartopy is present, we just don't have map features
     pass
+
+__all__ = ['USCOUNTIES', 'USSTATES']
 
 
 def import_cartopy():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
* Reduce import load of `metpy.io.metar`. This is currently causing importing `metpy.io` to trigger imports of `metpy.calc` and `metpy.plots`, which can add almost half a second to the total import and currently triggers warnings when Cartopy isn't installed
* Move handling of our Cartopy map features to only warn (when Cartopy isn't installed) upon *access* of the relevant attributes. This uses the module-level `__getattr__()` we have available now that we're only supporting Python >=3.7.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #1901 
