### PR TITLE
Fix linkchecker build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -390,5 +390,5 @@ other ways, feel free to contact us:
 There are a ton of great resources out there on contributing to open source and on the
 importance of writing tested and maintainable software.
 
-* [GitHub's Contributing to Open Source Guide](https://guides.github.com/activities/contributing-to-open-source/)
+* [How to Contribute to Open Source Guide](https://opensource.guide/how-to-contribute/)
 * [Zen of Scientific Software Maintenance](https://jrleeman.github.io/ScientificSoftwareMaintenance/)

--- a/docs/api/references.rst
+++ b/docs/api/references.rst
@@ -128,7 +128,7 @@ References
 
 .. [Liang2010] Liang, L., and D. Hale, 2010: *A Stable and Fast Implementation
            of Natural Neighbor Interpolation*. Center for Wave Phenomena `CWP-657
-           <https://github.com/Unidata/MetPy/files/138653/cwp-657.pdf>`_, 14 pp.
+           <https://cwp.mines.edu/wp-content/uploads/sites/112/2018/09/cwp-657.pdf>`_, 14 pp.
 
 .. [Markowski2010] Markowski, P. and Y. Richardson, 2010: *Mesoscale Meteorology in the
            Midlatitudes*. Wiley, 430 pp.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -366,13 +366,14 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
 
-linkcheck_ignore = [r'https://www\.youtube\.com/watch\?v=[\d\w\-_]+',
+linkcheck_ignore = [
     r'https://codecov.io/github/Unidata/MetPy',
+    r'https://www\.youtube\.com/watch\?v=[\d\w\-_]+',
     r'https://youtu\.be/[\d\w\-_]+',
-    # AMS DOIs should be stable, but resolved link consistently 403's with linkcheck
-    r'https://doi.org/10.1175/.*',
     # Giving 404s right now and is not going to change
     r'https://twitter.com/MetPy',
+    # AMS DOIs should be stable, but resolved link consistently 403's with linkcheck
+    r'https://doi.org/10.1175/.*',
     # This one appears to be blocking robots
     r'https://doi.org/10.1088/0026-1394/45/2/004'
     ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -378,5 +378,9 @@ linkcheck_ignore = [r'https://www\.youtube\.com/watch\?v=[\d\w\-_]+',
     ]
 
 linkcheck_allowed_redirects = {
-    r'http://xarray\.pydata\.org/': r'http://xarray\.pydata\.org/en/stable/'
+    r'http://xarray\.pydata\.org/': r'http://xarray\.pydata\.org/en/stable/',
+    r'http://pint\.readthedocs\.io': r'https://pint\.readthedocs\.io/en/stable/',
+    r'https://conda.io/docs/': r'https://conda.io/en/latest/',
+    r'https://github.com/Unidata/MetPy/issues/new/choose': r'https://github.com/login.*choose',
+    r'https://doi.org/.*': r'https://.*'
 }

--- a/examples/gridding/Point_Interpolation.py
+++ b/examples/gridding/Point_Interpolation.py
@@ -84,7 +84,7 @@ fig.colorbar(mmb, shrink=.4, pad=0, boundaries=levels)
 ###########################################
 # Natural neighbor interpolation (MetPy implementation)
 # -----------------------------------------------------
-# `Reference <https://github.com/Unidata/MetPy/files/138653/cwp-657.pdf>`_
+# `Reference <https://cwp.mines.edu/wp-content/uploads/sites/112/2018/09/cwp-657.pdf>`_
 gx, gy, img = interpolate_to_grid(x, y, temp, interp_type='natural_neighbor', hres=75000)
 img = np.ma.masked_where(np.isnan(img), img)
 fig, view = basic_map(to_proj, 'Natural Neighbor')


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Fix some redirecting links:
* Open source contributing guide was redirecting to GitHub's generic help--found correct link
* Instead of linking to the natural neighbor interpolation report that was uploaded to a MetPy issue, there's now a link on the Colorado School of Mines page. There's also a copy up on researchgate. This eliminates an ugly redirect
* Update allowed redirect patterns for the other URLs. This includes a blanket redirect for doi.org to go to any https site. I'm not sure what would be a better allow.
* Clean up ordering of our ignore list to group things a bit better

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2220 
~- [ ] Tests added~
- [x] Fully documented
