### PR TITLE
Fix wet_bulb_temperature for NumPy scalars

### DIFF
--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -3050,7 +3050,7 @@ def wet_bulb_temperature(pressure, temperature, dewpoint):
     caution on large arrays.
 
     """
-    if not hasattr(pressure, 'shape'):
+    if not getattr(pressure, 'shape', False):
         pressure = np.atleast_1d(pressure)
         temperature = np.atleast_1d(temperature)
         dewpoint = np.atleast_1d(dewpoint)

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1507,6 +1507,16 @@ def test_wet_bulb_temperature_saturated():
     assert_almost_equal(val, 17.6 * units.degC, 7)
 
 
+def test_wet_bulb_temperature_numpy_scalars():
+    """Test wet bulb calculation with NumPy scalars, which have a shape attribute."""
+    pressure = units.Quantity(np.float32(1000), 'hPa')
+    temperature = units.Quantity(np.float32(25), 'degC')
+    dewpoint = units.Quantity(np.float32(15), 'degC')
+    val = wet_bulb_temperature(pressure, temperature, dewpoint)
+    truth = 18.3432116 * units.degC
+    assert_almost_equal(val, truth, 5)
+
+
 def test_wet_bulb_temperature_1d():
     """Test wet bulb calculation with 1d list."""
     pressures = [1013, 1000, 990] * units.hPa


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

As identified via [this StackOverflow question](https://stackoverflow.com/questions/71655087/metpy-wet-bulb-temperature-function-returns-error-when-output-of-most-unstable-p), `wet_bulb_temperature` currently fails on (Quantity-wrapped) NumPy scalars since they *do* have a `shape` attribute (albeit empty), but are not "at least 1D" or indexable, which ends up in an `IndexError`. Changing

```python
if not hasattr(pressure, 'shape'):
```

to

```python
if not getattr(pressure, 'shape', False):
```

resolves this. So, this is the change that is implemented and tested here! 

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- ~~Closes #xxxx~~
- [x] Tests added
- ~~Fully documented~~
