### PR TITLE
Correct docs for search_radius in interpolate functions

### DIFF
--- a/src/metpy/interpolate/grid.py
+++ b/src/metpy/interpolate/grid.py
@@ -245,7 +245,7 @@ def interpolate_to_grid(x, y, z, interp_type='linear', hres=50000,
         The horizontal resolution of the generated grid, given in the same units as the
         x and y parameters. Default 50000.
     minimum_neighbors: int
-        Minimum number of neighbors needed to perform barnes or cressman interpolation for a
+        Minimum number of neighbors needed to perform Barnes or Cressman interpolation for a
         point. Default is 3.
     gamma: float
         Adjustable smoothing parameter for the barnes interpolation. Default 0.25.
@@ -253,8 +253,8 @@ def interpolate_to_grid(x, y, z, interp_type='linear', hres=50000,
         Response parameter for barnes interpolation, specified nondimensionally
         in terms of the Nyquist. Default 5.052
     search_radius: float
-        A search radius to use for the barnes and cressman interpolation schemes.
-        If search_radius is not specified, it will default to the average spacing of
+        A search radius to use for the Barnes and Cressman interpolation schemes.
+        If search_radius is not specified, it will default to 5 times the average spacing of
         observations.
     rbf_func: str
         Specifies which function to use for Rbf interpolation.

--- a/src/metpy/interpolate/points.py
+++ b/src/metpy/interpolate/points.py
@@ -307,7 +307,7 @@ def interpolate_to_points(points, values, xi, interp_type='linear', minimum_neig
         2) "natural_neighbor", "barnes", or "cressman" from `metpy.interpolate`.
         Default "linear".
     minimum_neighbors: int
-        Minimum number of neighbors needed to perform barnes or cressman interpolation for a
+        Minimum number of neighbors needed to perform Barnes or Cressman interpolation for a
         point. Default is 3.
     gamma: float
         Adjustable smoothing parameter for the barnes interpolation. Default 0.25.
@@ -315,8 +315,8 @@ def interpolate_to_points(points, values, xi, interp_type='linear', minimum_neig
         Response parameter for barnes interpolation, specified nondimensionally
         in terms of the Nyquist. Default 5.052
     search_radius: float
-        A search radius to use for the barnes and cressman interpolation schemes.
-        If search_radius is not specified, it will default to the average spacing of
+        A search radius to use for the Barnes and Cressman interpolation schemes.
+        If search_radius is not specified, it will default to 5 times the average spacing of
         observations.
     rbf_func: str
         Specifies which function to use for Rbf interpolation.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Default search radius is 5 times the average spacing, not the averagespacing itself.

Also went ahead and capitalized Barnes/Cressman as appropriate.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

~- [ ] Closes #xxxx~
~- [ ] Tests added~
- [x] Fully documented
