### PR TITLE
Add wind gusts to parsed METAR output

### DIFF
--- a/src/metpy/io/_metar_parser/metar_parser.peg
+++ b/src/metpy/io/_metar_parser/metar_parser.peg
@@ -5,10 +5,10 @@ sep      <- " "+
 siteid   <- sep? [0-9A-Z] [0-9A-Z] [0-9A-Z] [0-9A-Z]
 datetime <- sep [\d]+ "Z"
 auto     <- ((sep ("AUTO" / "COR"))+)?
-wind     <- ((sep? wind_dir wind_spd (gust)? ("KT" / "MPS") varwind?))?
+wind     <- ((sep? wind_dir wind_spd gust ("KT" / "MPS") varwind?))?
 wind_dir <- (([\d] [\d] [\d]) / 'VAR' / 'VRB' / "///")?
 wind_spd <- (([\d] [\d] [\d]?) / "//")?
-gust     <- "G" [\d]+
+gust     <- ("G" [\d]+)?
 varwind  <- sep [\d] [\d] [\d] "V" [\d] [\d] [\d]
 vis      <- ((sep ( ([\d] [\d] [\d] [\d] ("NDV")?) / ([\d] ([\d] / ((" " [\d])? "/" [\d]))? "SM") / ("M" [\d] "/" [\d] "SM") / "CAVOK" / "////") varvis?))?
 varvis   <- sep [\d] [\d] [\d] [\d] [NSEW]? [NSEW]?

--- a/src/metpy/io/_metar_parser/metar_parser.py
+++ b/src/metpy/io/_metar_parser/metar_parser.py
@@ -51,6 +51,7 @@ class TreeNode4(TreeNode):
         super(TreeNode4, self).__init__(text, offset, elements)
         self.wind_dir = elements[1]
         self.wind_spd = elements[2]
+        self.gust = elements[3]
 
 
 class TreeNode5(TreeNode):
@@ -679,15 +680,11 @@ class Grammar(object):
                 if address3 is not FAILURE:
                     elements0.append(address3)
                     address4 = FAILURE
-                    index4 = self._offset
                     address4 = self._read_gust()
-                    if address4 is FAILURE:
-                        address4 = TreeNode(self._input[index4:index4], index4, [])
-                        self._offset = index4
                     if address4 is not FAILURE:
                         elements0.append(address4)
                         address5 = FAILURE
-                        index5 = self._offset
+                        index4 = self._offset
                         chunk0, max0 = None, self._offset + 2
                         if max0 <= self._input_size:
                             chunk0 = self._input[self._offset:max0]
@@ -702,7 +699,7 @@ class Grammar(object):
                             if self._offset == self._failure:
                                 self._expected.append('"KT"')
                         if address5 is FAILURE:
-                            self._offset = index5
+                            self._offset = index4
                             chunk1, max1 = None, self._offset + 3
                             if max1 <= self._input_size:
                                 chunk1 = self._input[self._offset:max1]
@@ -717,15 +714,15 @@ class Grammar(object):
                                 if self._offset == self._failure:
                                     self._expected.append('"MPS"')
                             if address5 is FAILURE:
-                                self._offset = index5
+                                self._offset = index4
                         if address5 is not FAILURE:
                             elements0.append(address5)
                             address6 = FAILURE
-                            index6 = self._offset
+                            index5 = self._offset
                             address6 = self._read_varwind()
                             if address6 is FAILURE:
-                                address6 = TreeNode(self._input[index6:index6], index6, [])
-                                self._offset = index6
+                                address6 = TreeNode(self._input[index5:index5], index5, [])
+                                self._offset = index5
                             if address6 is not FAILURE:
                                 elements0.append(address6)
                             else:
@@ -985,7 +982,8 @@ class Grammar(object):
         if cached:
             self._offset = cached[1]
             return cached[0]
