### PR TITLE
Update coord criteria regex so that X prefixes or _ infixes don't break it

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,4 +1,4 @@
-        'vertical': (r'(lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|isobaric|pres|'
+            r'^(z|lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|isobaric|pres|isotherm)'
   | ``(thta, u, v, dx, dy, dim_order='yx')``                                                                         |
        Changed signature from ``(thta, u, v, dx, dy, dim_order='yx')``
     dpres = gempak.PRES.values

--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -83,13 +83,15 @@ coordinate_criteria = {
         },
     },
     'regular_expression': {
-        'time': r'time[0-9]*',
-        'vertical': (r'(lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|isobaric|pres|'
-                     r'isotherm)[a-z_]*[0-9]*'),
-        'y': r'y',
-        'latitude': r'x?lat[a-z0-9]*',
-        'x': r'x',
-        'longitude': r'x?lon[a-z0-9]*'
+        'time': re.compile(r'^(x?)time(s?)[0-9]*$'),
+        'vertical': re.compile(
+            r'^(z|lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|isobaric|pres|isotherm)'
+            r'[a-z_]*[0-9]*$'
+        ),
+        'y': re.compile(r'^y(_?)[a-z0-9]*$'),
+        'latitude': re.compile(r'^(x?)lat[a-z0-9_]*$'),
+        'x': re.compile(r'^x(?!lon|lat|time).*(_?)[a-z0-9]*$'),
+        'longitude': re.compile(r'^(x?)lon[a-z0-9_]*$')
     }
 }
 
@@ -505,8 +507,7 @@ class MetPyDataArrayAccessor:
                 # vertical dim recognition
                 if axis in ('vertical', 'y', 'x'):
                     for i, dim in enumerate(self._data_array.dims):
-                        if re.match(coordinate_criteria['regular_expression'][axis],
-                                    dim.lower()):
+                        if coordinate_criteria['regular_expression'][axis].match(dim.lower()):
                             return i
                 raise exc
             except ValueError:
@@ -1067,7 +1068,7 @@ def check_axis(var, *axes):
                 return True
 
         # Check if name matches regular expression (non-CF failsafe)
-        if re.match(coordinate_criteria['regular_expression'][axis], var.name.lower()):
+        if coordinate_criteria['regular_expression'][axis].match(var.name.lower()):
             return True
 
     # If no match has been made, return False (rather than None)

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -498,7 +498,10 @@ regex_matches = [
     ('time42', 'time'),
     ('Time', 'time'),
     ('TIME', 'time'),
+    ('XTIME', 'time'),
+    ('Times', 'time'),
     ('bottom_top', 'vertical'),
+    ('bottom_top_stag', 'vertical'),
     ('sigma', 'vertical'),
     ('HGHT', 'vertical'),
     ('height', 'vertical'),
@@ -512,18 +515,26 @@ regex_matches = [
     ('pressure', 'vertical'),
     ('pressure_difference_layer', 'vertical'),
     ('isothermal', 'vertical'),
+    ('z', 'vertical'),
+    ('z_stag', 'vertical'),
     ('y', 'y'),
     ('Y', 'y'),
+    ('y_stag', 'y'),
+    ('yc', 'y'),
     ('lat', 'latitude'),
     ('latitude', 'latitude'),
     ('Latitude', 'latitude'),
     ('XLAT', 'latitude'),
+    ('XLAT_U', 'latitude'),
     ('x', 'x'),
     ('X', 'x'),
+    ('x_stag', 'x'),
+    ('xc', 'x'),
     ('lon', 'longitude'),
     ('longitude', 'longitude'),
     ('Longitude', 'longitude'),
-    ('XLONG', 'longitude')
+    ('XLONG', 'longitude'),
+    ('XLONG_V', 'longitude')
 ]
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

Over the course of working on https://github.com/ncar-xdev/xwrf/pull/14 and recieving feedback on it, bugs arose in some edge cases of the regex coordinate criteria, particularly, `XTIME` got interpretted as an `x` axis coordinate (which is very much not right). To resolve this, I tightened the criteria with start and end matching, and then filled in what I'd otherwise expect to be allowed in between. WRF/xwrf-motivated test dimension names have also been added.

#### Checklist

- ~~Closes~~
- [x] Tests added
- ~~Fully documented~~
