### PR TITLE
ENH: Ignore bad points in reduce_point_density

### DIFF
--- a/tests/calc/test_calc_tools.py
+++ b/tests/calc/test_calc_tools.py
@@ -150,6 +150,15 @@ def test_reduce_point_density(thin_point_data, radius, truth):
     assert_array_equal(reduce_point_density(thin_point_data, radius=radius), truth)
 
 
+def test_reduce_point_density_nonfinite():
+    """Test that non-finite point values are properly marked not to keep."""
+    points = np.array(
+        [(np.nan, np.nan), (np.nan, 5), (5, 5), (5, np.nan),
+         (10, 10), (np.inf, 10), (10, np.inf), (np.inf, np.inf)])
+    mask = reduce_point_density(points, 1)
+    assert_array_equal(mask, [False, False, True, False, True, False, False, False])
+
+
 @pytest.mark.parametrize('radius, truth',
                          [(2.0, np.array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                           0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=bool)),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This makes `reduce_point_density` much easier to use with real data when we do not have station information. This also works around a crash with SciPy 1.7.1--and it's unclear if it actually worked correctly before. This is why I have elected *not* to hide this behind a flag.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #1775
- [x] Closes #2000
- [x] Tests added
- [x] Fully documented
