### PR TITLE
Absolute momentum units bug fix

### DIFF
--- a/src/metpy/calc/cross_sections.py
+++ b/src/metpy/calc/cross_sections.py
@@ -292,18 +292,14 @@ def absolute_momentum(u, v, index='index'):
 
     """
     # Get the normal component of the wind
-    u = u.metpy.convert_units('m/s')
-    v = v.metpy.convert_units('m/s')
-    norm_wind = normal_component(u, v, index=index)
+    norm_wind = normal_component(u.metpy.quantify(), v.metpy.quantify(), index=index)
 
     # Get other pieces of calculation (all as ndarrays matching shape of norm_wind)
     latitude = latitude_from_cross_section(norm_wind)
     _, latitude = xr.broadcast(norm_wind, latitude)
     f = coriolis_parameter(latitude)
     x, y = distances_from_cross_section(norm_wind)
-    x = x.metpy.convert_units('meters')
-    y = y.metpy.convert_units('meters')
     _, x, y = xr.broadcast(norm_wind, x, y)
     distance = np.hypot(x.metpy.quantify(), y.metpy.quantify())
 
-    return norm_wind + f * distance
+    return (norm_wind + f * distance).metpy.convert_units('m/s')

--- a/src/metpy/calc/cross_sections.py
+++ b/src/metpy/calc/cross_sections.py
@@ -292,12 +292,14 @@ def absolute_momentum(u, v, index='index'):
 
     """
     # Get the normal component of the wind
-    norm_wind = normal_component(u, v, index=index).metpy.convert_units('m/s')
+    u = u.metpy.convert_units('m/s')
+    v = v.metpy.convert_units('m/s')
+    norm_wind = normal_component(u, v, index=index)
 
     # Get other pieces of calculation (all as ndarrays matching shape of norm_wind)
     latitude = latitude_from_cross_section(norm_wind)
     _, latitude = xr.broadcast(norm_wind, latitude)
-    f = coriolis_parameter(np.deg2rad(latitude.values))
+    f = coriolis_parameter(latitude)
     x, y = distances_from_cross_section(norm_wind)
     x = x.metpy.convert_units('meters')
     y = y.metpy.convert_units('meters')


### PR DESCRIPTION
- Implements @jthielen's solution to issue #1948, which converts `u` and `v` to m/s before passing to `normal_component()`.

- Refactors one line of `absolute_momentum()`, but I'm not familiar with the absolute momentum calculation. I'm willing to include more refactoring in this PR, but I would need some more specific direction on what to adjust/remove.

#### Checklist

- [X] Closes #1948
