### PR TITLE
Fix unit power regex for parentheses handling

### DIFF
--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -42,7 +42,7 @@ units = pint.UnitRegistry(
     preprocessors=[
         functools.partial(
             re.sub,
-            r'(?<=[A-Za-z])(?![A-Za-z])(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])',
+            r'(?<=[A-Za-z\)])(?![A-Za-z\)])(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])',
             '**'
         ),
         lambda string: string.replace('%', 'percent')

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -190,6 +190,24 @@ def test_percent_units():
     assert str(units('%').units) == 'percent'
 
 
-def test_udunits_power_syntax():
+@pytest.mark.parametrize(
+    'unit_str,pint_unit',
+    (
+        # Validated against cf-units (UDUNITS-2 wrapper)
+        ('m s-1', units.m / units.s),
+        ('m2 s-2', units.m ** 2 / units.s ** 2),
+        ('kg(-1)', units.kg),
+        ('kg-1', units.kg ** -1),
+        ('W m(-2)', units.m ** 3 * units.kg * units.s ** -3),
+        ('W m-2', units.kg * units.s ** -3),
+        ('(W m-2 um-1)-1', units.m * units.kg ** -1 * units.s ** 3),
+        pytest.param(
+            '(J kg-1)(m s-1)-1', units.m / units.s,
+            marks=pytest.mark.xfail(reason='hgrecco/pint#1485')
+        ),
+        ('(J kg-1)(m s-1)(-1)', units.m ** 3 / units.s ** 3)
+    )
+)
+def test_udunits_power_syntax(unit_str, pint_unit):
     """Test that UDUNITS style powers are properly parsed and interpreted."""
-    assert units('m2 s-2').units == units.m ** 2 / units.s ** 2
+    assert units(unit_str).to_base_units().units == pint_unit


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

MetPy's CF/UDUNITS-style power handling regex failed on parentheses (as noted in https://github.com/Unidata/MetPy/issues/1362#issuecomment-863476636 ~~and https://github.com/Unidata/MetPy/issues/1362#issuecomment-1051310199~~ ). This fixes it and adds tests against those previously failing examples!

#### Checklist

- ~~Closes~~
- [x] Tests added
- ~~Fully documented~~
