### PR TITLE
Make install-pypi action handle extra requirements

### DIFF
--- a/.github/actions/install-pypi/action.yml
+++ b/.github/actions/install-pypi/action.yml
@@ -44,6 +44,11 @@ runs:
       shell: bash
       run: python -m pip install -r ci/${{ inputs.type }}_requirements.txt -c ci/${{ inputs.version-file }}
 
+    - name: Install extra dependencies
+      if: ${{ inputs.need-cartopy == 'true' }}
+      shell: bash
+      run: python -m pip install -r ci/extra_requirements.txt -c ci/${{ inputs.version-file }}
+
     - name: Download Cartopy Maps
       if: ${{ inputs.need-cartopy == 'true' }}
       shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,19 +47,12 @@ jobs:
     - name: Get tags
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-    - name: Add extras to requirements
-      run: cat ci/extra_requirements.txt >> ci/doc_requirements.txt
-
     - name: Install using PyPI
       uses: ./.github/actions/install-pypi
       with:
         need-cartopy: true
         type: 'doc'
         python-version: ${{ matrix.python-version }}
-
-    # Needed to have a clean version on tags due to modifying requirements above
-    - name: Clean modified files
-      run: git checkout -- .
 
     - name: Build docs
       id: build-docs

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -34,7 +34,6 @@ jobs:
 
     - name: Assemble test requirements
       run: |
-        cat ci/extra_requirements.txt >> ci/test_requirements.txt
         echo git+https://github.com/hgrecco/pint@master#egg=pint >> ci/test_requirements.txt
         echo git+https://github.com/pydata/xarray@main#egg=xarray >> ci/test_requirements.txt
 
@@ -77,7 +76,6 @@ jobs:
 
     - name: Assemble doc requirements
       run: |
-        cat ci/extra_requirements.txt >> ci/doc_requirements.txt
         echo git+https://github.com/hgrecco/pint@master#egg=pint >> ci/doc_requirements.txt
         echo git+https://github.com/pydata/xarray@main#egg=xarray >> ci/doc_requirements.txt
 

--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -42,10 +42,6 @@ jobs:
     - name: Get tags
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-    - name: Add extras to requirements
-      if: ${{ matrix.no-extras != 'No Extras' }}
-      run: cat ci/extra_requirements.txt >> ci/test_requirements.txt
-
     - name: Generate minimum dependencies
       if: ${{ matrix.dep-versions == 'Minimum' }}
       run: |


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Since cartopy is the only "extra" we have right now, just key an install of extra_requirements.txt. This allows us to remove the hacky cat-ing of requirements files, which was triggering the version in the built docs to become "1.xdev".

Hopefully with this and 513bdd07 our next release will finally have everything work automatically.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

~- [ ] Closes #xxxx~
~- [ ] Tests added~
~- [ ] Fully documented~
