### PR TITLE
Doc/warning improvements

### DIFF
--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -3,9 +3,13 @@
 {% include 'overrides/' ~ fullname ~ '.rst' with context %}
 
 {% else %}
+   {% if name == 'io' %}
+      {% set nice_name = 'Reading Data' %}
+   {% else %}
+      {% set nice_name = name | title | escape %}
+   {% endif %}
 
-{{ objname }}
-{{ underline }}
+{{ (nice_name ~ ' ``(' ~ fullname ~ ')``')|underline }}
 
 .. automodule:: {{ fullname }}
 

--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -13,36 +13,44 @@
 
 .. automodule:: {{ fullname }}
 
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Module Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
    {% block functions %}
    {% if functions %}
-   .. rubric:: Functions
+   .. rubric:: {{ _('Functions') }}
 
    .. autosummary::
       :toctree: ./
-
    {% for item in functions %}
-      {{ item}}
+      {{ item }}
    {%- endfor %}
    {% endif %}
    {% endblock %}
 
    {% block classes %}
    {% if classes %}
-   .. rubric:: Classes
+   .. rubric:: {{ _('Classes') }}
 
    .. autosummary::
       :toctree: ./
-
    {% for item in classes %}
       {{ item }}
    {%- endfor %}
-
    {% endif %}
    {% endblock %}
 
    {% block exceptions %}
    {% if exceptions %}
-   .. rubric:: Exceptions
+   .. rubric:: {{ _('Exceptions') }}
 
    .. autosummary::
       :toctree: ./

--- a/docs/_templates/overrides/metpy.calc.rst
+++ b/docs/_templates/overrides/metpy.calc.rst
@@ -1,5 +1,5 @@
-calc
-==========
+Calculations ``(metpy.calc)``
+=============================
 
 .. automodule:: metpy.calc
 

--- a/docs/_templates/overrides/metpy.plots.ctables.rst
+++ b/docs/_templates/overrides/metpy.plots.ctables.rst
@@ -1,7 +1,5 @@
-
-
-ctables
-===================
+Colortables ``(metpy.plots.ctables)``
+=====================================
 
 .. automodule:: metpy.plots.ctables
 

--- a/docs/_templates/overrides/metpy.xarray.rst
+++ b/docs/_templates/overrides/metpy.xarray.rst
@@ -1,5 +1,5 @@
-xarray
-==========
+Xarray Integration ``(metpy.xarray)``
+=====================================
 
 .. automodule:: metpy.xarray
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,7 +90,7 @@ source_suffix = ['.rst', '.md']
 
 # Controlling automatically generating summary tables in the docs
 autosummary_generate = True
-autosummary_imported_members = True
+autosummary_ignore_module_all = False
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -416,10 +416,6 @@ def lcl(pressure, temperature, dewpoint, max_iters=50, eps=1e-5):
 
     The function is guaranteed to finish by virtue of the `max_iters` counter.
 
-    Only functions on 1D profiles (not higher-dimension vertical cross sections or grids).
-    Since this function returns scalar values when given a profile, this will return Pint
-    Quantities even when given xarray DataArray profiles.
-
     .. versionchanged:: 1.0
        Renamed ``dewpt`` parameter to ``dewpoint``
 

--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -214,12 +214,12 @@ def _check_argument_units(args, defaults, dimensionality):
         # See if the value passed in is appropriate
         try:
             if val.dimensionality != parsed:
-                yield arg, val.units, need
+                yield arg, val, val.units, need
         # No dimensionality
         except AttributeError:
             # If this argument is dimensionless, don't worry
             if parsed != '':
-                yield arg, 'none', need
+                yield arg, val, 'none', need
 
 
 def _get_changed_version(docstring):
@@ -258,12 +258,20 @@ def _check_units_inner_helper(func, sig, defaults, dims, *args, **kwargs):
     if bad:
         msg = f'`{func.__name__}` given arguments with incorrect units: '
         msg += ', '.join(
-            f'`{arg}` requires "{req}" but given "{given}"' for arg, given, req in bad
+            f'`{arg}` requires "{req}" but given "{given}"' for arg, _, given, req in bad
         )
         if 'none' in msg:
-            msg += ('\nAny variable `x` can be assigned a unit as follows:\n'
-                    '    from metpy.units import units\n'
-                    '    x = units.Quantity(x, "m/s")')
+            if any(isinstance(x, np.ma.core.MaskedArray) for _, x, _, _ in bad):
+                msg += ('\nA masked array `m` can be assigned a unit as follows:\n'
+                        '    from metpy.units import units\n'
+                        '    m = units.Quantity(m, "m/s")')
+            else:
+                msg += ('\nA xarray DataArray or numpy array `x` can be assigned a unit as '
+                        'follows:\n'
+                        '    from metpy.units import units\n'
+                        '    x = x * units("m/s")')
+            msg += ('\nFor more information see the Units Tutorial: '
+                    'https://unidata.github.io/MetPy/latest/tutorials/unit_tutorial.html')
 
         # If function has changed, mention that fact
         if func.__doc__:

--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -6,6 +6,8 @@ r"""Module to provide unit support.
 This makes use of the :mod:`pint` library and sets up the default settings
 for good temperature support.
 
+See Also: :doc:`Working with Units </tutorials/unit_tutorial>`.
+
 Attributes
 ----------
 units : :class:`pint.UnitRegistry`

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -104,6 +104,16 @@ def test_bad(func, args, kwargs, bad_parts):
         assert 'unitless_const' not in message
 
 
+@pytest.mark.parametrize('func', test_funcs, ids=['some kwargs', 'all kwargs', 'all pos'])
+def test_bad_masked_array(func):
+    """Test getting a masked array-specific message when missing units."""
+    with pytest.raises(ValueError) as exc:
+        func(np.ma.array([30]), 1000 * units.mbar, 1.0 * units('kg/m^3'), 1, 5.)
+
+    message = str(exc.value)
+    assert 'units.Quantity' in message
+
+
 def test_pandas_units_simple():
     """Simple unit attachment to two columns."""
     df = pd.DataFrame(data=[[1, 4], [2, 5], [3, 6]], columns=['cola', 'colb'])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
* Fix incorrect note in `lcl` doc (#2313)
* Link to the units tutorial from the units API page
* Tweak our sphinx config to use recently added support to use `__all__` as the definitive source for what to include
* Improve the sidebar headings to be consistent and include a nice "English" heading as well as the full module name
* Make the error message on a calculation adjust the advice depending on the input data type (#2334)

With the last one:
```python
import metpy.calc as mpcalc
import numpy as np

mpcalc.wind_speed(np.ma.array([1]), np.ma.array([2]))
```
gives:
```
ValueError: `wind_speed` given arguments with incorrect units: `u` requires "[speed]" but given "none", `v` requires "[speed]" but given "none"
A masked array `m` can be assigned a unit as follows:
    from metpy.units import units
    m = units.Quantity(m, "m/s")
For more information see the Units Tutorial: https://unidata.github.io/MetPy/latest/tutorials/unit_tutorial.html
```
whereas with a numpy array it gives:
```
ValueError: `wind_speed` given arguments with incorrect units: `u` requires "[speed]" but given "none", `v` requires "[speed]" but given "none"
A xarray DataArray or numpy array `x` can be assigned a unit as follows:
    from metpy.units import units
    x = x * units("m/s")
For more information see the Units Tutorial: https://unidata.github.io/MetPy/latest/tutorials/unit_tutorial.html
```
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2334
- [x] Closes #2313
- [x] Tests added
- [x] Fully documented
