### PR TITLE
Add `__repr__` to TreeNode objects

### DIFF
--- a/src/metpy/io/_metar_parser/metar_parser.py
+++ b/src/metpy/io/_metar_parser/metar_parser.py
@@ -15,6 +15,17 @@ class TreeNode(object):
         for el in self.elements:
             yield el
 
+    def __repr__(self):
+        rep = self.__class__.__name__ + '('
+        args = []
+        for key, value in self.__dict__.items():
+            if key == 'elements':
+                continue
+            args.append(key + '=' + repr(value))
+        dict_str = ', '.join(args) + ')'
+        rep += dict_str
+        return rep
+
 
 class TreeNode1(TreeNode):
     def __init__(self, text, offset, elements):

--- a/src/metpy/io/_metar_parser/metar_parser.py
+++ b/src/metpy/io/_metar_parser/metar_parser.py
@@ -15,17 +15,6 @@ class TreeNode(object):
         for el in self.elements:
             yield el
 
-    def __repr__(self):
-        rep = self.__class__.__name__ + '('
-        args = []
-        for key, value in self.__dict__.items():
-            if key == 'elements':
-                continue
-            args.append(key + '=' + repr(value))
-        dict_str = ', '.join(args) + ')'
-        rep += dict_str
-        return rep
-
 
 class TreeNode1(TreeNode):
     def __init__(self, text, offset, elements):

--- a/src/metpy/io/metar.py
+++ b/src/metpy/io/metar.py
@@ -11,7 +11,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from ._metar_parser.metar_parser import parse, ParseError
+from ._metar_parser.metar_parser import parse, ParseError, TreeNode
 from ._tools import open_as_needed
 from .station_data import station_info
 from ..package_tools import Exporter
@@ -59,6 +59,23 @@ col_units = {'station_id': None,
              'current_wx1_symbol': None,
              'current_wx2_symbol': None,
              'current_wx3_symbol': None}
+
+
+def _tree_repr_(self):
+    """Produce string representation of a TreeNodex object."""
+    rep = self.__class__.__name__ + '('
+    args = []
+    for key, value in self.__dict__.items():
+        if key == 'elements':
+            continue
+        args.append(key + '=' + repr(value))
+        dict_str = ', '.join(args) + ')'
+    rep += dict_str
+    return rep
+
+
+# Monkey patch to improve debugging
+TreeNode.__repr__ = _tree_repr_
 
 
 @exporter.export

--- a/tests/io/test_metar.py
+++ b/tests/io/test_metar.py
@@ -10,6 +10,7 @@ import pytest
 
 from metpy.cbook import get_test_data
 from metpy.io import parse_metar_file, parse_metar_to_dataframe
+from metpy.io._metar_parser.metar_parser import parse
 from metpy.io.metar import Metar, parse_metar
 from metpy.units import units
 
@@ -352,3 +353,29 @@ def test_parse_no_pint_objects_in_df():
     for df in (parse_metar_file(input_file), parse_metar_to_dataframe(metar_str)):
         for column in df:
             assert not isinstance(df[column][0], units.Quantity)
+
+
+def test_repr():
+    """Test that the TreeNode string representation works."""
+    str1 = 'KSMQ 201953Z AUTO VRB05KT 10SM CLR 03/M10 A3026'
+    tree = parse(str1)
+    rep = repr(tree)
+    assert rep == ("TreeNode1(text='KSMQ 201953Z AUTO VRB05KT 10SM CLR 03/M10 A3026', "
+                   "offset=0, metar=TreeNode(text='', offset=0), "
+                   "siteid=TreeNode(text='KSMQ', offset=0), "
+                   "datetime=TreeNode2(text=' 201953Z', offset=4, "
+                   "sep=TreeNode(text=' ', offset=4)), "
+                   "auto=TreeNode(text=' AUTO', offset=12), "
+                   "wind=TreeNode4(text=' VRB05KT', offset=17, "
+                   "wind_dir=TreeNode(text='VRB', offset=18), "
+                   "wind_spd=TreeNode(text='05', offset=21), "
+                   "gust=TreeNode(text='', offset=23)), "
+                   "vis=TreeNode6(text=' 10SM', offset=25, "
+                   "sep=TreeNode(text=' ', offset=25)), run=TreeNode(text='', offset=30), "
+                   "curwx=TreeNode(text='', offset=30), "
+                   "skyc=TreeNode(text=' CLR', offset=30), "
+                   "temp_dewp=TreeNode13(text=' 03/M10', offset=34, "
+                   "sep=TreeNode(text=' ', offset=34), temp=TreeNode(text='03', offset=35), "
+                   "dewp=TreeNode(text='M10', offset=38)), "
+                   "altim=TreeNode(text=' A3026', offset=41), "
+                   "remarks=TreeNode(text='', offset=47), end=TreeNode(text='', offset=47))")


### PR DESCRIPTION
#### Description Of Changes
Sometimes the METAR parser chokes, but it isn't so easy to see what it
is doing under the hood.  This PR implements the `__repr__` special
method to the `TreeNode` class (and those classes which inherit from it)
to make debugging easier.

No test has been added; please let me know if this is desired.

#### Example Program
```python
from metpy.io._metar_parser.metar_parser import parse
str1 = 'METAR ORER 172000Z 30006KT 0400 FG VV// 12/12 Q1013 NOSIG='
tree = parse(str1)
print(repr(tree))
```

Output w/o PR:
```
<metpy.io._metar_parser.metar_parser.TreeNode1 object at 0x7f2a24e92bb0>
```

Output w/ PR:
```
TreeNode1(text='METAR ORER 172000Z 30006KT 0400 FG VV// 12/12 Q1013 NOSIG=', offset=0, metar=TreeNode(text='METAR', offset=0), siteid=TreeNode(text=' ORER', offset=5), datetime=TreeNode2(text=' 172000Z', offset=10, sep=TreeNode(text=' ', offset=10)), auto=TreeNode(text='', offset=18), wind=TreeNode4(text=' 30006KT', offset=18, wind_dir=TreeNode(text='300', offset=19), wind_spd=TreeNode(text='06', offset=22), gust=TreeNode(text='', offset=24)), vis=TreeNode6(text=' 0400', offset=26, sep=TreeNode(text=' ', offset=26)), run=TreeNode(text='', offset=31), curwx=TreeNode(text=' FG', offset=31), skyc=TreeNode(text=' VV', offset=34), temp_dewp=TreeNode(text='', offset=37), altim=TreeNode(text='', offset=37), remarks=TreeNode(text='// 12/12 Q1013 NOSIG=', offset=37), end=TreeNode(text='', offset=58))
```
