### PR TITLE
Add linkchecker to nightly CI run

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -196,12 +196,27 @@ jobs:
         )
         popd
 
+    - name: Enable link checker
+      # Running linkchecker separately so that we avoid problems with vendored LICENSE
+      # files in the build directory
+      if: always()
+      run: |
+        pushd docs
+        find build/html/_static -name LICENSE.md -delete
+        make linkcheck
+        # Make the presence of the output file with content (which could have specific redirects)
+        # fail the build
+        [ ! -s build/linkchecker/output.txt ] || (echo '::set-output name=LOG_AVAILABLE::true' && false)
+        popd
+
     - name: Upload build log
       if: ${{ always() && steps.build.outputs.LOG_AVAILABLE  == 'true' }}
       uses: actions/upload-artifact@v2
       with:
         name: log-nightly-docs-${{ matrix.python-version }}
-        path: build-${{ matrix.python-version }}.log
+        path: |
+          docs/build-${{ matrix.python-version }}.log
+          docs/build/linkchecker/output.txt
         retention-days: 5
 
     - name: Upload docs as artifact
@@ -229,7 +244,7 @@ jobs:
           path: /tmp/workspace/logs
 
       - name: Group logs
-        run: cat /tmp/workspace/logs/log-*/*.log > logs.txt
+        run: cat /tmp/workspace/logs/log-*/*.log /tmp/workspace/logs/log-*/output.txt > logs.txt
 
       - name: Report failures
         uses: actions/github-script@v4.1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This should allow the linkchecker to fail a nightly build and have the `output.txt` file appear in the log in the issue. This also fixes a bug in the workflow where the doc log wasn't being found due to a path issue.

This hits another item in #1843 to reduce CI flakiness. We can then completely remove the linkchecker from PRs (and rely on the CI nightly check), or possibly check any failures in a PR against the git changes. We need to do something because I'm tired of PRs hanging up on this kind of stuff.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Addresses part of #1843
~- [ ] Tests added~
~- [ ] Fully documented~
