### PR TITLE
Handle units external to iteration in moist_lapse and lcl

### DIFF
--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -25,11 +25,11 @@ exporter = Exporter(globals())
 sat_pressure_0c = units.Quantity(6.112, 'millibar')
 base_unit_sat_pressure_0c = sat_pressure_0c.to_base_units().m
 base_unit_epsilon = mpconsts.epsilon.to_base_units().m
-base_unit_Rd = mpconsts.Rd.to_base_units().m
-base_unit_Lv = mpconsts.Lv.to_base_units().m
-base_unit_Cp_d = mpconsts.Cp_d.to_base_units().m
+base_unit_rd = mpconsts.Rd.to_base_units().m
+base_unit_lv = mpconsts.Lv.to_base_units().m
+base_unit_cp_d = mpconsts.Cp_d.to_base_units().m
 base_unit_kappa = mpconsts.kappa.to_base_units().m
-base_unit_zero_degC = units.Quantity(0., 'degC').m_as('kelvin')
+base_unit_zero_degc = units.Quantity(0., 'degC').m_as('kelvin')
 
 
 @exporter.export
@@ -306,9 +306,9 @@ def moist_lapse(pressure, temperature, reference_pressure=None):
         partial_press = base_unit_sat_pressure_0c * np.exp(17.67 * (t - 273.15) / (t - 29.65))
         rs = base_unit_epsilon * partial_press / (p - partial_press)
         frac = (
-            (base_unit_Rd * t + base_unit_Lv * rs)
-            / (base_unit_Cp_d + (
-                base_unit_Lv * base_unit_Lv * rs * base_unit_epsilon / (base_unit_Rd * t * t)
+            (base_unit_rd * t + base_unit_lv * rs)
+            / (base_unit_cp_d + (
+                base_unit_lv * base_unit_lv * rs * base_unit_epsilon / (base_unit_rd * t * t)
             ))
         )
         return frac / p
@@ -421,7 +421,7 @@ def lcl(pressure, temperature, dewpoint, max_iters=50, eps=1e-5):
         nonlocal nan_mask
         vapor_pressure = p * w / (base_unit_epsilon + w)
         val = np.log(vapor_pressure / base_unit_sat_pressure_0c)
-        td = base_unit_zero_degC + 243.5 * val / (17.67 - val)
+        td = base_unit_zero_degc + 243.5 * val / (17.67 - val)
         p_new = p0 * (td / t) ** (1. / base_unit_kappa)
         nan_mask = nan_mask | np.isnan(p_new)
         return np.where(np.isnan(p_new), p, p_new)

--- a/tools/flake8-metpy/flake8_metpy.py
+++ b/tools/flake8-metpy/flake8_metpy.py
@@ -30,7 +30,8 @@ class MetPyVisitor(ast.NodeVisitor):
                        and isinstance(node.value, ast.Name) and node.value.id == 'units')
         is_reg_call = (isinstance(node, ast.Call)
                        and isinstance(node.func, ast.Name) and node.func.id == 'units')
-        is_unit_alias = isinstance(node, ast.Name) and 'unit' in node.id
+        is_unit_alias = (isinstance(node, ast.Name)
+                         and 'unit' in node.id and 'base_unit_' not in node.id)
 
         return is_units_attr or is_reg_attr or is_reg_call or is_unit_alias
 

--- a/tools/flake8-metpy/test_flake8_metpy.py
+++ b/tools/flake8-metpy/test_flake8_metpy.py
@@ -20,7 +20,8 @@ from flake8_metpy import MetPyChecker
     ('np.nan * pressure.units', 1),
     ('np.array([1, 2, 3]) * units.m', 1),
     ('np.arange(4) * units.s', 1),
-    ('np.ma.array([1, 2, 3]) * units.hPa', 1)
+    ('np.ma.array([1, 2, 3]) * units.hPa', 1),
+    ('base_unit_rd * t', 0)
 ])
 def test_plugin(source, errs):
     """Test that the flake8 checker works correctly."""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

In the process of reviewing https://github.com/Unidata/MetPy/pull/1968, I began experimenting with performance optimizations to `moist_lapse` to compare against the current implementation and the lookup table approach used there. While my ideal solution of using `guvectorize` with `numba` came up short for now (need an ODE solver that works *within* `numba`'s `nopython` mode, so something like [`NumbaLSODA`](https://github.com/Nicholaswogan/NumbaLSODA) that brings with it dependency troubles, [`numbakit-ode`](https://github.com/hgrecco/numbakit-ode) that's [partially held up by some upstream issues](https://github.com/hgrecco/numbakit-ode/issues/23), or a home-spun solver with increased maintenance costs), I was able to get around an order of magnitude improvement by moving unit handling outside of the iterator function, as done here.

Since I went ahead and applied analogous changes to `lcl`, this PR can replace the draft implementation of https://github.com/Unidata/MetPy/pull/1169.

No robust benchmarks were evaluated, but this did speed up `pytest tests/calc/test_thermo.py` on my workstation from about 3.5 seconds to 0.68 seconds.

The biggest caveat is that this moves the full chain of operations internal to these iterating functions (so any updates to the underlying functions will also have to modify the code here). However, I don't see that as much of a concern, since I'd expect the future ~~plug-gable calculation suite/automated solver~~ "numbafied" internal routines to necessitate refactoring all of that anyways (EDIT: after some later analysis, I doubt that we'll be able to make a robustly plug-able suite while also using numba-complied underlying routines...but that doesn't change the fact that we'll likely be refactoring these internals relatively soon anyways).

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #1169
- ~~Tests added~~ (internal refactor only)
- ~~Fully documented~~ (internal refactor only)
