### PR TITLE
add accessor convert to base units

### DIFF
--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -174,6 +174,22 @@ class MetPyDataArrayAccessor:
         """
         return self.quantify().copy(data=self.unit_array.to(units))
 
+    def convert_to_base_units(self):
+        """Return new DataArray with values converted to base units.
+
+        See Also
+        --------
+        convert_units
+
+        Notes
+        -----
+        Any cached/lazy-loaded data (except that in a Dask array) will be loaded into memory
+        by this operation. Do not utilize on moderate- to large-sized remote datasets before
+        subsetting!
+
+        """
+        return self.quantify().copy(data=self.unit_array.to_base_units())
+
     def convert_coordinate_units(self, coord, units):
         """Return new DataArray with specified coordinate converted to different units.
 

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -153,6 +153,19 @@ def test_convert_units(test_var):
     assert_almost_equal(result[0, 0, 0, 0], 18.44 * units.degC, 2)
 
 
+def test_convert_to_base_units(test_ds):
+    """Test conversion of units."""
+    uwnd = test_ds.u_wind.metpy.quantify()
+    result = (uwnd * (500 * units.hPa)).metpy.convert_to_base_units()
+
+    # Check that units are updated without modifying original
+    assert result.metpy.units == units('kg s**-3')
+    assert test_ds.u_wind.metpy.units == units('m/s')
+
+    # Make sure we now get an array back with properly converted values
+    assert_almost_equal(result[0, 0, 0, 0], -448416.12 * units('kg s**-3'), 2)
+
+
 def test_convert_coordinate_units(test_ds_generic):
     """Test conversion of coordinate units."""
     result = test_ds_generic['test'].metpy.convert_coordinate_units('b', 'percent')

--- a/tutorials/xarray_tutorial.py
+++ b/tutorials/xarray_tutorial.py
@@ -230,8 +230,8 @@ temperature_degc
 #########################################################################
 # To base unit conversion:
 
-temperature_degK = temperature_degc.metpy.convert_to_base_units()
-temperature_degK
+temperature_degk = temperature_degc.metpy.convert_to_base_units()
+temperature_degk
 
 #########################################################################
 # Unit conversion for coordinates:

--- a/tutorials/xarray_tutorial.py
+++ b/tutorials/xarray_tutorial.py
@@ -228,6 +228,12 @@ temperature_degc = temperature[0].metpy.convert_units('degC')
 temperature_degc
 
 #########################################################################
+# To base unit conversion:
+
+temperature_degK = temperature_degc.metpy.convert_to_base_units()
+temperature_degK
+
+#########################################################################
 # Unit conversion for coordinates:
 heights_on_hpa_levels = heights.metpy.convert_coordinate_units('isobaric3', 'hPa')
 heights_on_hpa_levels['isobaric3']


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This PR adds to the metpy xarray accessor to have a `convert_to_base_units()` function, which will allow for the simplification of complex units following calculations using quantify xarray DataArrays.

Added a test and a simple example to the xarray tutorial.
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2363 
- [x] Tests added
- [x] Fully documented
