### PR TITLE
Cleaning up analysis warnings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -151,3 +151,14 @@ def test_da_xy():
     }
 
     return ds.metpy.parse_cf('temperature')
+
+
+@pytest.fixture()
+def set_agg_backend():
+    """Fixture to ensure the Agg backend is active."""
+    prev_backend = matplotlib.pyplot.get_backend()
+    try:
+        matplotlib.pyplot.switch_backend('agg')
+        yield
+    finally:
+        matplotlib.pyplot.switch_backend(prev_backend)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,6 @@
 # serve to show the default.
 
 from datetime import datetime
-import os
 from pathlib import Path
 import re
 import sys

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ where = src
 [options.extras_require]
 doc = sphinx; sphinx-gallery>=0.4; myst-parser; netCDF4
 examples = cartopy>=0.15.0; matplotlib>=2.2.0
-test = pytest>=2.4; pytest-mpl; cartopy>=0.16.0; netCDF4
+test = pytest>=2.4; pytest-mpl; cartopy>=0.17.0; netCDF4
 
 [build_sphinx]
 source-dir = docs/source

--- a/src/metpy/io/metar.py
+++ b/src/metpy/io/metar.py
@@ -4,6 +4,7 @@
 """Parse METAR-formatted data."""
 # Import the necessary libraries
 from collections import namedtuple
+import contextlib
 from datetime import datetime
 import warnings
 
@@ -521,11 +522,9 @@ def parse_metar_file(filename, *, year=None, month=None):
         if len(tmp):
             yield ' '.join(tmp)
 
-    # Open the file
-    myfile = open_as_needed(filename, 'rt')
-
-    # Clean up the file and take out the next line (\n)
-    value = myfile.read().rstrip()
+    # Open the file and clean up and take out the next line (\n)
+    with contextlib.closing(open_as_needed(filename, 'rt')) as myfile:
+        value = myfile.read().rstrip()
     list_values = value.split('\n')
     list_values = list(filter(None, list_values))
 

--- a/src/metpy/io/nexrad.py
+++ b/src/metpy/io/nexrad.py
@@ -964,7 +964,7 @@ class EDRMapper(DataMapper):
         offset = prod.thresholds[1] / 1000.
         leading_flags = prod.thresholds[3]
         for i in range(leading_flags, data_levels):
-            self.lut = scale * i + offset
+            self.lut[i] = scale * i + offset
 
 
 class LegacyMapper(DataMapper):

--- a/src/metpy/plots/cartopy_utils.py
+++ b/src/metpy/plots/cartopy_utils.py
@@ -27,7 +27,7 @@ try:
             # Ensure that the associated files are in the cache
             fname = f'{self.name}_{self.scaler.scale}'
             for extension in ['.dbf', '.shx']:
-                get_test_data(fname + extension)
+                get_test_data(fname + extension, as_file_obj=False)
             path = get_test_data(fname + '.shp', as_file_obj=False)
             return iter(tuple(shapereader.Reader(path).geometries()))
 

--- a/src/metpy/testing.py
+++ b/src/metpy/testing.py
@@ -200,18 +200,6 @@ def assert_xarray_allclose(actual, desired):
     assert desired.attrs == actual.attrs
 
 
