### PR TITLE
support versions like x.y in docs/conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,7 @@ copyright = (
 # built documents.
 #
 verinfo = metpy.__version__
-parsed_version = re.search(r'(?P<full>(?P<base>\d+\.\d+)\.\d+\w*)', verinfo).groupdict()
+parsed_version = re.search(r'(?P<full>(?P<base>\d+\.\d+)\.?\w*)', verinfo).groupdict()
 # The short X.Y version.
 version = parsed_version['base']
 if '+' in verinfo:


### PR DESCRIPTION
#### Description Of Changes

Allows MetPy versions in the form of x.y to not trip up version parsing in `docs/conf.py`

#### Checklist

- [x] Closes #2290
- ~~Tests added~~
- ~~Fully documented~~
