### PR TITLE
BUG: Fix handling of reference level for moist_lapse (Fixes #2128)

### DIFF
--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -316,16 +316,12 @@ def moist_lapse(pressure, temperature, reference_pressure=None):
     org_units = temperature.units
     temperature = np.atleast_1d(temperature).to('kelvin')
 
-    side = 'left'
-
     pres_decreasing = (pressure[0] > pressure[-1])
     if pres_decreasing:
         # Everything is easier if pressures are in increasing order
         pressure = pressure[::-1]
-        side = 'right'
 
-    ref_pres_idx = np.searchsorted(pressure.m, reference_pressure.m, side=side)
-
+    ref_pres_idx = np.searchsorted(pressure.m, reference_pressure.m, side='right')
     ret_temperatures = np.empty((0, temperature.shape[0]))
 
     if _greater_or_close(reference_pressure, pressure.min()):

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -155,6 +155,23 @@ def test_moist_lapse_nan_ref_press():
     assert_nan(temp, units.degC)
 
 
+def test_moist_lapse_downwards():
+    """Test moist_lapse when integrating downwards (#2128)."""
+    temp = moist_lapse(units.Quantity([600, 700], 'mbar'), units.Quantity(0, 'degC'))
+    assert_almost_equal(temp, units.Quantity([0, 6.47748353], units.degC))
+
+
+@pytest.mark.parametrize('direction', (1, -1))
+@pytest.mark.parametrize('start', list(range(5)))
+def test_moist_lapse_starting_points(start, direction):
+    """Test moist_lapse with a variety of reference points."""
+    truth = units.Quantity([20.0804315, 17.2333509, 14.0752659, 6.4774835, 0.0],
+                           'degC')[::direction]
+    pressure = units.Quantity([1000, 925, 850, 700, 600], 'hPa')[::direction]
+    temp = moist_lapse(pressure, truth[start], pressure[start])
+    assert_almost_equal(temp, truth, 4)
+
+
 def test_parcel_profile():
     """Test parcel profile calculation."""
     levels = np.array([1000., 900., 800., 700., 600., 500., 400.]) * units.mbar


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
The indexing math wasn't quite correct if the reference index was 0 (0 - 1 = -1 is very different from 0). Fortunately, it works just to always use the right side index from searchsorted. Added some more exhaustive testing to validate this.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2128
- [x] Tests added
~- [ ] Fully documented~
