### PR TITLE
Updates for CI pipeline

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,7 @@
+codecov:
+  notify:
+    after_n_builds: 9
+
 coverage:
   status:
     patch:

--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -50,7 +50,7 @@ runs:
       shell: bash -l {0}
       run: |
         set -e -o pipefail
-        ci/filter_links.py docs/build/linkcheck/output.json $(git rev-list --parents -n 1 HEAD) 2>&1 | tee linkchecker.log || (
+        ci/filter_links.py docs/build/linkcheck/output.json ${{ github.event_name == 'pull_request' }} 2>&1 | tee linkchecker.log || (
             echo '::set-output name=log_available::true' && false
         )
 

--- a/.github/actions/install-conda/action.yml
+++ b/.github/actions/install-conda/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Setup conda caching
-      uses: actions/cache@v2.1.6
+      uses: actions/cache@v2
       with:
         path: ~/conda_pkgs_dir
         key: conda-${{ inputs.type }}-${{ runner.os }}-${{ inputs.python-version}}-${{ hashFiles('ci/*') }}
@@ -21,7 +21,7 @@ runs:
           conda-${{ inputs.type }}-
 
     - name: Set up Python ${{ inputs.python-version }}
-      uses: conda-incubator/setup-miniconda@v2.1.1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         miniforge-version: latest
         miniforge-variant: mambaforge

--- a/.github/actions/install-pypi/action.yml
+++ b/.github/actions/install-pypi/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'

--- a/.github/actions/install-pypi/action.yml
+++ b/.github/actions/install-pypi/action.yml
@@ -25,8 +25,8 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'
         cache-dependency-path: |
-          - ci/${{ inputs.type }}_requirements.txt
-          - ci/${{ inputs.version-file }}
+          ci/${{ inputs.type }}_requirements.txt
+          ci/${{ inputs.version-file }}
 
     - name: Setup PROJ
       if: ${{ inputs.need-cartopy == 'true' }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -50,6 +50,6 @@ runs:
 
     - name: Upload coverage
       if: ${{ always() && inputs.upload-coverage == 'true' }}
-      uses: codecov/codecov-action@v2.1.0
+      uses: codecov/codecov-action@v2
       with:
         name: ${{ inputs.key }}

--- a/.github/actions/setup-proj/action.yml
+++ b/.github/actions/setup-proj/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - name: Set up caching
-      uses: actions/cache@v2.1.6
+      uses: actions/cache@v2
       id: cache-proj
       with:
         path: ~/${{ inputs.install-path }}

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2.4.0
+      uses: actions/checkout@v2
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,5 +1,9 @@
 name: "Code Analysis"
 
+concurrency:
+  group: ${{ github.workflow}}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/docs-conda.yml
+++ b/.github/workflows/docs-conda.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     # We check out only a limited depth and then pull tags to save time
     - name: Checkout source
-      uses: actions/checkout@v2.4.0
+      uses: actions/checkout@v2
       with:
         fetch-depth: 100
 

--- a/.github/workflows/docs-conda.yml
+++ b/.github/workflows/docs-conda.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow}}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   #
   # Build our docs on macOS and Windows on Python 3.8 and 3.7, respectively.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow}}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   #
   # Build our docs on Linux against multiple Pythons

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
     # We check out only a limited depth and then pull tags to save time
     - name: Checkout source
-      uses: actions/checkout@v2.4.0
+      uses: actions/checkout@v2
       with:
         fetch-depth: 100
 
@@ -85,7 +85,7 @@ jobs:
       run: echo "DOC_VERSION=v${{ needs.Docs.outputs.doc-version }}" >> $GITHUB_ENV
 
     - name: Upload to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3.8.0
+      uses: peaceiris/actions-gh-pages@v3
       with:
         deploy_key: ${{ secrets.GHPAGES_DEPLOY_KEY }}
         publish_dir: ./docs/build/html

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,6 +4,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow}}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   flake8:
     name: Flake8

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,10 +9,10 @@ jobs:
     name: Flake8
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v2
 
       - name: Set up Python 3
-        uses: actions/setup-python@v2.3.0
+        uses: actions/setup-python@v2
         with:
           python-version: 3.x
           cache: 'pip'

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     # We check out only a limited depth and then pull tags to save time
     - name: Checkout source
-      uses: actions/checkout@v2.4.0
+      uses: actions/checkout@v2
       with:
         fetch-depth: 100
 
@@ -70,7 +70,7 @@ jobs:
     steps:
     # We check out only a limited depth and then pull tags to save time
     - name: Checkout source
-      uses: actions/checkout@v2.4.0
+      uses: actions/checkout@v2
       with:
         fetch-depth: 100
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       url: https://pypi.org/project/MetPy/
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 10
 
@@ -21,7 +21,7 @@ jobs:
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
     - name: Set up Python
-      uses: actions/setup-python@v2.3.0
+      uses: actions/setup-python@v2
       with:
         python-version: 3.x
 

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow}}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   #
   # Run all tests on Conda on both Windows and macOS

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     # We check out only a limited depth and then pull tags to save time
     - name: Checkout source
-      uses: actions/checkout@v2.4.0
+      uses: actions/checkout@v2
       with:
         fetch-depth: 100
 

--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow}}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   #
   # Run all tests on Linux using standard PyPI packages, including minimum requirements

--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     # We check out only a limited depth and then pull tags to save time
     - name: Checkout source
-      uses: actions/checkout@v2.4.0
+      uses: actions/checkout@v2
       with:
         fetch-depth: 100
 


### PR DESCRIPTION
#### Description Of Changes
1. Fix linkchecker for nightly builds
We were always filtering based on the (assumed) current merge. Instead, just pass true/false based on whether the build is a PR, and find the appropriate commits within the script.

2. Update action version numbers
Replace explicit versions for actions with only major where possible. This will hopefully reduce dependabot churn (assuming it supports this--[unclear](https://github.com/dependabot/dependabot-core/issues/2304) but has seemed to be working for us), and also compensates for the fact that dependabot is not issuing updates for actions versions within our own composite actions. This also updates the `install-pypi` action to use a version of `setup-python` that supports caching.

3. Add `concurrency` setting which uses concurrency groups to cancel existing builds (pending and running) on a PR when new commits are pushed.
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

~- [ ] Closes #xxxx~
~- [ ] Tests added~
~- [ ] Fully documented~
