### PR TITLE
Improve some thermo calculation bottlenecks by refactoring how units are handled

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,7 @@ per-file-ignores = examples/*.py: D MPY001 T003 T001
                    src/metpy/interpolate/*.py: RST306
                    src/metpy/io/*.py: RST306
                    src/metpy/future.py: RST307
-                   src/metpy/constants.py: RST306
+                   src/metpy/constants/*.py: RST306
                    docs/doc-server.py: T001
                    tests/*.py: MPY001
                    ci/filter_links.py: E731 T001

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -17,12 +17,10 @@ from .. import constants as mpconsts
 from ..cbook import broadcast_indices
 from ..interpolate.one_dimension import interpolate_1d
 from ..package_tools import Exporter
-from ..units import check_units, concatenate, units
+from ..units import check_units, concatenate, process_units, units
 from ..xarray import add_vertical_dim_from_xarray, preprocess_and_wrap
 
 exporter = Exporter(globals())
-
-sat_pressure_0c = units.Quantity(6.112, 'millibar')
 
 
 @exporter.export
@@ -248,7 +246,14 @@ def dry_lapse(pressure, temperature, reference_pressure=None, vertical_dim=0):
     wrap_like='temperature',
     broadcast=('pressure', 'temperature', 'reference_pressure')
 )
-@check_units('[pressure]', '[temperature]', '[pressure]')
+@process_units(
+    {
+        'pressure': '[pressure]',
+        'temperature': '[temperature]',
+        'reference_pressure': '[pressure]'
+    },
+    '[temperature]'
+)
 def moist_lapse(pressure, temperature, reference_pressure=None):
     r"""Calculate the temperature at a level assuming liquid saturation processes.
 
@@ -296,24 +301,23 @@ def moist_lapse(pressure, temperature, reference_pressure=None):
 
     """
     def dt(p, t):
-        t = units.Quantity(t, 'kelvin')
-        p = units.Quantity(p, 'mbar')
-        rs = saturation_mixing_ratio(p, t)
-        frac = ((mpconsts.Rd * t + mpconsts.Lv * rs)
-                / (mpconsts.Cp_d + (mpconsts.Lv * mpconsts.Lv * rs * mpconsts.epsilon
-                                    / (mpconsts.Rd * t**2)))).to('kelvin')
-        return (frac / p).magnitude
+        rs = saturation_mixing_ratio._nounit(p, t)
+        frac = (
+            (mpconsts.nounit.Rd * t + mpconsts.nounit.Lv * rs)
+            / (mpconsts.nounit.Cp_d + (
+                mpconsts.nounit.Lv * mpconsts.nounit.Lv * rs * mpconsts.nounit.epsilon
+                / (mpconsts.nounit.Rd * t * t)
+            ))
+        )
+        return frac / p
 
+    temperature = np.atleast_1d(temperature)
     pressure = np.atleast_1d(pressure)
     if reference_pressure is None:
         reference_pressure = pressure[0]
-    pressure = pressure.to('mbar')
-    reference_pressure = reference_pressure.to('mbar')
-    org_units = temperature.units
-    temperature = np.atleast_1d(temperature).m_as('kelvin')
 
     if np.isnan(reference_pressure) or np.all(np.isnan(temperature)):
-        return units.Quantity(np.full((temperature.size, pressure.size), np.nan), org_units)
+        return np.full((temperature.size, pressure.size), np.nan)
 
     pres_decreasing = (pressure[0] > pressure[-1])
     if pres_decreasing:
@@ -336,10 +340,10 @@ def moist_lapse(pressure, temperature, reference_pressure=None):
     points_above = (pressure < reference_pressure) & ~close
     if np.any(points_above):
         # Integrate upward--need to flip so values are properly ordered from ref to min
-        press_side = pressure[points_above][::-1].m
+        press_side = pressure[points_above][::-1]
 
         # Flip on exit so t values correspond to increasing pressure
-        trace = si.solve_ivp(t_span=(reference_pressure.m, press_side[-1]),
+        trace = si.solve_ivp(t_span=(reference_pressure, press_side[-1]),
                              t_eval=press_side, **solver_args).y[..., ::-1]
         ret = np.concatenate((trace, ret), axis=-1)
 
@@ -347,20 +351,23 @@ def moist_lapse(pressure, temperature, reference_pressure=None):
     points_below = ~points_above & ~close
     if np.any(points_below):
         # Integrate downward
-        press_side = pressure[points_below].m
-        trace = si.solve_ivp(t_span=(reference_pressure.m, press_side[-1]),
+        press_side = pressure[points_below]
+        trace = si.solve_ivp(t_span=(reference_pressure, press_side[-1]),
                              t_eval=press_side, **solver_args).y
         ret = np.concatenate((ret, trace), axis=-1)
 
     if pres_decreasing:
         ret = ret[..., ::-1]
 
-    return units.Quantity(ret.squeeze(), 'kelvin').to(org_units)
+    return ret.squeeze()
 
 
 @exporter.export
 @preprocess_and_wrap()
-@check_units('[pressure]', '[temperature]', '[temperature]')
+@process_units(
+    {'pressure': '[pressure]', 'temperature': '[temperature]', 'dewpoint': '[temperature]'},
+    ('[pressure]', '[temperature]')
+)
 def lcl(pressure, temperature, dewpoint, max_iters=50, eps=1e-5):
     r"""Calculate the lifted condensation level (LCL) from the starting point.
 
@@ -420,25 +427,24 @@ def lcl(pressure, temperature, dewpoint, max_iters=50, eps=1e-5):
     """
     def _lcl_iter(p, p0, w, t):
         nonlocal nan_mask
-        td = globals()['dewpoint'](vapor_pressure(units.Quantity(p, pressure.units), w))
-        p_new = (p0 * (td / t) ** (1. / mpconsts.kappa)).m
+        td = globals()['dewpoint']._nounit(vapor_pressure._nounit(p, w))
+        p_new = (p0 * (td / t) ** (1. / mpconsts.nounit.kappa))
         nan_mask = nan_mask | np.isnan(p_new)
         return np.where(np.isnan(p_new), p, p_new)
 
     # Handle nans by creating a mask that gets set by our _lcl_iter function if it
     # ever encounters a nan, at which point pressure is set to p, stopping iteration.
     nan_mask = False
-    w = mixing_ratio(saturation_vapor_pressure(dewpoint), pressure)
-    lcl_p = so.fixed_point(_lcl_iter, pressure.m, args=(pressure.m, w, temperature),
+    w = mixing_ratio._nounit(saturation_vapor_pressure._nounit(dewpoint), pressure)
+    lcl_p = so.fixed_point(_lcl_iter, pressure, args=(pressure, w, temperature),
                            xtol=eps, maxiter=max_iters)
     lcl_p = np.where(nan_mask, np.nan, lcl_p)
 
     # np.isclose needed if surface is LCL due to precision error with np.log in dewpoint.
     # Causes issues with parcel_profile_with_lcl if removed. Issue #1187
-    lcl_p = units.Quantity(np.where(np.isclose(lcl_p, pressure.m), pressure.m, lcl_p),
-                           pressure.units)
+    lcl_p = np.where(np.isclose(lcl_p, pressure), pressure, lcl_p)
 
-    return lcl_p, globals()['dewpoint'](vapor_pressure(lcl_p, w)).to(temperature.units)
+    return lcl_p, globals()['dewpoint']._nounit(vapor_pressure._nounit(lcl_p, w))
 
 
 @exporter.export
@@ -950,7 +956,7 @@ def _insert_lcl_level(pressure, temperature, lcl_pressure):
 
 @exporter.export
 @preprocess_and_wrap(wrap_like='mixing_ratio', broadcast=('pressure', 'mixing_ratio'))
-@check_units('[pressure]', '[dimensionless]')
+@process_units({'pressure': '[pressure]', 'mixing_ratio': '[dimensionless]'}, '[pressure]')
 def vapor_pressure(pressure, mixing_ratio):
     r"""Calculate water vapor (partial) pressure.
 
@@ -985,12 +991,12 @@ def vapor_pressure(pressure, mixing_ratio):
        Renamed ``mixing`` parameter to ``mixing_ratio``
 
     """
-    return pressure * mixing_ratio / (mpconsts.epsilon + mixing_ratio)
+    return pressure * mixing_ratio / (mpconsts.nounit.epsilon + mixing_ratio)
 
 
 @exporter.export
 @preprocess_and_wrap(wrap_like='temperature')
-@check_units('[temperature]')
+@process_units({'temperature': '[temperature]'}, '[pressure]')
 def saturation_vapor_pressure(temperature):
     r"""Calculate the saturation water vapor (partial) pressure.
 
@@ -1018,10 +1024,10 @@ def saturation_vapor_pressure(temperature):
     .. math:: 6.112 e^\frac{17.67T}{T + 243.5}
 
     """
-    # Converted from original in terms of C to use kelvin. Using raw absolute values of C in
-    # a formula plays havoc with units support.
-    return sat_pressure_0c * np.exp(17.67 * (temperature - units.Quantity(273.15, 'kelvin'))
-                                    / (temperature - units.Quantity(29.65, 'kelvin')))
+    # Converted from original in terms of C to use kelvin.
+    return mpconsts.nounit.sat_pressure_0c * np.exp(
+        17.67 * (temperature - 273.15) / (temperature - 29.65)
+    )
 
 
 @exporter.export
@@ -1059,7 +1065,7 @@ def dewpoint_from_relative_humidity(temperature, relative_humidity):
 
 @exporter.export
 @preprocess_and_wrap(wrap_like='vapor_pressure')
-@check_units('[pressure]')
+@process_units({'vapor_pressure': '[pressure]'}, '[temperature]', output_to=units.degC)
 def dewpoint(vapor_pressure):
     r"""Calculate the ambient dewpoint given the vapor pressure.
 
@@ -1089,15 +1095,22 @@ def dewpoint(vapor_pressure):
        Renamed ``e`` parameter to ``vapor_pressure``
 
     """
-    val = np.log(vapor_pressure / sat_pressure_0c)
-    return (units.Quantity(0., 'degC')
-            + units.Quantity(243.5, 'delta_degC') * val / (17.67 - val))
+    val = np.log(vapor_pressure / mpconsts.nounit.sat_pressure_0c)
+    return mpconsts.nounit.zero_degC + 243.5 * val / (17.67 - val)
 
 
 @exporter.export
 @preprocess_and_wrap(wrap_like='partial_press', broadcast=('partial_press', 'total_press'))
-@check_units('[pressure]', '[pressure]', '[dimensionless]')
-def mixing_ratio(partial_press, total_press, molecular_weight_ratio=mpconsts.epsilon):
+@process_units(
+    {
+        'partial_press': '[pressure]',
+        'total_press': '[pressure]',
+        'molecular_weight_ratio': '[dimensionless]'
+    },
+    '[dimensionless]',
+    ignore_inputs_for_output=('molecular_weight_ratio',)
+)
+def mixing_ratio(partial_press, total_press, molecular_weight_ratio=mpconsts.nounit.epsilon):
     r"""Calculate the mixing ratio of a gas.
 
     This calculates mixing ratio given its partial pressure and the total pressure of
@@ -1137,13 +1150,15 @@ def mixing_ratio(partial_press, total_press, molecular_weight_ratio=mpconsts.eps
        Renamed ``part_press``, ``tot_press`` parameters to ``partial_press``, ``total_press``
 
     """
-    return (molecular_weight_ratio * partial_press
-            / (total_press - partial_press)).to('dimensionless')
+    return molecular_weight_ratio * partial_press / (total_press - partial_press)
 
 
 @exporter.export
 @preprocess_and_wrap(wrap_like='temperature', broadcast=('total_press', 'temperature'))
-@check_units('[pressure]', '[temperature]')
+@process_units(
+    {'total_press': '[pressure]', 'temperature': '[temperature]'},
+    '[dimensionless]'
+)
 def saturation_mixing_ratio(total_press, temperature):
     r"""Calculate the saturation mixing ratio of water vapor.
 
@@ -1173,7 +1188,7 @@ def saturation_mixing_ratio(total_press, temperature):
        Renamed ``tot_press`` parameter to ``total_press``
 
     """
-    return mixing_ratio(saturation_vapor_pressure(temperature), total_press)
+    return mixing_ratio._nounit(saturation_vapor_pressure._nounit(temperature), total_press)
 
 
 @exporter.export

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -1095,7 +1095,7 @@ def dewpoint(vapor_pressure):
 
     """
     val = np.log(vapor_pressure / mpconsts.nounit.sat_pressure_0c)
-    return mpconsts.nounit.zero_degC + 243.5 * val / (17.67 - val)
+    return mpconsts.nounit.zero_degc + 243.5 * val / (17.67 - val)
 
 
 @exporter.export
@@ -2762,7 +2762,7 @@ def thickness_hydrostatic(pressure, temperature, mixing_ratio=None,
             # Note: get_layer works on *args and has arguments that make the function behave
             # differently depending on units, making a unit-free version nontrivial. For now,
             # since optimized path doesn't use this conditional branch at all, we can safely
-            # sacrafice performance by reattaching and restripping units to use unit-aware
+            # sacrifice performance by reattaching and restripping units to use unit-aware
             # get_layer
             layer_p, layer_virttemp = get_layer(
                 units.Quantity(pressure, 'Pa'),

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -305,7 +305,7 @@ def moist_lapse(pressure, temperature, reference_pressure=None):
             (mpconsts.nounit.Rd * t + mpconsts.nounit.Lv * rs)
             / (mpconsts.nounit.Cp_d + (
                 mpconsts.nounit.Lv * mpconsts.nounit.Lv * rs * mpconsts.nounit.epsilon
-                / (mpconsts.nounit.Rd * t * t)
+                / (mpconsts.nounit.Rd * t**2)
             ))
         )
         return frac / p

--- a/src/metpy/constants/__init__.py
+++ b/src/metpy/constants/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008,2015,2016,2018 MetPy Developers.
+# Copyright (c) 2008,2015,2016,2018,2021 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 
@@ -70,59 +70,10 @@ molecular_weight_ratio   :math:`\epsilon`  epsilon     :math:`\text{None}`      
 .. [8] [Picard2008]_
 """  # noqa: E501
 
-from .package_tools import Exporter
-from .units import units
+from . import nounit
+from .default import *  # noqa: F403
+from ..package_tools import set_module
 
-exporter = Exporter(globals())
+__all__ = default.__all__[:]  # pylint: disable=undefined-variable
 
-# Export all the variables defined in this block
-with exporter:
-    # Earth
-    earth_gravity = g = units.Quantity(9.80665, 'm / s^2')
-    Re = earth_avg_radius = units.Quantity(6371008.7714, 'm')
-    G = gravitational_constant = units.Quantity(6.67430e-11, 'm^3 / kg / s^2')
-    GM = geocentric_gravitational_constant = units.Quantity(3986005e8, 'm^3 / s^2')
-    omega = earth_avg_angular_vel = units.Quantity(7292115e-11, 'rad / s')
-    d = earth_sfc_avg_dist_sun = units.Quantity(149597870700., 'm')
-    S = earth_solar_irradiance = units.Quantity(1360.8, 'W / m^2')
-    delta = earth_max_declination = units.Quantity(23.45, 'degrees')
-    earth_orbit_eccentricity = units.Quantity(0.0167, 'dimensionless')
-    earth_mass = me = geocentric_gravitational_constant / gravitational_constant
-
-    # molar gas constant
-    R = units.Quantity(8.314462618, 'J / mol / K')
-
-    # Water
-    Mw = water_molecular_weight = units.Quantity(18.015268, 'g / mol')
-    Rv = water_gas_constant = R / Mw
-    rho_l = density_water = units.Quantity(999.97495, 'kg / m^3')
-    wv_specific_heat_ratio = units.Quantity(1.330, 'dimensionless')
-    Cp_v = wv_specific_heat_press = (
-        wv_specific_heat_ratio * Rv / (wv_specific_heat_ratio - 1)
-    )
-    Cv_v = wv_specific_heat_vol = Cp_v / wv_specific_heat_ratio
-    Cp_l = water_specific_heat = units.Quantity(4.2194, 'kJ / kg / K')
-    Lv = water_heat_vaporization = units.Quantity(2.50084e6, 'J / kg')
-    Lf = water_heat_fusion = units.Quantity(3.337e5, 'J / kg')
-    Cp_i = ice_specific_heat = units.Quantity(2090, 'J / kg / K')
-    rho_i = density_ice = units.Quantity(917, 'kg / m^3')
-
-    # Dry air
-    Md = dry_air_molecular_weight = units.Quantity(28.96546e-3, 'kg / mol')
-    Rd = dry_air_gas_constant = R / Md
-    dry_air_spec_heat_ratio = units.Quantity(1.4, 'dimensionless')
-    Cp_d = dry_air_spec_heat_press = (
-        dry_air_spec_heat_ratio * Rd / (dry_air_spec_heat_ratio - 1)
-    )
-    Cv_d = dry_air_spec_heat_vol = Cp_d / dry_air_spec_heat_ratio
-    rho_d = dry_air_density_stp = (
-        units.Quantity(1000., 'mbar') / (Rd * units.Quantity(273.15, 'K'))
-    ).to('kg / m^3')
-
-    # General meteorology constants
-    P0 = pot_temp_ref_press = units.Quantity(1000., 'mbar')
-    kappa = poisson_exponent = (Rd / Cp_d).to('dimensionless')
-    gamma_d = dry_adiabatic_lapse_rate = g / Cp_d
-    epsilon = molecular_weight_ratio = (Mw / Md).to('dimensionless')
-
-del Exporter
+set_module(globals())

--- a/src/metpy/constants/__init__.py
+++ b/src/metpy/constants/__init__.py
@@ -70,7 +70,7 @@ molecular_weight_ratio   :math:`\epsilon`  epsilon     :math:`\text{None}`      
 .. [8] [Picard2008]_
 """  # noqa: E501
 
-from . import nounit
+from . import nounit  # noqa: F401
 from .default import *  # noqa: F403
 from ..package_tools import set_module
 

--- a/src/metpy/constants/default.py
+++ b/src/metpy/constants/default.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2008,2015,2016,2018,2021 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Constant and thermophysical property values expressed as quantities."""
+
+from ..package_tools import Exporter
+from ..units import units
+
+exporter = Exporter(globals())
+
+# Export all the variables defined in this block
+with exporter:
+    # Earth
+    earth_gravity = g = units.Quantity(9.80665, 'm / s^2')
+    Re = earth_avg_radius = units.Quantity(6371008.7714, 'm')
+    G = gravitational_constant = units.Quantity(6.67430e-11, 'm^3 / kg / s^2')
+    GM = geocentric_gravitational_constant = units.Quantity(3986005e8, 'm^3 / s^2')
+    omega = earth_avg_angular_vel = units.Quantity(7292115e-11, 'rad / s')
+    d = earth_sfc_avg_dist_sun = units.Quantity(149597870700., 'm')
+    S = earth_solar_irradiance = units.Quantity(1360.8, 'W / m^2')
+    delta = earth_max_declination = units.Quantity(23.45, 'degrees')
+    earth_orbit_eccentricity = units.Quantity(0.0167, 'dimensionless')
+    earth_mass = me = geocentric_gravitational_constant / gravitational_constant
+
+    # molar gas constant
+    R = units.Quantity(8.314462618, 'J / mol / K')
+
+    # Water
+    Mw = water_molecular_weight = units.Quantity(18.015268, 'g / mol')
+    Rv = water_gas_constant = R / Mw
+    rho_l = density_water = units.Quantity(999.97495, 'kg / m^3')
+    wv_specific_heat_ratio = units.Quantity(1.330, 'dimensionless')
+    Cp_v = wv_specific_heat_press = (
+        wv_specific_heat_ratio * Rv / (wv_specific_heat_ratio - 1)
+    )
+    Cv_v = wv_specific_heat_vol = Cp_v / wv_specific_heat_ratio
+    Cp_l = water_specific_heat = units.Quantity(4.2194, 'kJ / kg / K')
+    Lv = water_heat_vaporization = units.Quantity(2.50084e6, 'J / kg')
+    Lf = water_heat_fusion = units.Quantity(3.337e5, 'J / kg')
+    Cp_i = ice_specific_heat = units.Quantity(2090, 'J / kg / K')
+    rho_i = density_ice = units.Quantity(917, 'kg / m^3')
+    sat_pressure_0c = units.Quantity(6.112, 'millibar')
+
+    # Dry air
+    Md = dry_air_molecular_weight = units.Quantity(28.96546e-3, 'kg / mol')
+    Rd = dry_air_gas_constant = R / Md
+    dry_air_spec_heat_ratio = units.Quantity(1.4, 'dimensionless')
+    Cp_d = dry_air_spec_heat_press = (
+        dry_air_spec_heat_ratio * Rd / (dry_air_spec_heat_ratio - 1)
+    )
+    Cv_d = dry_air_spec_heat_vol = Cp_d / dry_air_spec_heat_ratio
+    rho_d = dry_air_density_stp = (
+        units.Quantity(1000., 'mbar') / (Rd * units.Quantity(273.15, 'K'))
+    ).to('kg / m^3')
+
+    # General meteorology constants
+    P0 = pot_temp_ref_press = units.Quantity(1000., 'mbar')
+    kappa = poisson_exponent = (Rd / Cp_d).to('dimensionless')
+    gamma_d = dry_adiabatic_lapse_rate = g / Cp_d
+    epsilon = molecular_weight_ratio = (Mw / Md).to('dimensionless')
+
+del Exporter

--- a/src/metpy/constants/nounit.py
+++ b/src/metpy/constants/nounit.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2021 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Subset of constant and thermophysical property values expressed as floats in base units."""
+
+from . import default
+from ..units import units
+
+Rd = default.Rd.m_as('m**2 / K / s**2')
+Lv = default.Lv.m_as('m**2 / s**2')
+Cp_d = default.Cp_d.m_as('m**2 / K / s**2')
+zero_degC = units.Quantity(0., 'degC').m_as('K')
+sat_pressure_0c = default.sat_pressure_0c.m_as('Pa')
+epsilon = default.epsilon.m_as('')
+kappa = default.kappa.m_as('')
+g = default.g.m_as('m / s**2')

--- a/src/metpy/constants/nounit.py
+++ b/src/metpy/constants/nounit.py
@@ -9,7 +9,7 @@ from ..units import units
 Rd = default.Rd.m_as('m**2 / K / s**2')
 Lv = default.Lv.m_as('m**2 / s**2')
 Cp_d = default.Cp_d.m_as('m**2 / K / s**2')
-zero_degC = units.Quantity(0., 'degC').m_as('K')
+zero_degc = units.Quantity(0., 'degC').m_as('K')
 sat_pressure_0c = default.sat_pressure_0c.m_as('Pa')
 epsilon = default.epsilon.m_as('')
 kappa = default.kappa.m_as('')

--- a/src/metpy/io/gempak.py
+++ b/src/metpy/io/gempak.py
@@ -171,7 +171,7 @@ Surface = namedtuple('Surface', [
 
 def convert_degc_to_k(val, missing=-9999):
     """Convert scalar values from degC to K, handling missing values."""
-    return val + constants.nounit.zero_degC if val != missing else val
+    return val + constants.nounit.zero_degc if val != missing else val
 
 
 def _data_source(source):

--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -328,7 +328,11 @@ def process_units(
                                 or name not in ignore_inputs_for_output
                             )
                         ):
-                            convert_to = bound_args.arguments[name].units
+                            try:
+                                convert_to = bound_args.arguments[name].units
+                            except AttributeError:
+                                # We don't have units, so given prior check, is dimensionless
+                                convert_to = ''
                             break
 
                 output_control.append((_base_unit_of_dimensionality[output], convert_to))

--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -246,7 +246,7 @@ def _check_units_outer_helper(func, *args, **kwargs):
 
 
 def _check_units_inner_helper(func, sig, defaults, dims, *args, **kwargs):
-    """Check bound arguments for unit correctness"""
+    """Check bound arguments for unit correctness."""
     # Match all passed in value to their proper arguments so we can check units
     bound_args = sig.bind(*args, **kwargs)
     bad = list(_check_argument_units(bound_args.arguments, defaults, dims))

--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -28,7 +28,7 @@ from pyproj import CRS, Proj
 import xarray as xr
 
 from ._vendor.xarray import either_dict_or_kwargs, expanded_indexer, is_dict_like
-from .units import DimensionalityError, UndefinedUnitError, units
+from .units import _mutate_arguments, DimensionalityError, UndefinedUnitError, units
 
 __all__ = ('MetPyDataArrayAccessor', 'MetPyDatasetAccessor', 'grid_deltas_from_dataarray')
 metpy_axes = ['time', 'vertical', 'y', 'latitude', 'x', 'longitude']
@@ -1244,22 +1244,6 @@ def preprocess_and_wrap(broadcast=None, wrap_like=None, match_unit=False, to_mag
                     return wrapping(result, match)
         return wrapper
     return decorator
-
-
-def _mutate_arguments(bound_args, check_type, mutate_arg):
-    """Handle adjusting bound arguments.
-
-    Calls ``mutate_arg`` on every argument, including those passed as ``*args``, if they are
-    of type ``check_type``.
-    """
-    for arg_name, arg_val in bound_args.arguments.items():
-        if isinstance(arg_val, check_type):
-            bound_args.arguments[arg_name] = mutate_arg(arg_val, arg_name)
-
-    if isinstance(bound_args.arguments.get('args'), tuple):
-        bound_args.arguments['args'] = tuple(
-            mutate_arg(arg_val, '(unnamed)') if isinstance(arg_val, check_type) else arg_val
-            for arg_val in bound_args.arguments['args'])
 
 
 def _wrap_output_like_matching_units(result, match):


### PR DESCRIPTION
#### Description Of Changes

I noticed that there have been two major performance bottlenecks caused by the existing approaches to unit handling: iteration in `moist_lapse`/`lcl` (#1169) and looping of `thickness_hydrostatic` in `io.gempak`'s `_interp_*` functions (#2062). In an attempt to improve this situation, this PR takes the approach of refactoring the relevant thermo calculations to have private versions that only use base units (no `pint.Quantity` handling), and wrapping those while handling units. No robust benchmarks were evaluated, but this did speed up `pytest tests/calc/test_thermo.py` on my workstation from about 3.5 seconds to 0.69 seconds (similar to #1980), and @akrherz's test file in https://github.com/Unidata/MetPy/issues/2041#issuecomment-904920081 from 35.88 seconds to 1.78 seconds.

I tried to be careful to not touch any tests in this refactor (other than the fix to the flake8 checker), but do let me know if any tests should be added.

Future work building on this PR could examine if all/most of the calculations should be refactored in this way (which may also reveal some cleaner implementation approaches) and if numba `jit`/`guvectorize` could meaningfully accelerate any of these private routines.

@sgdecker, could you evaluate how much performance improvement this gives you relative to your earlier tests in #2062?

@nawendt, these changes caused some failing tests in the GEMPAK reader due to what looks to be marginally different output values. Would you be willing to take a look and see if these differences are significant or not?

#### Checklist

- [x] Closes #1169, closes #2062
- [ ] Tests added
- [ ] Fully documented
