### PR TITLE
Add field for traceback to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -56,7 +56,7 @@ body:
       label: Errors, Traceback, and Logs
       description: |
         If applicable, share with us the Error and full Traceback provided by your interpreter.
-      render: python
+      render: pytb
       placeholder: |
         Traceback (most recent call last):
           File "<stdin>", line 1, in <module>

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     attributes:
       label: What went wrong?
       description: This should explain what went wrong and what you expected to happen.
-      placeholder: Please describe the bug!
+      placeholder: Please describe the bug! You can attach example code and error messages in separate fields below.
     validations:
       required: true
   - type: dropdown
@@ -50,3 +50,19 @@ body:
       placeholder: "# Your code here"
     validations:
       required: true
+  - type: textarea
+    id: error
+    attributes:
+      label: Errors, Traceback, and Logs
+      description: |
+        If applicable, share with us the Error and full Traceback provided by your interpreter.
+      render: python
+      placeholder: |
+        Traceback (most recent call last):
+          File "<stdin>", line 1, in <module>
+          File "/metpy/xarray.py", line 1229, in wrapper
+            result = func(*bound_args.args, **bound_args.kwargs)
+          File "/metpy/units.py", line 245, in wrapper
+            raise ValueError(msg)
+        ValueError: This function changed in 1.0--double check that the function is being called properly.
+        `dewpoint` given arguments with incorrect units: `vapor_pressure` requires "[pressure]" but given "gram / kilogram"


### PR DESCRIPTION
#### Description Of Changes
Per a mention at last week's dev call, add a dedicated field for errors and tracebacks to our bug report issue template. I've included an example traceback in the placeholder.

#### Checklist

 - ~[ ] Closes #xxxx~
 - ~[ ] Tests added~
 - ~[ ] Fully documented~
