### PR TITLE
fix isentropic example

### DIFF
--- a/examples/isentropic_example.py
+++ b/examples/isentropic_example.py
@@ -149,7 +149,7 @@ fig.tight_layout()
 msf = mpcalc.montgomery_streamfunction(
     isent_data['Geopotential_height'],
     isent_data['temperature']
-).values / 100.
+).data.to_base_units() * 1e-2
 
 # Choose a level to plot, in this case 296 K
 level = 0


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
When working on some examples and looking through the ones we currently have, I noticed that there were no contours on the Montgomery Streamfunction example. Needed to convert to base units in order for the desired output to plot. This PR makes a small change to ensure the data are in base units and then scaled accordingly.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
