### PR TITLE
Add description of `scale` to declarative tutorial

### DIFF
--- a/src/metpy/plots/declarative.py
+++ b/src/metpy/plots/declarative.py
@@ -946,7 +946,7 @@ class Plots2D(SubsetTraits):
 
     This attribute will scale the field by multiplying by the scale. For example, to
     scale vorticity to be whole values for contouring you could set the scale to 1e5, such that
-    the data values will be scaled by 10^5.
+    the data values will be multiplied by 10^5.
     """
 
     @property

--- a/tutorials/declarative_tutorial.py
+++ b/tutorials/declarative_tutorial.py
@@ -391,6 +391,13 @@ pc.show()
 # If you want to change the units for plotting purposes, add the string value of the units
 # desired. For example, if you want to plot temperature in Celsius, then set this attribute
 # to ``‘degC’``.
+#
+# ``scale``
+#
+# This attribute will scale the field by multiplying by the scale. For example, to
+# scale vorticity to be whole values for contouring you could set the scale to 1e5, such that
+# the data values will be multiplied by 10^5.
+
 
 #########################################################################
 # FilledContourPlot()


### PR DESCRIPTION
Fixes #2136

This is essentially a copy/paste of the docstring into the tutorial
document.

Unable to test due to errors below, but this is trivial so hopefully
it works!

```
preparing documents... WARNING: unsupported theme option 'navbar_start' given
WARNING: unsupported theme option 'navbar_center' given
WARNING: unsupported theme option 'navbar_end' given
done
writing output... [  0%] api/generated/metpy.calc
Theme error:
An error happened in rendering the page api/generated/metpy.calc.
Reason: TemplateNotFound('versions')
```
