### PR TITLE
Fix lifted_index cannot calculate when data at 500 hpa is missing

### DIFF
--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -3257,12 +3257,10 @@ def lifted_index(pressure, temperature, parcel_profile):
         Lifted Index
 
     """
-    # find the index for the 500 hPa pressure level.
-    idx = np.where(pressure == units.Quantity(500, 'hPa'))
-    # find the measured temperature at 500 hPa.
-    t500 = temperature[idx]
-    # find the parcel profile temperature at 500 hPa.
-    tp500 = parcel_profile[idx]
+    # find the measured temperature and parcel profile temperature at 500 hPa.
+    t500, tp500 = interpolate_1d(units.Quantity(500,'hPa'),
+                                 pressure, temperature, parcel_profile)
+
     # calculate the lifted index.
     lifted_index = t500 - tp500.to(units.degC)
     return lifted_index

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -3258,7 +3258,7 @@ def lifted_index(pressure, temperature, parcel_profile):
 
     """
     # find the measured temperature and parcel profile temperature at 500 hPa.
-    t500, tp500 = interpolate_1d(units.Quantity(500,'hPa'),
+    t500, tp500 = interpolate_1d(units.Quantity(500, 'hPa'),
                                  pressure, temperature, parcel_profile)
 
     # calculate the lifted index.

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1871,6 +1871,31 @@ def test_lifted_index():
     assert_almost_equal(li, -7.9176350 * units.delta_degree_Celsius, 2)
 
 
+def test_lifted_index_500hpa_missing():
+    """Test the Lifted Index calculation when data at 500 hpa is missing"""
+    pressure = np.array([1014., 1000., 997., 981.2, 947.4, 925., 914.9, 911.,
+                         902., 883., 850., 822.3, 816., 807., 793.2, 770.,
+                         765.1, 753., 737.5, 737., 713., 700., 688., 685.,
+                         680., 666., 659.8, 653., 643., 634., 615., 611.8,
+                         566.2, 516., 487., 484.2, 481., 475., 460.,
+                         400.]) * units.hPa
+    temperature = np.array([24.2, 24.2, 24., 23.1, 21., 19.6, 18.7, 18.4,
+                            19.2, 19.4, 17.2, 15.3, 14.8, 14.4, 13.4, 11.6,
+                            11.1, 10., 8.8, 8.8, 8.2, 7., 5.6, 5.6,
+                            5.6, 4.4, 3.8, 3.2, 3., 3.2, 1.8, 1.5,
+                            -3.4, -9.3, -13.1, -13.1, -13.1, -13.7, -15.1,
+                            -23.5]) * units.degC
+    dewpoint = np.array([23.2, 23.1, 22.8, 22., 20.2, 19., 17.6, 17.,
+                         16.8, 15.5, 14., 11.7, 11.2, 8.4, 7., 4.6,
+                         5., 6., 4.2, 4.1, -1.8, -2., -1.4, -0.4,
+                         -3.4, -5.6, -4.3, -2.8, -7., -25.8, -31.2, -31.4,
+                         -34.1, -37.3, -34.1, -37.3, -41.1, -37.7, -58.1,
+                         -57.5]) * units.degC
+    parcel_prof = parcel_profile(pressure, temperature[0], dewpoint[0])
+    li = lifted_index(pressure, temperature, parcel_prof)
+    assert_almost_equal(li, -7.9176350 * units.delta_degree_Celsius, 1)
+
+
 def test_k_index():
     """Test the K Index calculation."""
     pressure = np.array([1014., 1000., 997., 981.2, 947.4, 925., 914.9, 911.,

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1872,7 +1872,7 @@ def test_lifted_index():
 
 
 def test_lifted_index_500hpa_missing():
-    """Test the Lifted Index calculation when data at 500 hpa is missing"""
+    """Test the Lifted Index calculation when data at 500 hpa is missing."""
     pressure = np.array([1014., 1000., 997., 981.2, 947.4, 925., 914.9, 911.,
                          902., 883., 850., 822.3, 816., 807., 793.2, 770.,
                          765.1, 753., 737.5, 737., 713., 700., 688., 685.,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Fix lifted_index function error when data at 500 hpa is missing by change np.where to interpolate_1d.
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [ ] Closes #xxxx
- [ X ] Tests added (Re-test already)
- [ X ] Fully documented (Only edit in comment code part)
