### PR TITLE
`CITATION.cff` 1.2.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -63,7 +63,7 @@ references:
         email: "mohan@ucar.edu"
     date-released: 2014-04-01
     institution:
-      - name: "National Science Foundation"
+      name: "National Science Foundation"
     identifiers:
       - description: "NSF award number."
         type: other
@@ -81,7 +81,7 @@ references:
         given-names: John
     date-released: 2017-09-01
     institution:
-      - name: "National Science Foundation"
+      name: "National Science Foundation"
     identifiers:
       - description: "NSF award number."
         type: other
@@ -101,7 +101,7 @@ references:
         given-names: Davide
     date-released: 2017-08-21
     institution:
-      - name: "National Science Foundation"
+      name: "National Science Foundation"
     identifiers:
       - description: "NSF award number."
         type: other
@@ -115,7 +115,7 @@ references:
         email: "mohan@ucar.edu"
     date-released: 2019-05-01
     institution:
-      - name: "National Science Foundation"
+      name: "National Science Foundation"
     identifiers:
       - description: "NSF award number."
         type: other
@@ -133,7 +133,7 @@ references:
         given-names: Michael
     date-released: 2021-05-01
     institution:
-      - name: "National Science Foundation"
+      name: "National Science Foundation"
     identifiers:
       - description: "NSF award number."
         type: other


### PR DESCRIPTION
#### Description Of Changes
Update to [`CITATION.cff` 1.2.0](https://github.com/citation-file-format/citation-file-format/blob/main/CHANGELOG.md) and fix invalid reference name key.

Allows identifier descriptions for our NSF award numbers. Adds root-level `type` key (software vs dataset.) `version` and `date-released` keys are no longer required and so we can remove them altogether if we'd like (I've done so here, let me know if this is preferable), removing the need to update this committed file on-release.

#### Checklist

- [X] Closes #1992
- [X] Fully documented
