### PR TITLE
Fix `dev` docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,6 +78,7 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: Linux-3.9-docs
+        path: ./docs/build/html
 
     # This overrides the version "dev" with the proper version if we're building off a
     # branch that's not main (which is confined to n.nn.x above) or on a tag.


### PR DESCRIPTION
#### Description Of Changes
Docs `Deploy` workflow had a mismatch in artifact download location with expected deploy directory. Download the artifact to the expected subdirectory to get the dev docs back.

#### Checklist

- ~[ ] Closes #xxxx~
- ~[ ] Tests added~
- ~[ ] Fully documented~
