### PR TITLE
Validate declarative interface attributes

### DIFF
--- a/src/metpy/plots/declarative.py
+++ b/src/metpy/plots/declarative.py
@@ -534,6 +534,7 @@ class ValidationMixin:
                      'data',
                      'handle',
                      'notify_change',
+                     'panel'
                      ]
 
         allowlist.extend(self.trait_names())
@@ -562,7 +563,7 @@ class Panel(MetPyHasTraits):
 
 
 @exporter.export
-class PanelContainer(MetPyHasTraits):
+class PanelContainer(MetPyHasTraits, ValidationMixin):
     """Collects panels and set complete figure related settings (e.g., size)."""
 
     size = Union([Tuple(Union([Int(), Float()]), Union([Int(), Float()])),
@@ -1240,7 +1241,7 @@ class ColorfillTraits(MetPyHasTraits):
 
 
 @exporter.export
-class ImagePlot(PlotScalar, ColorfillTraits):
+class ImagePlot(PlotScalar, ColorfillTraits, ValidationMixin):
     """Make raster image using `~matplotlib.pyplot.imshow` for satellite or colored image."""
 
     @observe('colormap', 'image_range')
@@ -1295,7 +1296,7 @@ class ImagePlot(PlotScalar, ColorfillTraits):
 
 
 @exporter.export
-class ContourPlot(PlotScalar, ContourTraits):
+class ContourPlot(PlotScalar, ContourTraits, ValidationMixin):
     """Make contour plots by defining specific traits."""
 
     linecolor = Unicode('black')
@@ -1344,7 +1345,7 @@ class ContourPlot(PlotScalar, ContourTraits):
 
 
 @exporter.export
-class FilledContourPlot(PlotScalar, ColorfillTraits, ContourTraits):
+class FilledContourPlot(PlotScalar, ColorfillTraits, ContourTraits, ValidationMixin):
     """Make color-filled contours plots by defining appropriate traits."""
 
     @observe('contours', 'colorbar', 'colormap')
@@ -1516,7 +1517,7 @@ class PlotVector(Plots2D):
 
 
 @exporter.export
-class BarbPlot(PlotVector):
+class BarbPlot(PlotVector, ValidationMixin):
     """Make plots of wind barbs on a map with traits to refine the look of plotted elements."""
 
     barblength = Float(default_value=7)
@@ -1552,7 +1553,7 @@ class BarbPlot(PlotVector):
 
 
 @exporter.export
-class PlotObs(MetPyHasTraits):
+class PlotObs(MetPyHasTraits, ValidationMixin):
     """The highest level class related to plotting observed surface and upperair data.
 
     This class collects all common methods no matter whether plotting a upper-level or

--- a/src/metpy/plots/declarative.py
+++ b/src/metpy/plots/declarative.py
@@ -508,7 +508,7 @@ def plot_kwargs(data):
     return kwargs
 
 
-class ValidationMixin(object):
+class ValidationMixin:
     """Provides validation of attribute names when set by user."""
 
     def __setattr__(self, name, value):
@@ -530,29 +530,17 @@ class ValidationMixin(object):
                 distances = new_distances
             return distances[-1]
 
-        whitelist = ('area',
-                     'ax',
-                     'clabels',
-                     'contours',
+        allowlist = ['ax',
                      'data',
-                     'layers',
-                     'layout',
-                     'linecolor',
+                     'handle',
                      'notify_change',
-                     'panels',
-                     'parent',
-                     'plot_units',
-                     'plots',
-                     'projection',
-                     'size',
-                     'title',
-                     'title_fontsize',
-                     )
+                     ]
 
-        if name in whitelist or name.startswith('_'):
+        allowlist.extend(self.trait_names())
+        if name in allowlist or name.startswith('_'):
             super().__setattr__(name, value)
         else:
-            alt = sorted(whitelist, key=lambda x: _levenshtein(name, x))[0]
+            alt = sorted(allowlist, key=lambda x: _levenshtein(name, x))[0]
             obj = self.__class__
             msg = f"'{name}' is not a valid attribute for {obj}. Perhaps you meant '{alt}'?"
             raise AttributeError(msg)

--- a/tests/plots/test_declarative.py
+++ b/tests/plots/test_declarative.py
@@ -1668,3 +1668,21 @@ def test_drop_traitlets_dir():
         assert not dir(plot_obj())[0].startswith('_')
         assert 'cross_validation_lock' in dir(plot_obj)
         assert 'cross_validation_lock' not in dir(plot_obj())
+
+
+@needs_cartopy
+def test_attribute_error_suggest():
+    """Test that a mistyped attribute name raises an exception with fix."""
+    with pytest.raises(AttributeError) as excinfo:
+        panel = MapPanel()
+        panel.pots = []
+    assert "Perhaps you meant 'plots'?" in str(excinfo.value)
+
+
+@needs_cartopy
+def test_attribute_error_no_suggest():
+    """Test that a mistyped attribute name raises an exception w/o a fix."""
+    with pytest.raises(AttributeError) as excinfo:
+        panel = MapPanel()
+        panel.galaxy = 'Andromeda'
+    assert 'Perhaps you meant' not in str(excinfo.value)


### PR DESCRIPTION
This PR addresses a portion of #2016

Right now, typos in the names of attributes used by the declarative
plotting interface lead to strange errors that can be difficult to
debug.  Here, a new mixin class is defined to provide
validation of attribute names against a whitelist.

This approach was inspired by a [Stack Overflow question](https://stackoverflow.com/questions/20406363/setattr-versus-slots-for-constraining-attribute-creation-in-python/20406443#20406443)
and the nearest-string function was stolen from Rosetta Code.

~~Since this is a proof of concept, validation is only applied to the
MapPanel object.~~

Validation is extended to all publicly facing objects in the decalarative interface, and a test has been added.

Here is a motivating example:
```python
from datetime import datetime, timedelta

from metpy.io import GempakGrid
from metpy.units import units
from metpy.plots import ContourPlot, MapPanel, PanelContainer

init_time = datetime(2021, 10, 21, 12)
plot_time = init_time + timedelta(hours=12)

gem_file = '/ldmdata/gempak/model/nam/21102112_nam211.gem'
gem_data = GempakGrid(gem_file)

ht500 = gem_data.gdxarray(parameter='HGHT',
                          date_time=plot_time,
                          level=500)[0] * units('m')

cp = ContourPlot()
cp.data = ht500
cp.contours = list(range(0, 700, 6))
cp.linecolor = 'green'
cp.clabels = True
cp.plot_units = 'dam'

panel = MapPanel()
panel.area = [-130, -70, 20, 55]
panel.layers = ['states', 'coastline', 'borders']
panel.title = f'NAM forecast of 500-mb Heights at {plot_time}'
panel.pots = [cp]

pc = PanelContainer()
pc.size = (12, 10)
pc.panels = [panel]
pc.show()
```

Output w/o the PR:
```
Traceback (most recent call last):
  File "/home/decker/classes/met433/new_labs/lab07/typo.py", line 33, in <module>
    pc.show()
  File "/home/decker/src/git_repos/metpy/src/metpy/plots/declarative.py", line 594, in show
    self.draw()
  File "/home/decker/src/git_repos/metpy/src/metpy/plots/declarative.py", line 581, in draw
    panel.draw()
  File "/home/decker/src/git_repos/metpy/src/metpy/plots/declarative.py", line 837, in draw
    self.ax.set_extent(self.area, ccrs.PlateCarree())
  File "/home/decker/src/git_repos/metpy/src/metpy/plots/declarative.py", line 809, in ax
    self._ax = self.parent.figure.add_subplot(*self.layout, projection=self._proj_obj)
  File "/home/decker/src/git_repos/metpy/src/metpy/plots/declarative.py", line 744, in _proj_obj
    if isinstance(self.plots[0].griddata, tuple):
IndexError: list index out of range
```

Output w/ the PR:
```
Traceback (most recent call last):
  File "/home/decker/classes/met433/new_labs/lab07/typo.py", line 28, in <module>
    panel.pots = [cp]
  File "/home/decker/src/git_repos/metpy/src/metpy/plots/declarative.py", line 558, in __setattr__
    raise AttributeError(msg)
AttributeError: 'pots' is not a valid attribute for <class 'metpy.plots.MapPanel'>. Perhaps you meant 'plots'?
```