### PR TITLE
Misc cleanups

### DIFF
--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -3323,7 +3323,7 @@ def k_index(pressure, temperature, dewpoint):
 )
 @check_units('[length]', '[temperature]', '[speed]', '[speed]')
 def gradient_richardson_number(height, potential_temperature, u, v, vertical_dim=0):
-    r"""Calculate the gradient (or flux) Richardson number.
+    r"""Calculate the gradient Richardson number.
 
     .. math:: Ri = \frac{g}{\theta} \frac{\left(\partial \theta/\partial z\right)}
              {\left(\partial u / \partial z\right)^2 + \left(\partial v / \partial z\right)^2}

--- a/src/metpy/io/_tools.py
+++ b/src/metpy/io/_tools.py
@@ -138,7 +138,7 @@ class Enum:
     def __init__(self, *args, **kwargs):
         """Initialize the mapping."""
         # Assign values for args in order starting at 0
-        self.val_map = {ind: a for ind, a in enumerate(args)}
+        self.val_map = dict(enumerate(args))
 
         # Invert the kwargs dict so that we can map from value to name
         self.val_map.update(zip(kwargs.values(), kwargs.keys()))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
* Replace unnecessary dict comprehension (grabbed from #1785). Closes out #1933.
* Remove "flux" from the `gradient_richardson_number` docstring since based on some reading ([AMS Glossary](https://glossary.ametsoc.org/wiki/Flux_richardson_number) among them) it seems like flux Richardson number is different and relies on the prototypical boundary layer perturbations rather than gradients.
* 
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #1933
~- [ ] Tests added~
- [x] Fully documented