-        index1, elements0 = self._offset, []
+        index1 = self._offset
+        index2, elements0 = self._offset, []
         address1 = FAILURE
         chunk0, max0 = None, self._offset + 1
         if max0 <= self._input_size:
@@ -1003,7 +1001,7 @@ class Grammar(object):
         if address1 is not FAILURE:
             elements0.append(address1)
             address2 = FAILURE
-            remaining0, index2, elements1, address3 = 1, self._offset, [], True
+            remaining0, index3, elements1, address3 = 1, self._offset, [], True
             while address3 is not FAILURE:
                 chunk1, max1 = None, self._offset + 1
                 if max1 <= self._input_size:
@@ -1022,7 +1020,7 @@ class Grammar(object):
                     elements1.append(address3)
                     remaining0 -= 1
             if remaining0 <= 0:
-                address2 = TreeNode(self._input[index2:self._offset], index2, elements1)
+                address2 = TreeNode(self._input[index3:self._offset], index3, elements1)
                 self._offset = self._offset
             else:
                 address2 = FAILURE
@@ -1030,15 +1028,18 @@ class Grammar(object):
                 elements0.append(address2)
             else:
                 elements0 = None
-                self._offset = index1
+                self._offset = index2
         else:
             elements0 = None
-            self._offset = index1
+            self._offset = index2
         if elements0 is None:
             address0 = FAILURE
         else:
-            address0 = TreeNode(self._input[index1:self._offset], index1, elements0)
+            address0 = TreeNode(self._input[index2:self._offset], index2, elements0)
             self._offset = self._offset
+        if address0 is FAILURE:
+            address0 = TreeNode(self._input[index1:index1], index1, [])
+            self._offset = index1
         self._cache['gust'][index0] = (address0, self._offset)
         return address0
 

