### PR TITLE
Add check_units to `geopotential_to_height`

### DIFF
--- a/src/metpy/calc/basic.py
+++ b/src/metpy/calc/basic.py
@@ -496,6 +496,7 @@ def height_to_geopotential(height):
 
 @exporter.export
 @preprocess_and_wrap(wrap_like='geopotential')
+@check_units('[length] ** 2 / [time] ** 2')
 def geopotential_to_height(geopotential):
     r"""Compute height above sea level from a given geopotential.
 


### PR DESCRIPTION
#### Description Of Changes
Decorates `geopotential_to_height` with `@check_units` to provide appropriate error on non-united input, thanks #1998!

#### Checklist

- ~[ ] Closes #xxxx~
- ~[ ] Tests added~ (bugfix, tests pass locally)
- ~[ ] Fully documented~
