### PR TITLE
Fix up Showalter Index calculation

### DIFF
--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -3314,7 +3314,7 @@ def gradient_richardson_number(height, potential_temperature, u, v, vertical_dim
 @exporter.export
 @preprocess_and_wrap()
 @check_units('[pressure]', '[temperature]', '[temperature]')
-def showalter_index(pressure, temperature, dewpt):
+def showalter_index(pressure, temperature, dewpoint):
     """Calculate Showalter Index from pressure temperature and 850 hPa lcl.
 
     Showalter Index derived from [Galway1956]_:
@@ -3333,7 +3333,7 @@ def showalter_index(pressure, temperature, dewpt):
         temperature : `pint.Quantity`
             Parcel temperature for corresponding pressure
 
-        dewpt : `pint.Quantity`
+        dewpoint : `pint.Quantity`
             Parcel dew point temperatures for corresponding pressure
 
     Returns
@@ -3343,7 +3343,7 @@ def showalter_index(pressure, temperature, dewpt):
 
     """
     # find the measured temperature and dew point temperature at 850 hPa.
-    t850, td850 = interpolate_1d(units.Quantity(850, 'hPa'), pressure, temperature, dewpt)
+    t850, td850 = interpolate_1d(units.Quantity(850, 'hPa'), pressure, temperature, dewpoint)
 
     # find the parcel profile temperature at 500 hPa.
     tp500 = interpolate_1d(units.Quantity(500, 'hPa'), pressure, temperature)

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1912,12 +1912,19 @@ def test_gradient_richardson_number_with_xarray():
 
 def test_showalter_index():
     """Test the Showalter index calculation."""
-    p_upper = np.arange(1000, 200, -50) * units.hPa
-    p_lower = np.arange(175, 0, -25) * units.hPa
-    p = np.append(p_upper, p_lower,)
-    tc = np.linspace(30, -30, 25) * units.degC
-    tdc = np.linspace(10, -30, 25) * units.degC
+    pressure = units.Quantity(np.array([931.0, 925.0, 911.0, 891.0, 886.9, 855.0, 850.0, 825.6,
+                                        796.3, 783.0, 768.0, 759.0, 745.0, 740.4, 733.0, 715.0,
+                                        700.0, 695.0, 687.2, 684.0, 681.0, 677.0, 674.0, 661.9,
+                                        657.0, 639.0, 637.6, 614.0, 592.0, 568.9, 547.4, 526.8,
+                                        500.0, 487.5, 485.0]), 'hPa')
+    temps = units.Quantity(np.array([18.4, 19.8, 20.0, 19.6, 19.3, 16.8, 16.4, 15.1, 13.4,
+                                     12.6, 11.2, 10.4, 8.6, 8.3, 7.8, 5.8, 4.6, 4.2, 3.4, 3.0,
+                                     3.0, 4.4, 5.0, 5.1, 5.2, 3.4, 3.3, 2.4, 1.4, -0.4, -2.2,
+                                     -3.9, -6.3, -7.6, -7.9]), 'degC')
+    dewp = units.Quantity(np.array([9.4, 8.8, 6.0, 8.6, 8.4, 6.8, 6.4, 4.0, 1.0, -0.4, -1.1,
+                                    -1.6, 1.6, -0.2, -3.2, -3.2, -4.4, -2.8, -3.6, -4.0, -6.0,
+                                    -17.6, -25.0, -31.2, -33.8, -29.6, -30.1, -39.0, -47.6,
+                                    -48.9, -50.2, -51.5, -53.3, -55.5, -55.9]), 'degC')
 
-    result = showalter_index(p, tc, tdc)
-    expected = 23.73036498600014 * units.delta_degree_Celsius
-    assert_array_almost_equal(result, expected, 4)
+    result = showalter_index(pressure, temps, dewp)
+    assert_almost_equal(result, units.Quantity(7.6024, 'delta_degC'), 4)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This was incorrectly lifting a surface parcel to the LCL calculated from the 850 point. Instead, eliminate all of the manual calculation and just use parcel_profile. The new values are with 1% of those from Wyoming--which is now what's used in the test (the original test value was off by 50% of the new value). Also fix the function parameter name (`dewpt` -> `dewpoint`) and clean up a bit of the docstring.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #1999
- [x] Tests added
- [x] Fully documented
