### PR TITLE
Correct array shape typos in natural_neighbor_to_grid

### DIFF
--- a/src/metpy/interpolate/grid.py
+++ b/src/metpy/interpolate/grid.py
@@ -138,16 +138,16 @@ def natural_neighbor_to_grid(xp, yp, variable, grid_x, grid_y):
 
     Parameters
     ----------
-    xp: (N, ) ndarray
+    xp: (P, ) ndarray
         x-coordinates of observations
-    yp: (N, ) ndarray
+    yp: (P, ) ndarray
         y-coordinates of observations
-    variable: (N, ) ndarray
+    variable: (P, ) ndarray
         observation values associated with (xp, yp) pairs.
         IE, variable[i] is a unique observation at (xp[i], yp[i])
-    grid_x: (M, 2) ndarray
+    grid_x: (M, N) ndarray
         Meshgrid associated with x dimension
-    grid_y: (M, 2) ndarray
+    grid_y: (M, N) ndarray
         Meshgrid associated with y dimension
 
     Returns


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

A [recent StackOverflow question](https://stackoverflow.com/questions/70077232/grid-x-and-grid-y-dimension-in-natural-neighbour-to-grid) pointed out some errors in the array shapes given in the docstring for `natural_neighbor_to_grid`. This PR is a quick correction to those.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- ~~Closes #xxxx~~
- ~~Tests added~~
- ~~Fully documented~~ (doc clean-up only)