-@pytest.fixture(scope='module', autouse=True)
-def set_agg_backend():
-    """Fixture to ensure the Agg backend is active."""
-    import matplotlib.pyplot as plt
-    prev_backend = plt.get_backend()
-    try:
-        plt.switch_backend('agg')
-        yield
-    finally:
-        plt.switch_backend(prev_backend)
-
-
 def check_and_silence_warning(warn_type):
     """Decorate a function to swallow some warning type, making sure they are present.
 

--- a/tests/interpolate/test_grid.py
+++ b/tests/interpolate/test_grid.py
@@ -164,6 +164,7 @@ def test_inverse_distance_to_grid(method, test_data, test_grid):
     xg, yg = test_grid
 
     extra_kw = {}
+    test_file = ''
     if method == 'cressman':
         extra_kw['r'] = 20
         extra_kw['min_neighbors'] = 1

--- a/tests/interpolate/test_points.py
+++ b/tests/interpolate/test_points.py
@@ -119,27 +119,28 @@ def test_inverse_distance_to_points(method, test_data, test_points):
     obs_points = np.vstack([xp, yp]).transpose()
 
     extra_kw = {}
-    if method == 'cressman':
-        extra_kw['r'] = 20
-        extra_kw['min_neighbors'] = 1
-        test_file = 'cressman_r20_mn1.npz'
-    elif method == 'barnes':
-        extra_kw['r'] = 40
-        extra_kw['kappa'] = 100
-        test_file = 'barnes_r40_k100.npz'
-    elif method == 'shouldraise':
+    if method == 'shouldraise':
         extra_kw['r'] = 40
         with pytest.raises(ValueError):
             inverse_distance_to_points(
                 obs_points, z, test_points, kind=method, **extra_kw)
-        return
+    else:
+        test_file = ''
+        if method == 'cressman':
+            extra_kw['r'] = 20
+            extra_kw['min_neighbors'] = 1
+            test_file = 'cressman_r20_mn1.npz'
+        elif method == 'barnes':
+            extra_kw['r'] = 40
+            extra_kw['kappa'] = 100
+            test_file = 'barnes_r40_k100.npz'
 
-    img = inverse_distance_to_points(obs_points, z, test_points, kind=method, **extra_kw)
+        img = inverse_distance_to_points(obs_points, z, test_points, kind=method, **extra_kw)
 
-    with get_test_data(test_file) as fobj:
-        truth = np.load(fobj)['img'].reshape(-1)
+        with get_test_data(test_file) as fobj:
+            truth = np.load(fobj)['img'].reshape(-1)
 
-    assert_array_almost_equal(truth, img)
+        assert_array_almost_equal(truth, img)
 
 
 @pytest.mark.parametrize('method', ['natural_neighbor', 'cressman', 'barnes', 'linear',

--- a/tests/io/test_nexrad.py
+++ b/tests/io/test_nexrad.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Test the `nexrad` module."""
-
+import contextlib
 from datetime import datetime
 from io import BytesIO
 import logging
@@ -76,7 +76,8 @@ def test_level2_fobj(filename, use_seek):
 
 def test_doubled_file():
     """Test for #489 where doubled-up files didn't parse at all."""
-    data = get_test_data('Level2_KFTG_20150430_1419.ar2v').read()
+    with contextlib.closing(get_test_data('Level2_KFTG_20150430_1419.ar2v')) as infile:
+        data = infile.read()
     fobj = BytesIO(data + data)
     f = Level2File(fobj)
     assert len(f.sweeps) == 12

--- a/tests/plots/test_cartopy_utils.py
+++ b/tests/plots/test_cartopy_utils.py
@@ -7,8 +7,6 @@ import matplotlib.pyplot as plt
 import pytest
 
 import metpy.plots as mpplots
-# Fixture to make sure we have the right backend
-from metpy.testing import set_agg_backend  # noqa: F401, I202
 
 MPL_VERSION = matplotlib.__version__[:3]
 

--- a/tests/plots/test_cartopy_utils.py
+++ b/tests/plots/test_cartopy_utils.py
@@ -7,7 +7,6 @@ import matplotlib.pyplot as plt
 import pytest
 
 import metpy.plots as mpplots
-from metpy.plots import cartopy_utils
 # Fixture to make sure we have the right backend
 from metpy.testing import set_agg_backend  # noqa: F401, I202
 
@@ -79,7 +78,7 @@ def test_cartopy_stub(monkeypatch):
     # This makes sure that cartopy is not found
     monkeypatch.setitem(sys.modules, 'cartopy.crs', None)
 
-    ccrs = cartopy_utils.import_cartopy()
+    ccrs = mpplots.cartopy_utils.import_cartopy()
     with pytest.raises(AttributeError, match='without Cartopy'):
         ccrs.PlateCarree()
 
@@ -87,7 +86,7 @@ def test_cartopy_stub(monkeypatch):
 def test_plots_getattr(monkeypatch):
     """Ensure the module-level getattr works."""
     # Make sure the feature is missing
-    monkeypatch.delattr(cartopy_utils, 'USSTATES', raising=False)
+    monkeypatch.delattr(mpplots.cartopy_utils, 'USSTATES', raising=False)
     with pytest.raises(AttributeError, match='Cannot use USSTATES without Cartopy'):
         assert not mpplots.USSTATES  # Should fail on attribute lookup before assert
 