--- a/tests/io/test_metar.py
+++ b/tests/io/test_metar.py
@@ -17,165 +17,166 @@ from metpy.units import units
 @pytest.mark.parametrize(['metar', 'truth'], [
     # Missing station
     ('METAR KLBG 261155Z AUTO 00000KT 10SM CLR 05/00 A3001 RMK AO2=',
-     Metar('KLBG', np.nan, np.nan, np.nan, datetime(2017, 5, 26, 11, 55), 0, 0, 16093.44,
-           np.nan, np.nan, np.nan, 'CLR', np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-           np.nan, 0, 5, 0, 30.01, 0, 0, 0, 'AO2')),
+     Metar('KLBG', np.nan, np.nan, np.nan, datetime(2017, 5, 26, 11, 55), 0, 0, np.nan,
+           16093.44, np.nan, np.nan, np.nan, 'CLR', np.nan, np.nan, np.nan, np.nan, np.nan,
+           np.nan, np.nan, 0, 5, 0, 30.01, 0, 0, 0, 'AO2')),
     # Broken clouds
     ('METAR KLOT 261155Z AUTO 00000KT 10SM BKN100 05/00 A3001 RMK AO2=',
-     Metar('KLOT', 41.6, -88.1, 205, datetime(2017, 5, 26, 11, 55), 0, 0, 16093.44, np.nan,
-           np.nan, np.nan, 'BKN', 10000, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 6, 5,
-           0, 30.01, 0, 0, 0, 'AO2')),
+     Metar('KLOT', 41.6, -88.1, 205, datetime(2017, 5, 26, 11, 55), 0, 0, np.nan, 16093.44,
+           np.nan, np.nan, np.nan, 'BKN', 10000, np.nan, np.nan, np.nan, np.nan, np.nan,
+           np.nan, 6, 5, 0, 30.01, 0, 0, 0, 'AO2')),
     # Few clouds, bad time and winds
     ('METAR KMKE 266155Z AUTO /////KT 10SM FEW100 05/00 A3001 RMK AO2=',
-     Metar('KMKE', 42.95, -87.9, 206, np.nan, np.nan, np.nan, 16093.44,
-           np.nan, np.nan, np.nan, 'FEW', 10000, np.nan, np.nan, np.nan, np.nan, np.nan,
-           np.nan, 2, 5, 0, 30.01, 0, 0, 0, 'AO2')),
+     Metar('KMKE', 42.95, -87.9, 206, np.nan, np.nan, np.nan, np.nan, 16093.44, np.nan, np.nan,
+           np.nan, 'FEW', 10000, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 2, 5, 0,
+           30.01, 0, 0, 0, 'AO2')),
     # Many weather and cloud slots taken
     ('METAR RJOI 261155Z 00000KT 4000 -SHRA BR VCSH BKN009 BKN015 OVC030 OVC040 22/21 A2987 '
      'RMK SHRAB35E44 SLP114 VCSH S-NW P0000 60021 70021 T02220206 10256 20211 55000=',
-     Metar('RJOI', 34.13, 132.22, 2, datetime(2017, 5, 26, 11, 55), 0, 0, 4000, '-SHRA', 'BR',
-           'VCSH', 'BKN', 900, 'BKN', 1500, 'OVC', 3000, 'OVC', 4000, 8, 22, 21, 29.87, 80, 10,
-           16, 'SHRAB35E44 SLP114 VCSH S-NW P0000 60021 70021 T02220206 10256 20211 55000')),
+     Metar('RJOI', 34.13, 132.22, 2, datetime(2017, 5, 26, 11, 55), 0, 0, np.nan, 4000,
+           '-SHRA', 'BR', 'VCSH', 'BKN', 900, 'BKN', 1500, 'OVC', 3000, 'OVC', 4000, 8, 22, 21,
+           29.87, 80, 10, 16,
+           'SHRAB35E44 SLP114 VCSH S-NW P0000 60021 70021 T02220206 10256 20211 55000')),
     # Smoke for current weather
     ('KFLG 252353Z AUTO 27005KT 10SM FU BKN036 BKN085 22/03 A3018 RMK AO2 SLP130 T02220033 '
      '10250 20217 55007=',
-     Metar('KFLG', 35.13, -111.67, 2134, datetime(2017, 5, 25, 23, 53), 270, 5, 16093.44, 'FU',
-           np.nan, np.nan, 'BKN', 3600, 'BKN', 8500, np.nan, np.nan, np.nan, np.nan, 6, 22, 3,
-           30.18, 4, 0, 0, 'AO2 SLP130 T02220033 10250 20217 55007')),
+     Metar('KFLG', 35.13, -111.67, 2134, datetime(2017, 5, 25, 23, 53), 270, 5, np.nan,
+           16093.44, 'FU', np.nan, np.nan, 'BKN', 3600, 'BKN', 8500, np.nan, np.nan, np.nan,
+           np.nan, 6, 22, 3, 30.18, 4, 0, 0, 'AO2 SLP130 T02220033 10250 20217 55007')),
     # CAVOK for visibility group
     ('METAR OBBI 011200Z 33012KT CAVOK 40/18 Q0997 NOSIG=',
-     Metar('OBBI', 26.27, 50.63, 2, datetime(2017, 5, 1, 12, 00), 330, 12, 10000, np.nan,
-           np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 0,
-           40, 18, units.Quantity(997, 'hPa').m_as('inHg'), 0, 0, 0, 'NOSIG')),
+     Metar('OBBI', 26.27, 50.63, 2, datetime(2017, 5, 1, 12, 00), 330, 12, np.nan, 10000,
+           np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+           np.nan, 0, 40, 18, units.Quantity(997, 'hPa').m_as('inHg'), 0, 0, 0, 'NOSIG')),
     # Visibility using a mixed fraction
     ('K2I0 011155Z AUTO 05004KT 1 3/4SM BR SCT001 22/22 A3009 RMK AO2 70001 T02210221 10223 '
      '20208=',
-     Metar('K2I0', 37.35, -87.4, 134, datetime(2017, 5, 1, 11, 55), 50, 4, 2816.352, 'BR',
-           np.nan, np.nan, 'SCT', 100, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 4,
+     Metar('K2I0', 37.35, -87.4, 134, datetime(2017, 5, 1, 11, 55), 50, 4, np.nan, 2816.352,
+           'BR', np.nan, np.nan, 'SCT', 100, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 4,
            22, 22, 30.09, 10, 0, 0, 'AO2 70001 T02210221 10223 20208')),
     # Missing temperature
     ('KIOW 011152Z AUTO A3006 RMK AO2 SLPNO 70020 51013 PWINO=',
      Metar('KIOW', 41.63, -91.55, 198, datetime(2017, 5, 1, 11, 52), np.nan, np.nan, np.nan,
            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-           np.nan, 10, np.nan, np.nan, 30.06, 0, 0, 0, 'AO2 SLPNO 70020 51013 PWINO')),
+           np.nan, np.nan, 10, np.nan, np.nan, 30.06, 0, 0, 0, 'AO2 SLPNO 70020 51013 PWINO')),
     # Missing data
     ('METAR KBOU 011152Z AUTO 02006KT //// // ////// 42/02 Q1004=',
-     Metar('KBOU', 40., -105.33, 1625, datetime(2017, 5, 1, 11, 52), 20, 6, np.nan,
+     Metar('KBOU', 40., -105.33, 1625, datetime(2017, 5, 1, 11, 52), 20, 6, np.nan, np.nan,
            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
            np.nan, 10, 42, 2, units.Quantity(1004, 'hPa').m_as('inHg'), 0, 0, 0, '')),
     # Vertical visibility
     ('KSLK 011151Z AUTO 21005KT 1/4SM FG VV002 14/13 A1013 RMK AO2 SLP151 70043 T01390133 '
      '10139 20094 53002=',
-     Metar('KSLK', 44.4, -74.2, 498, datetime(2017, 5, 1, 11, 51), 210, 5, 402.336, 'FG',
-           np.nan, np.nan, 'VV', 200, np.nan, np.nan, np.nan, np.nan, np.nan,
-           np.nan, 8, 14, 13, units.Quantity(1013, 'hPa').m_as('inHg'), 45, 0, 0,
+     Metar('KSLK', 44.4, -74.2, 498, datetime(2017, 5, 1, 11, 51), 210, 5, np.nan, 402.336,
+           'FG', np.nan, np.nan, 'VV', 200, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 8,
+           14, 13, units.Quantity(1013, 'hPa').m_as('inHg'), 45, 0, 0,
            'AO2 SLP151 70043 T01390133 10139 20094 53002')),
     # Missing vertical visibility height
     ('SLCP 011200Z 18008KT 0100 FG VV/// 19/19 Q1019=',
-     Metar('SLCP', -16.14, -62.02, 497, datetime(2017, 5, 1, 12, 00), 180, 8, 100, 'FG',
-           np.nan, np.nan, 'VV', np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 8, 19,
-           19, units.Quantity(1019, 'hPa').m_as('inHg'), 45, 0, 0, '')),
+     Metar('SLCP', -16.14, -62.02, 497, datetime(2017, 5, 1, 12, 00), 180, 8, np.nan, 100,
+           'FG', np.nan, np.nan, 'VV', np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+           8, 19, 19, units.Quantity(1019, 'hPa').m_as('inHg'), 45, 0, 0, '')),
     # BCFG current weather; also visibility is encoding 80SM which we're not adjusting
     ('METAR KMWN 011249Z 36037G45KT 80SM BCFG BKN/// FEW000 07/05 RMK BCFG FEW000 TPS LWR '
      'BKN037 BCFG INTMT=',
-     Metar('KMWN', 44.27, -71.3, 1910, datetime(2017, 5, 1, 12, 49), 360, 37,
+     Metar('KMWN', 44.27, -71.3, 1910, datetime(2017, 5, 1, 12, 49), 360, 37, 45,
            units.Quantity(80, 'mi').m_as('m'), 'BCFG', np.nan, np.nan, 'BKN', np.nan,
            'FEW', 0, np.nan, np.nan, np.nan, np.nan, 6, 7, 5, np.nan, 41, 0, 0,
            'BCFG FEW000 TPS LWR BKN037 BCFG INTMT')),
     # -DZ current weather
     ('KULM 011215Z AUTO 22003KT 10SM -DZ CLR 19/19 A3000 RMK AO2=',
-     Metar('KULM', 44.32, -94.5, 308, datetime(2017, 5, 1, 12, 15), 220, 3, 16093.44, '-DZ',
-           np.nan, np.nan, 'CLR', np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 0,
-           19, 19, 30., 51, 0, 0, 'AO2')),
+     Metar('KULM', 44.32, -94.5, 308, datetime(2017, 5, 1, 12, 15), 220, 3, np.nan, 16093.44,
+           '-DZ', np.nan, np.nan, 'CLR', np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+           np.nan, 0, 19, 19, 30., 51, 0, 0, 'AO2')),
     # CB trailing on cloud group
     ('METAR AGGH 011200Z 25003KT 9999 FEW015 FEW017CB BKN030 25/24 Q1011=',
-     Metar('AGGH', -9.42, 160.05, 9, datetime(2017, 5, 1, 12, 00), 250, 3., 9999, np.nan,
-           np.nan, np.nan, 'FEW', 1500, 'FEW', 1700, 'BKN', 3000, np.nan, np.nan, 6, 25,
-           24, units.Quantity(1011, 'hPa').m_as('inHg'), 0, 0, 0, '')),
+     Metar('AGGH', -9.42, 160.05, 9, datetime(2017, 5, 1, 12, 00), 250, 3., np.nan, 9999,
+           np.nan, np.nan, np.nan, 'FEW', 1500, 'FEW', 1700, 'BKN', 3000, np.nan, np.nan, 6,
+           25, 24, units.Quantity(1011, 'hPa').m_as('inHg'), 0, 0, 0, '')),
     # 5 levels of clouds
     ('METAR KSEQ 011158Z AUTO 08003KT 9SM FEW009 BKN020 BKN120 BKN150 OVC180 22/22 A3007 RMK '
      'AO2 RAB12E46RAB56E57 CIG 020V150 BKN020 V FEW SLP179 P0000 60000 70001 52008=',
      Metar('KSEQ', 29.566666666666666, -97.91666666666667, 160, datetime(2017, 5, 1, 11, 58),
-           80, 3., units.Quantity(9, 'miles').m_as('m'), np.nan, np.nan, np.nan, 'FEW', 900.,
-           'BKN', 2000., 'BKN', 12000., 'BKN', 15000., 8, 22., 22., 30.07, 0, 0, 0,
+           80, 3., np.nan, units.Quantity(9, 'miles').m_as('m'), np.nan, np.nan, np.nan, 'FEW',
+           900., 'BKN', 2000., 'BKN', 12000., 'BKN', 15000., 8, 22., 22., 30.07, 0, 0, 0,
            'AO2 RAB12E46RAB56E57 CIG 020V150 BKN020 V FEW SLP179 P0000 60000 70001 52008')),
     # -FZUP
     ('SPECI CBBC 060030Z AUTO 17009G15KT 9SM -FZUP FEW011 SCT019 BKN026 OVC042 02/01 A3004 '
      'RMK ICG INTMT SLP177=',
-     Metar('CBBC', 52.18, -128.15, 43, datetime(2017, 5, 6, 0, 30), 170, 9.,
+     Metar('CBBC', 52.18, -128.15, 43, datetime(2017, 5, 6, 0, 30), 170, 9., 15.,
            units.Quantity(9, 'miles').m_as('m'), '-FZUP', np.nan, np.nan, 'FEW', 1100.,
            'SCT', 1900., 'BKN', 2600., 'OVC', 4200., 8, 2, 1, 30.04, 147, 0, 0,
            'ICG INTMT SLP177')),
     # Weird VV group and +SG
     ('BGGH 060750Z AUTO 36004KT 0100NDV +SG VV001/// 05/05 Q1000',
-     Metar('BGGH', 64.2, -51.68, 70, datetime(2017, 5, 6, 7, 50), 360, 4, 100, '+SG', np.nan,
-           np.nan, 'VV', 100, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 8, 5, 5,
+     Metar('BGGH', 64.2, -51.68, 70, datetime(2017, 5, 6, 7, 50), 360, 4, np.nan, 100, '+SG',
+           np.nan, np.nan, 'VV', 100, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 8, 5, 5,
            units.Quantity(1000, 'hPa').m_as('inHg'), 77, 0, 0, '')),
     # COR at beginning, also wind MPS (m/s)
     ('COR ZLLL 101100Z 13010MPS 5000 -SHRA BLDU FEW033CB BKN046 21/11 Q1014 BECMG TL1240 '
      '04004MPS NSW',
      Metar('ZLLL', 36.52, 103.62, 1947, datetime(2017, 5, 10, 11, 0), 130,
-           units.Quantity(10, 'm/s').m_as('knots'), 5000, '-SHRA', 'BLDU', np.nan, 'FEW',
-           3300, 'BKN', 4600, np.nan, np.nan, np.nan, np.nan, 6, 21, 11,
+           units.Quantity(10, 'm/s').m_as('knots'), np.nan, 5000, '-SHRA', 'BLDU', np.nan,
+           'FEW', 3300, 'BKN', 4600, np.nan, np.nan, np.nan, np.nan, 6, 21, 11,
            units.Quantity(1014, 'hPa').m_as('inHg'), 80, 1007, 0,
            'BECMG TL1240 04004MPS NSW')),
     # M1/4SM vis, -VCTSSN weather
     ('K4BM 020127Z AUTO 04013G24KT 010V080 M1/4SM -VCTSSN OVC002 07/06 A3060 '
      'RMK AO2 LTG DSNT SE THRU SW',
-     Metar('K4BM', 39.04, -105.52, 3438, datetime(2017, 5, 2, 1, 27), 40, 13,
+     Metar('K4BM', 39.04, -105.52, 3438, datetime(2017, 5, 2, 1, 27), 40, 13, 24,
            units.Quantity(0.25, 'mi').m_as('m'), '-VCTSSN', np.nan, np.nan, 'OVC', 200,
            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 8, 7, 6, 30.60, 2095, 0, 0,
            'AO2 LTG DSNT SE THRU SW')),
     # Variable visibility group
     ('ENBS 121620Z 36008KT 9999 3000N VCFG -DZ SCT006 BKN009 12/11 Q1014',
-     Metar('ENBS', 70.62, 29.72, 10, datetime(2017, 5, 12, 16, 20), 360, 8, 9999, 'VCFG',
-           '-DZ', np.nan, 'SCT', 600, 'BKN', 900, np.nan, np.nan, np.nan, np.nan, 6, 12, 11,
-           units.Quantity(1014, 'hPa').m_as('inHg'), 40, 51, 0, '')),
+     Metar('ENBS', 70.62, 29.72, 10, datetime(2017, 5, 12, 16, 20), 360, 8, np.nan, 9999,
+           'VCFG', '-DZ', np.nan, 'SCT', 600, 'BKN', 900, np.nan, np.nan, np.nan, np.nan, 6,
+           12, 11, units.Quantity(1014, 'hPa').m_as('inHg'), 40, 51, 0, '')),
     # More complicated runway visibility
     ('CYYC 030047Z 26008G19KT 170V320 1SM R35L/5500VP6000FT/D R29/P6000FT/D R35R/P6000FT/D '
      '+TSRAGS BR OVC009CB 18/16 A2993 RMK CB8 FRQ LTGIC OVRHD PRESRR SLP127 DENSITY ALT '
      '4800FT',
-     Metar('CYYC', 51.12, -114.02, 1084, datetime(2017, 5, 3, 0, 47), 260, 8,
+     Metar('CYYC', 51.12, -114.02, 1084, datetime(2017, 5, 3, 0, 47), 260, 8, 19,
            units.Quantity(1, 'mi').m_as('m'), '+TSRAGS', 'BR', np.nan, 'OVC', 900, np.nan,
            np.nan, np.nan, np.nan, np.nan, np.nan, 8, 18, 16, 29.93, 99, 10, 0,
            'CB8 FRQ LTGIC OVRHD PRESRR SLP127 DENSITY ALT 4800FT')),
     # Oddly-placed COR
     ('KDMA 110240Z COR AUTO 08039G47KT 1/4SM -TSRA DS FEW008 BKN095 27/19 A2998 RMK AO2 '
      'RAB0159E20DZB20E27DZB27E27RAB35 TSB00E15TSB32 PRESFR SLP106 $ COR 0246',
-     Metar('KDMA', 32.17, -110.87, 824, datetime(2017, 5, 11, 2, 40), 80, 39, 402.336,
+     Metar('KDMA', 32.17, -110.87, 824, datetime(2017, 5, 11, 2, 40), 80, 39, 47, 402.336,
            '-TSRA', 'DS', np.nan, 'FEW', 800, 'BKN', 9500, np.nan, np.nan, np.nan, np.nan,
            6, 27, 19, 29.98, 1095, 31, 0,
            'AO2 RAB0159E20DZB20E27DZB27E27RAB35 TSB00E15TSB32 PRESFR SLP106 $ COR 0246')),
     # Ice crystals (IC) and no dewpoint -- South Pole!
     ('NZSP 052350Z 03009KT 3200 IC BLSN SCT019 M58/ A2874 RMK SKWY WNDS ESTMD CLN AIR 03005KT '
      'ALL WNDS GRID',
-     Metar('NZSP', -89.98, 179.98, 2830, datetime(2017, 5, 5, 23, 50), 30, 9, 3200, 'IC',
-           'BLSN', np.nan, 'SCT', 1900, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 4,
-           -58, np.nan, 28.74, 78, 38, 0, 'SKWY WNDS ESTMD CLN AIR 03005KT ALL WNDS GRID')),
+     Metar('NZSP', -89.98, 179.98, 2830, datetime(2017, 5, 5, 23, 50), 30, 9, np.nan, 3200,
+           'IC', 'BLSN', np.nan, 'SCT', 1900, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+           4, -58, np.nan, 28.74, 78, 38, 0, 'SKWY WNDS ESTMD CLN AIR 03005KT ALL WNDS GRID')),
     # NSW
     ('VEIM 121200Z 09008KT 8000 NSW FEW018 SCT100 28/23 Q1008 BECMG 7000 NSW',
-     Metar('VEIM', 24.77, 93.9, 781, datetime(2017, 5, 12, 12, 0), 90, 8, 8000, np.nan,
+     Metar('VEIM', 24.77, 93.9, 781, datetime(2017, 5, 12, 12, 0), 90, 8, np.nan, 8000, np.nan,
            np.nan, np.nan, 'FEW', 1800, 'SCT', 10000, np.nan, np.nan, np.nan, np.nan, 4,
            28, 23, units.Quantity(1008, 'hPa').m_as('inHg'), 0, 0, 0, 'BECMG 7000 NSW')),
     # Variable vis with no direction
     ('TFFF 111830Z AUTO 11019G30KT 1000 0600 R10/1100D RA BCFG FEW014/// BKN021/// BKN027/// '
      '///CB 27/24 Q1015',
-     Metar('TFFF', 14.6, -61.0, 5, datetime(2017, 5, 11, 18, 30), 110, 19, 1000, 'RA', 'BCFG',
-           np.nan, 'FEW', 1400, 'BKN', 2100, 'BKN', 2700, np.nan, np.nan, 6, 27, 24,
+     Metar('TFFF', 14.6, -61.0, 5, datetime(2017, 5, 11, 18, 30), 110, 19, 30, 1000, 'RA',
+           'BCFG', np.nan, 'FEW', 1400, 'BKN', 2100, 'BKN', 2700, np.nan, np.nan, 6, 27, 24,
            units.Quantity(1015, 'hPa').m_as('inHg'), 63, 41, 0, '')),
     # Interchanged wind and vis groups
     ('KBMI 121456Z COR 10SM 10005KT SCT055 OVC065 23/22 A3000 RMK AO2 '
      'LTG DSNT E AND SE TSB1358E13 SLP150 6//// T02280222 53011=',
-     Metar('KBMI', 40.47, -88.92, 267, datetime(2017, 5, 12, 14, 56), np.nan, np.nan,
+     Metar('KBMI', 40.47, -88.92, 267, datetime(2017, 5, 12, 14, 56), np.nan, np.nan, np.nan,
            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
            np.nan, np.nan, 10, np.nan, np.nan, np.nan, 0, 0, 0,
            '5KT SCT055 OVC065 23/22 A3000 RMK AO2 LTG DSNT E AND SE TSB1358E13 SLP150 6//// '
            'T02280222 53011')),
     # Space between + and wx code
     ('SKCG 031730Z 13004KT 0500 + TSRA BKN010 25/25 Q1012 RMK A2990',
-     Metar('SKCG', 10.43, -75.52, 1, datetime(2017, 5, 3, 17, 30), 130, 4, 500, '+TSRA',
-           np.nan, np.nan, 'BKN', 1000, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 6,
-           25, 25, units.Quantity(1012, 'hPa').m_as('inHg'), 1097, 0, 0, 'A2990'))],
+     Metar('SKCG', 10.43, -75.52, 1, datetime(2017, 5, 3, 17, 30), 130, 4, np.nan, 500,
+           '+TSRA', np.nan, np.nan, 'BKN', 1000, np.nan, np.nan, np.nan, np.nan, np.nan,
+           np.nan, 6, 25, 25, units.Quantity(1012, 'hPa').m_as('inHg'), 1097, 0, 0, 'A2990'))],
     ids=['missing station', 'BKN', 'FEW', 'current weather', 'smoke', 'CAVOK', 'vis fraction',
          'missing temps', 'missing data', 'vertical vis', 'missing vertical vis', 'BCFG',
          '-DZ', 'sky cover CB', '5 sky levels', '-FZUP', 'VV group', 'COR placement',
@@ -233,6 +234,7 @@ def test_parse_file():
     assert counts.date_time == 8980
     assert counts.wind_direction == 8577
     assert counts.wind_speed == 8844
+    assert counts.wind_gust == 347
     assert counts.visibility == 8486
     assert counts.current_wx1 == 1090
     assert counts.current_wx2 == 82
@@ -295,6 +297,7 @@ def test_parse_file_bad_encoding():
     assert counts.date_time == 8802
     assert counts.wind_direction == 8377
     assert counts.wind_speed == 8673
+    assert counts.wind_gust == 1053
     assert counts.visibility == 8312
     assert counts.current_wx1 == 1412
     assert counts.current_wx2 == 213


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Adds wind gusts, which were already part of the grammar to the parsed output. Had to slightly tweak the grammar so that gust became a labelled node in the tree. Otherwise, it was just a matter of wiring it up to end up in the output. As requested in #2074.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2075
- [x] Tests added
- [x] Fully documented
