### PR TITLE
Update stations.txt

### DIFF
--- a/staticdata/stations.txt
+++ b/staticdata/stations.txt
@@ -654,7 +654,7 @@ CO COLORADO SPRINGS KCOS  COS   72466  38 49N  104 41W 1856   X     T     A    3
 CO CO SPNGS MEADOW  KFLY  FLY          38 57N  104 34W 2096   X           A    7 US
 CO CORTEZ           KCEZ  CEZ          37 18N  108 38W 1797   X           A    7 US
 CO CRAIG            KCAG  CAG   72570  40 30N  107 31W 1887   X           A    4 US
-CO DAKOTA HILL      KC99  C99          29 52N  105 33W 3320   X                7 US
+CO DAKOTA HILL      KC99  C99          39 52N  105 33W 3320   X                7 US
 CO DEL NORTE        KRCV  RCV          37 43N  106 21W 2424   X                7 US
 CO DENVER/ARAPAHOE  KAPA  APA          39 34N  104 51W 1775   X     T     A    4 US
 CO DENVER F. RANGE  KFTG  FTG          39 47N  104 33W 1675   X  X             8 US


### PR DESCRIPTION
latitude for KC99 (Dakota Hill, CO AWOS) was incorrect - file has 29 52N but should be 39 52 N (https://www.codot.gov/programs/aeronautics/mtnawos/DakotaHill_C99)

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Fully documented
