### PR TITLE
GHA Workflow fixes from release

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: ''
 outputs:
-  doc_version:
+  doc-version:
     description: 'What version the docs correspond to'
     value: ${{ steps.docversion.outputs.doc_version }}
 runs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,6 +59,10 @@ jobs:
         type: 'doc'
         python-version: ${{ matrix.python-version }}
 
+    # Needed to have a clean version on tags due to modifying requirements above
+    - name: Clean modified files
+      run: git checkout -- .
+
     - name: Build docs
       id: build-docs
       uses: ./.github/actions/build-docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,6 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
   pull_request:
-  release:
-    types: [published]
 
 permissions:
   contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
             check-links: true
             dep-versions: requirements.txt
     outputs:
-      doc_version: ${{ steps.build-docs.outputs.doc-version }}
+      doc-version: ${{ steps.build-docs.outputs.doc-version }}
 
     steps:
     # We check out only a limited depth and then pull tags to save time

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -10,6 +10,8 @@ on:
 
   # Run if we modify the workflow
   push:
+    branches:
+      - main
     paths:
       - .github/workflows/nightly-builds.yml
   pull_request:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
A collection of various GitHub action workflow fixes that were surfaced by the recent release:
* Don't run the nightly builds on new tags
* Don't build docs on both release and tags--just use tags since we're already restricting those to the proper version
* Fix doc version for upload directory. Some `-` vs. `_` typos kept that from flowing through correctly
* Fix version in built docs. The built docs were detecting a dev build because the version came back as "dirty" because we were modifying one of the requirements files.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2302
~- [ ] Tests added~
~- [ ] Fully documented~
