### PR TITLE
Add argument name check in preprocess_and_wrap, and fix dewpoint_from_specific_humidity

### DIFF
--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -3053,7 +3053,7 @@ def static_stability(pressure, temperature, vertical_dim=0):
 @exporter.export
 @preprocess_and_wrap(
     wrap_like='temperature',
-    broadcast=('pressure', 'temperature', 'specific_humdiity')
+    broadcast=('pressure', 'temperature', 'specific_humidity')
 )
 @check_units('[pressure]', '[temperature]', '[dimensionless]')
 def dewpoint_from_specific_humidity(pressure, temperature, specific_humidity):

--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -1170,9 +1170,18 @@ def preprocess_and_wrap(broadcast=None, wrap_like=None, match_unit=False, to_mag
         xarray arguments to Quantity, and do not change other array-like arguments.
     """
     def decorator(func):
+        sig = signature(func)
+        if broadcast is not None:
+            for arg_name in broadcast:
+                if arg_name not in sig.parameters:
+                    raise ValueError(
+                        f'Cannot broadcast argument {arg_name} as it is not in function '
+                        'signature'
+                    )
+
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            bound_args = signature(func).bind(*args, **kwargs)
+            bound_args = sig.bind(*args, **kwargs)
 
             # Auto-broadcast select xarray arguments, and update bound_args
             if broadcast is not None:

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -1298,6 +1298,14 @@ def test_preprocess_and_wrap_with_broadcasting():
     assert_array_equal(func(data, data2), [[0, 1, 2], [0, 0, 0], [0, 0, 0]] * units('N m'))
 
 
+def test_preprocess_and_wrap_broadcasting_error():
+    """Test that decorator with bad arguments specified to broadcast errors out."""
+    with pytest.raises(ValueError):
+        @preprocess_and_wrap(broadcast=('a', 'c'))
+        def func(a, b):
+            """Test a mismatch between arguments in signature and decorator."""
+
+
 def test_preprocess_and_wrap_with_to_magnitude():
     """Test preprocessing and wrapping with casting to magnitude."""
     data = xr.DataArray([1, 0, 1] * units.m)


### PR DESCRIPTION
#### Description Of Changes

Implements the argument name check suggested in #2069, and fixes the spelling error in the decorator on `dewpoint_from_specific_humidity`.

I'm marking this as closing #2069, but if the intent for #2069 was broader than just this particular function's issue, then I'll edit that out. Also, not sure where to log the suggestion to "audit" all the decorator usage for broadcasting order and the like.

#### Checklist

- [x] Closes #2069 
- [x] Tests added
- ~~Fully documented~~
