### PR TITLE
Reduce warning to a debug log message

### DIFF
--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -771,8 +771,8 @@ class MetPyDatasetAccessor:
             else:
                 if latitude.identical(y) and longitude.identical(x):
                     crs = CFProjection({'grid_mapping_name': 'latitude_longitude'})
-                    log.warning('Found valid latitude/longitude coordinates, assuming '
-                                'latitude_longitude for projection grid_mapping variable')
+                    log.debug('Found valid latitude/longitude coordinates, assuming '
+                              'latitude_longitude for projection grid_mapping variable')
 
         # Rebuild the coordinates of the dataarray, and return quantified DataArray
         var = self._rebuild_coords(var, crs)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
CF Conventions allow you to omit a grid_mapping when data are natively on lat/lon coordinates. Therefore we should not be warning users about our assumption of a lat/lon coordinate system. Just decrease to a debug message (in case we need it for debugging).

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2238
~- [ ] Tests added~
~- [ ] Fully documented~
