### PR TITLE
CI: Fix duplicate doc builds on release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
   pull_request:
   release:
+    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Saw two doc builds for 1.1--one of which fails because they're running concurrently. Need to specify one of published or released, since published fires for both released and prereleased.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

~- [ ] Closes #xxxx~
~- [ ] Tests added~
~- [ ] Fully documented~
