### PR TITLE
Retaining global attrs on MetPyDatasetAccessor.quantify()

### DIFF
--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -1000,11 +1000,11 @@ class MetPyDatasetAccessor:
         by this operation. Do not utilize on moderate- to large-sized remote datasets before
         subsetting!
         """
-        return self._dataset.map(lambda da: da.metpy.quantify())
+        return self._dataset.map(lambda da: da.metpy.quantify(), keep_attrs=True)
 
     def dequantify(self):
         """Return new dataset with variables cast to magnitude and units on attribute."""
-        return self._dataset.map(lambda da: da.metpy.dequantify())
+        return self._dataset.map(lambda da: da.metpy.dequantify(), keep_attrs=True)
 
 
 def _assign_axis(attributes, axis):

--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -1000,11 +1000,17 @@ class MetPyDatasetAccessor:
         by this operation. Do not utilize on moderate- to large-sized remote datasets before
         subsetting!
         """
-        return self._dataset.map(lambda da: da.metpy.quantify(), keep_attrs=True)
+        _attr_save = self._dataset.attrs.copy()
+        dataset = self._dataset.map(lambda da: da.metpy.quantify())
+        dataset.attrs = _attr_save
+        return dataset
 
     def dequantify(self):
         """Return new dataset with variables cast to magnitude and units on attribute."""
-        return self._dataset.map(lambda da: da.metpy.dequantify(), keep_attrs=True)
+        _attr_save = self._dataset.attrs.copy()
+        dataset = self._dataset.map(lambda da: da.metpy.dequantify())
+        dataset.attrs = _attr_save
+        return dataset
 
 
 def _assign_axis(attributes, axis):

--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -1000,17 +1000,11 @@ class MetPyDatasetAccessor:
         by this operation. Do not utilize on moderate- to large-sized remote datasets before
         subsetting!
         """
-        _attr_save = self._dataset.attrs.copy()
-        dataset = self._dataset.map(lambda da: da.metpy.quantify())
-        dataset.attrs = _attr_save
-        return dataset
+        return self._dataset.map(lambda da: da.metpy.quantify()).assign_attrs(self._dataset.attrs)
 
     def dequantify(self):
         """Return new dataset with variables cast to magnitude and units on attribute."""
-        _attr_save = self._dataset.attrs.copy()
-        dataset = self._dataset.map(lambda da: da.metpy.dequantify())
-        dataset.attrs = _attr_save
-        return dataset
+        return self._dataset.map(lambda da: da.metpy.dequantify()).assign_attrs(self._dataset.attrs)
 
 
 def _assign_axis(attributes, axis):

--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -1000,11 +1000,15 @@ class MetPyDatasetAccessor:
         by this operation. Do not utilize on moderate- to large-sized remote datasets before
         subsetting!
         """
-        return self._dataset.map(lambda da: da.metpy.quantify()).assign_attrs(self._dataset.attrs)
+        return self._dataset.map(lambda da: da.metpy.quantify()).assign_attrs(
+            self._dataset.attrs
+        )
 
     def dequantify(self):
         """Return new dataset with variables cast to magnitude and units on attribute."""
-        return self._dataset.map(lambda da: da.metpy.dequantify()).assign_attrs(self._dataset.attrs)
+        return self._dataset.map(lambda da: da.metpy.dequantify()).assign_attrs(
+            self._dataset.attrs
+        )
 
 
 def _assign_axis(attributes, axis):

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -35,7 +35,7 @@ def test_ds_generic():
                             'c': xr.DataArray(np.arange(3), dims='c'),
                             'd': xr.DataArray(np.arange(5), dims='d'),
                             'e': xr.DataArray(np.arange(5), dims='e')
-    }, dims=['a', 'b', 'c', 'd', 'e'], name='test').to_dataset()
+    }, dims=['a', 'b', 'c', 'd', 'e'], attrs={'units': 'kelvin'}, name='test').to_dataset()
 
 
 @pytest.fixture
@@ -165,7 +165,7 @@ def test_quantify(test_ds_generic):
     original = test_ds_generic['test'].values
     result = test_ds_generic['test'].metpy.quantify()
     assert isinstance(result.data, units.Quantity)
-    assert result.data.units == units.dimensionless
+    assert result.data.units == units.kelvin
     assert 'units' not in result.attrs
     np.testing.assert_array_almost_equal(result.data, units.Quantity(original))
 
@@ -185,7 +185,7 @@ def test_dataset_quantify(test_ds_generic):
     """Test quantify method for converting data to Quantity on Datasets."""
     result = test_ds_generic.metpy.quantify()
     assert isinstance(result['test'].data, units.Quantity)
-    assert result['test'].data.units == units.dimensionless
+    assert result['test'].data.units == units.kelvin
     assert 'units' not in result['test'].attrs
     np.testing.assert_array_almost_equal(
         result['test'].data,
@@ -199,7 +199,7 @@ def test_dataset_dequantify():
     original = xr.Dataset({
         'test': ('x', units.Quantity([280, 290, 300], 'K')),
         'x': np.arange(3)
-    }, attrs={'test_': 'test'})
+    }, attrs={'test': 'test'})
     result = original.metpy.dequantify()
     assert isinstance(result['test'].data, np.ndarray)
     assert result['test'].attrs['units'] == 'kelvin'

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -199,7 +199,7 @@ def test_dataset_dequantify():
     original = xr.Dataset({
         'test': ('x', units.Quantity([280, 290, 300], 'K')),
         'x': np.arange(3)
-    }, attrs={'test': 'test'})
+    }, attrs={'test_': 'test'})
     result = original.metpy.dequantify()
     assert isinstance(result['test'].data, np.ndarray)
     assert result['test'].attrs['units'] == 'kelvin'

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -191,6 +191,7 @@ def test_dataset_quantify(test_ds_generic):
         result['test'].data,
         units.Quantity(test_ds_generic['test'].data)
     )
+    assert result.attrs == test_ds_generic.attrs
 
 
 def test_dataset_dequantify():
@@ -198,11 +199,12 @@ def test_dataset_dequantify():
     original = xr.Dataset({
         'test': ('x', units.Quantity([280, 290, 300], 'K')),
         'x': np.arange(3)
-    })
+    }, attrs={'test': 'test'})
     result = original.metpy.dequantify()
     assert isinstance(result['test'].data, np.ndarray)
     assert result['test'].attrs['units'] == 'kelvin'
     np.testing.assert_array_almost_equal(result['test'].data, original['test'].data.magnitude)
+    assert result.attrs == original.attrs
 
 
 def test_radian_projection_coords():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

When using `MetPyDataSetAccessor.quantify`, I noticed the global attributes being deleted. This didn't seem 
I added the `keep_attrs = True` argument to the `.map` operation in `MetPyDataSetAccessor.quantify` as I don't see any reason why the global attributes of a dataset should be deleted upon quantification.

Closing #2311

#### Checklist

- [x] Tests added
