### PR TITLE
Use new allow_updates arg for pooch

### DIFF
--- a/src/metpy/cbook.py
+++ b/src/metpy/cbook.py
@@ -11,19 +11,23 @@ import pooch
 
 from . import __version__
 
-POOCH = pooch.create(
-    path=pooch.os_cache('metpy'),
-    base_url='https://github.com/Unidata/MetPy/raw/{version}/staticdata/',
-    version='v' + __version__,
-    version_dev='main')
+pooch_path = pooch.os_cache('metpy')
+pooch_updates = True
 
 # Check if we have the data available directly from a git checkout, either from the
 # TEST_DATA_DIR variable, or looking relative to the path of this module's file. Use this
 # to override Pooch's path and disable downloading from GitHub.
 dev_data_path = os.environ.get('TEST_DATA_DIR', Path(__file__).parents[2] / 'staticdata')
 if Path(dev_data_path).exists():
-    POOCH.path = dev_data_path
-    POOCH.base_url = 'NODOWNLOAD:'
+    pooch_path = dev_data_path
+    pooch_updates = False
+
+POOCH = pooch.create(
+    path=pooch_path,
+    base_url='https://github.com/Unidata/MetPy/raw/{version}/staticdata/',
+    version='v' + __version__,
+    version_dev='main',
+    allow_updates=pooch_updates)
 
 POOCH.load_registry(Path(__file__).parent / 'static-data-manifest.txt')
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This allows us (when using the latest pooch) to disable updates to downloaded data. This means our current minimum build (using 0.1) won't fail when someone updates data without the registry, but the other jobs should so that's fine.

This cleans up the hack that was added in #2283 and replaces it with the newly added argument for Pooch.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

~- [ ] Closes #xxxx~
~- [ ] Tests added~
~- [ ] Fully documented~
