### PR TITLE
Bump scipy and pandas minimum versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,11 +42,11 @@ install_requires =
     importlib_resources>=1.3.0; python_version < '3.9'
     matplotlib>=3.3.0
     numpy>=1.18.0
-    pandas>=0.24.0
+    pandas>=1.0.0
     pint>=0.10.1
     pooch>=1.2.0
     pyproj>=2.5.0
-    scipy>=1.2.0
+    scipy>=1.4.0
     traitlets>=4.3.0
     xarray>=0.14.1
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This keeps within our support window and avoids building scipy and pandas from source on our 3.8 minimum job. Right now the 3.8 Minimum CI job is taking ~40 minutes (~32 minutes just installing) because of this.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

~- [ ] Closes #xxxx~
~- [ ] Tests added~
- [x] Fully documented
