### PR TITLE
Fixes for nightly CI run

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -10,15 +10,17 @@ inputs:
     required: false
     default: ''
 outputs:
-  log_available:
-    description: 'Whether a log from the doc build is available'
-    value: ${{ steps.builddocs.outputs.log_available == 'true' || steps.linkchecker.outputs.log_available == 'true'}}
   doc_version:
     description: 'What version the docs correspond to'
     value: ${{ steps.docversion.outputs.doc_version }}
 runs:
   using: composite
   steps:
+    - name: Set doc version
+      id: docversion
+      shell: bash -l {0}
+      run: echo "::set-output name=doc_version::v$(python -c 'import metpy,re; print(re.search(r"(\d+\.\d+)", metpy.__version__)[0])')"
+
     - name: Build docs
       shell: bash -l {0}
       id: builddocs
@@ -28,10 +30,7 @@ runs:
         set -e -o pipefail
         export TEST_DATA_DIR=$GITHUB_WORKSPACE/staticdata
         pushd docs
-        make overridecheck html O=-W 2>&1 | tee build-${{ inputs.key }}.log || (
-            echo '::set-output name=log_available::true' && false
-        )
-        popd
+        make overridecheck html O=-W 2>&1 | tee ../build.log && popd || (popd && false)
 
     - name: Run link checker
       # Running linkchecker separately so that we avoid problems with vendored LICENSE
@@ -39,25 +38,11 @@ runs:
       if: ${{ inputs.run-linkchecker == 'true'}}
       shell: bash -l {0}
       run: |
+        set -e -o pipefail
         pushd docs
-        find build/html/_static -name LICENSE.md -delete
         make linkcheck || true
         popd
-
-    - name: Check linkchecker output
-      id: linkchecker
-      if: ${{ inputs.run-linkchecker == 'true'}}
-      shell: bash -l {0}
-      run: |
-        set -e -o pipefail
-        ci/filter_links.py docs/build/linkcheck/output.json ${{ github.event_name == 'pull_request' }} 2>&1 | tee linkchecker.log || (
-            echo '::set-output name=log_available::true' && false
-        )
-
-    - name: Set doc version
-      id: docversion
-      shell: bash -l {0}
-      run: echo "::set-output name=doc_version::v$(python -c 'import metpy,re; print(re.search(r"(\d+\.\d+)", metpy.__version__)[0])')"
+        ci/filter_links.py docs/build/linkcheck/output.json ${{ github.event_name == 'pull_request' }} 2>&1 | tee linkchecker.log
 
     - name: Upload docs as artifact
       if: ${{ always() && inputs.key != '' }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -36,7 +36,7 @@ runs:
       run: python -m pytest --doctest-modules -k "not test" src;
 
     - name: Upload test images
-      if: ${{ failure() }}
+      if: failure()
       uses: actions/upload-artifact@v2
       with:
         name: ${{ inputs.key }}-images

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -12,10 +12,6 @@ inputs:
     description: 'Whether to upload coverage report'
     required: false
     default: 'true'
-outputs:
-  log_available:
-    description: 'Whether a log for running the tests is available'
-    value: ${{ steps.run-tests.outputs.log_available }}
 runs:
   using: composite
   steps:
@@ -27,9 +23,7 @@ runs:
       run: |
         set -e -o pipefail
         export TEST_DATA_DIR=$GITHUB_WORKSPACE/staticdata
-        python -m coverage run -p -m pytest --mpl -W error::metpy.deprecation.MetpyDeprecationWarning tests/ 2>&1 | tee tests-${{ inputs.key }}.log || (
-            echo '::set-output name=log_available::true' && false
-        )
+        python -m coverage run -p -m pytest --mpl -W error::metpy.deprecation.MetpyDeprecationWarning tests/ 2>&1 | tee tests-${{ inputs.key }}.log
         python -m coverage combine
         python -m coverage report
         python -m coverage xml

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Run doc8
         # Don't skip doc8 if flake8 fails
-        if: ${{ always() }}
+        if: always()
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run codespell
         # Don't skip codespell if any other steps fail
-        if: ${{ always() }}
+        if: always()
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -119,7 +119,7 @@ jobs:
           path: /tmp/workspace/logs
 
       - name: Group logs
-        run: cat /tmp/workspace/logs/log-*/*.log > logs.txt
+        run: cat /tmp/workspace/logs/log-*/*.log > logs.txt || touch logs.txt
 
       - name: Report failures
         uses: actions/github-script@v5

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -15,8 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.9]
-    outputs:
-      log_available: ${{ steps.tests.outputs.log_available }}
 
     steps:
     # We check out only a limited depth and then pull tags to save time
@@ -51,7 +49,7 @@ jobs:
         upload-coverage: false
 
     - name: Upload test log
-      if: ${{ always() && steps.tests.outputs.log_available  == 'true' }}
+      if: failure()
       uses: actions/upload-artifact@v2
       with:
         name: log-nightly-tests-${{ matrix.python-version }}
@@ -64,8 +62,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.9]
-    outputs:
-      log_available: ${{ steps.build.outputs.LOG_AVAILABLE }}
 
     steps:
     # We check out only a limited depth and then pull tags to save time
@@ -99,19 +95,19 @@ jobs:
         key: ${{ matrix.python-version }}-nightly
 
     - name: Upload build log
-      if: ${{ always() && steps.build.outputs.log_available  == 'true' }}
+      if: failure()
       uses: actions/upload-artifact@v2
       with:
         name: log-nightly-docs-${{ matrix.python-version }}
         path: |
-          docs/build-${{ matrix.python-version }}.log
-          docs/linkchecker.log
+          build.log
+          linkchecker.log
         retention-days: 5
 
   Report:
     name: Report
     needs: [Tests, Docs]
-    if: always() && (needs.Tests.outputs.log_available == 'true' || needs.Docs.outputs.log_available == 'true')
+    if: failure()
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Nightly is currently failing (and not reporting) because it can't find the logs for the doc build. Fix that and:
* Vastly simplify logic by just using `failure()` as the condition rather than the poorly named and manually managed `log_available` output (logs are always available)
* Ensure that the Report job always succeeds by ensuring even an empty log is available (and the step succeeds)

Also simplify a bit of syntax around `always()` and `failure()`.

The real test of this PR is in running the nightly workflow, but since this changes the `run_test` and `build_docs` actions, thought best to at least sanity check those in a PR.
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

~- [ ] Closes #xxxx~
~- [ ] Tests added~
~- [ ] Fully documented~