--- a/tests/plots/test_declarative.py
+++ b/tests/plots/test_declarative.py
@@ -19,8 +19,7 @@ from metpy.io import GiniFile
 from metpy.io.metar import parse_metar_file
 from metpy.plots import (BarbPlot, ContourPlot, FilledContourPlot, ImagePlot, MapPanel,
                          PanelContainer, PlotObs)
-# Fixtures to make sure we have the right backend
-from metpy.testing import needs_cartopy, set_agg_backend  # noqa: F401, I202
+from metpy.testing import needs_cartopy
 from metpy.units import units
 
 
@@ -1357,7 +1356,7 @@ def test_save():
     assert fobj.read()
 
 
-def test_show():
+def test_show(set_agg_backend):
     """Test that show works properly."""
     pc = PanelContainer()
 

--- a/tests/plots/test_mapping.py
+++ b/tests/plots/test_mapping.py
@@ -136,14 +136,13 @@ def test_mercator():
     assert crs.proj4_params['lon_0'] == -100
 
 
-# This won't work until at least CartoPy > 0.16.0
-# def test_mercator_scale_factor():
-#     """Test handling a mercator projection with a scale factor."""
-#     attrs = {'grid_mapping_name': 'mercator', 'scale_factor_at_projection_origin': 0.9}
-#     crs = CFProjection(attrs).to_cartopy()
-#
-#     assert isinstance(crs, ccrs.Mercator)
-#     assert crs.proj4_params['k_0'] == 0.9
+def test_mercator_scale_factor():
+    """Test handling a mercator projection with a scale factor."""
+    attrs = {'grid_mapping_name': 'mercator', 'scale_factor_at_projection_origin': 0.9}
+    crs = CFProjection(attrs).to_cartopy()
+
+    assert isinstance(crs, ccrs.Mercator)
+    assert crs.proj4_params['k_0'] == 0.9
 
 
 def test_geostationary():

--- a/tests/plots/test_mpl.py
+++ b/tests/plots/test_mpl.py
@@ -11,8 +11,6 @@ import numpy as np
 
 # Needed to trigger scattertext monkey-patching
 import metpy.plots  # noqa: F401, I202
-# Fixture to make sure we have the right backend
-from metpy.testing import set_agg_backend  # noqa: F401, I202
 
 
 # Avoiding an image-based test here since that would involve text, which can be tricky

--- a/tests/plots/test_skewt.py
+++ b/tests/plots/test_skewt.py
@@ -10,8 +10,6 @@ import numpy as np
 import pytest
 
 from metpy.plots import Hodograph, SkewT
-# Fixtures to make sure we have the right backend and consistent round
-from metpy.testing import set_agg_backend  # noqa: F401, I202
 from metpy.units import units
 
 

--- a/tests/plots/test_station_plot.py
+++ b/tests/plots/test_station_plot.py
@@ -11,8 +11,6 @@ import pytest
 
 from metpy.plots import (current_weather, high_clouds, nws_layout, simple_layout,
                          sky_cover, StationPlot, StationPlotLayout)
-# Fixtures to make sure we have the right backend and consistent round
-from metpy.testing import set_agg_backend  # noqa: F401, I202
 from metpy.units import units
 
 

--- a/tests/plots/test_util.py
+++ b/tests/plots/test_util.py
@@ -11,8 +11,6 @@ import numpy as np
 import pytest
 
 from metpy.plots import add_metpy_logo, add_timestamp, add_unidata_logo, convert_gempak_color
-# Fixture to make sure we have the right backend
-from metpy.testing import set_agg_backend  # noqa: F401, I202
 
 MPL_VERSION = matplotlib.__version__[:3]
 

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 from metpy.testing import assert_array_almost_equal, assert_array_equal
-from metpy.testing import assert_nan, set_agg_backend  # noqa: F401
+from metpy.testing import assert_nan
 from metpy.units import check_units, concatenate, pandas_dataframe_to_unit_arrays, units
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

Fixing up some style issues from CodeQL, including one real bug (in code for a NEXRAD product that likely no one uses).
* Clean up some imports
* Put `set_agg_backend` with the rest of the fixtures in `conftest.py` and only use on the one test that requires it (`test_show` in `test_declarative.py`, because otherwise it opens a window).
* Enable a commented-out test in `test_mapping.py`--this was waiting on CartoPy>0.16 (0.17 came out November 2018). This is why, boys and girls, you don't comment things out but use `skips` and stuff.
* Clean up some spots where file objects weren't being explicitly closed

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
