### PR TITLE
run conda tests on python 3.10

### DIFF
--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         os: [macOS, Windows]
 
     steps:

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, '3.10']
         os: [macOS, Windows]
 
     steps:


### PR DESCRIPTION
#### Description Of Changes

See if MetPy can be tested with python 3.10 on conda now.

#### Checklist

- [x] refs #2175
-  Tests added
- Fully documented
