### PR TITLE
Add unit-awareness to azimuth_range_to_lat_lon function

### DIFF
--- a/src/metpy/calc/tools.py
+++ b/src/metpy/calc/tools.py
@@ -4,6 +4,7 @@
 """Contains a collection of generally useful calculation tools."""
 import functools
 from operator import itemgetter
+import warnings
 
 import numpy as np
 from numpy.core.numeric import normalize_axis_index
@@ -887,6 +888,16 @@ def azimuth_range_to_lat_lon(azimuths, ranges, center_lon, center_lat, geod=None
     else:
         g = geod
 
+    try:  # convert range units to meters
+        ranges = ranges.m_as('meters')
+    except AttributeError:  # no units associated
+        warnings.warn('Range values are not a Pint-Quantity, assuming values are in meters.')
+    try:  # convert azimuth units to degrees
+        azimuths = azimuths.m_as('degrees')
+    except AttributeError:  # no units associated
+        warnings.warn(
+            'Azimuth values are not a Pint-Quantity, assuming values are in degrees.'
+        )
     rng2d, az2d = np.meshgrid(ranges, azimuths)
     lats = np.full(az2d.shape, center_lat)
     lons = np.full(az2d.shape, center_lon)

--- a/tests/calc/test_calc_tools.py
+++ b/tests/calc/test_calc_tools.py
@@ -920,7 +920,8 @@ def test_azimuth_range_to_lat_lon():
     rng = [2125., 64625., 127125., 189625., 252125., 314625.]
     clon = -89.98416666666667
     clat = 32.27972222222222
-    output_lon, output_lat = azimuth_range_to_lat_lon(az, rng, clon, clat)
+    with pytest.warns(UserWarning, match='not a Pint-Quantity'):
+        output_lon, output_lat = azimuth_range_to_lat_lon(az, rng, clon, clat)
     true_lon = [[-89.9946968, -90.3061798, -90.6211612, -90.9397425, -91.2620282,
                 -91.5881257],
                 [-89.9938369, -90.2799198, -90.5692874, -90.8620385, -91.1582743,
@@ -947,8 +948,8 @@ def test_azimuth_range_to_lat_lon():
 
 def test_azimuth_range_to_lat_lon_diff_ellps():
     """Test conversion of azimuth and range to lat/lon grid."""
-    az = [332.2403, 334.6765, 337.2528, 339.73846, 342.26257]
-    rng = [2125., 64625., 127125., 189625., 252125., 314625.]
+    az = [332.2403, 334.6765, 337.2528, 339.73846, 342.26257] * units.degrees
+    rng = [2125., 64625., 127125., 189625., 252125., 314625.] * units.meters
     clon = -89.98416666666667
     clat = 32.27972222222222
     output_lon, output_lat = azimuth_range_to_lat_lon(az, rng, clon, clat, Geod(ellps='WGS84'))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This PR resolves #1970 by adding some unit handling and issue a warning if ranges and/or azimuths are supplied without units to alert the user to the assumed behavior. Test slightly updated to account for different use cases of units or no units attached to arrays.
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #1970
- [x] Tests adapted
