### PR TITLE
Remove "united" as meaning "having units"

### DIFF
--- a/src/metpy/testing.py
+++ b/src/metpy/testing.py
@@ -130,7 +130,7 @@ def check_and_drop_units(actual, desired):
                 actual = units.Quantity(actual, 'dimensionless')
             actual = actual.to(desired.units)
         # Otherwise, the desired result has no units. Convert the actual result to
-        # dimensionless units if it is a united quantity.
+        # dimensionless units if it is a quantity.
         else:
             if hasattr(actual, 'units'):
                 actual = actual.to('dimensionless')

--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -72,7 +72,7 @@ if hasattr(pint, 'UnitStrippedWarning'):
 
 
 def pandas_dataframe_to_unit_arrays(df, column_units=None):
-    """Attach units to data in pandas dataframes and return united arrays.
+    """Attach units to data in pandas dataframes and return quantities.
 
     Parameters
     ----------
@@ -85,7 +85,7 @@ def pandas_dataframe_to_unit_arrays(df, column_units=None):
 
     Returns
     -------
-        Dictionary containing united arrays with keys corresponding to the dataframe
+        Dictionary containing `Quantity` instances with keys corresponding to the dataframe
         column names.
 
     """
@@ -107,7 +107,7 @@ def pandas_dataframe_to_unit_arrays(df, column_units=None):
 
 
 def concatenate(arrs, axis=0):
-    r"""Concatenate multiple values into a new unitized object.
+    r"""Concatenate multiple values into a new quantity.
 
     This is essentially a scalar-/masked array-aware version of `numpy.concatenate`. All items
     must be able to be converted to the same units. If an item has no units, it will be given

--- a/tests/plots/test_skewt.py
+++ b/tests/plots/test_skewt.py
@@ -298,7 +298,7 @@ def test_hodograph_api():
 
 @pytest.mark.mpl_image_compare(remove_text=True, tolerance=0.6 if MPL_VERSION == '3.3' else 0.)
 def test_hodograph_units():
-    """Test passing unit-ed quantities to Hodograph."""
+    """Test passing quantities to Hodograph."""
     fig = plt.figure(figsize=(9, 9))
     ax = fig.add_subplot(1, 1, 1)
     hodo = Hodograph(ax)
@@ -402,7 +402,7 @@ def test_skewt_barb_no_default_unit_conversion():
 @pytest.mark.parametrize('u,v', [(np.array([3]) * units('m/s'), np.array([3])),
                                  (np.array([3]), np.array([3]) * units('m/s'))])
 def test_skewt_barb_unit_conversion_exception(u, v):
-    """Test that errors are raise if unit conversion is requested on un-united data."""
+    """Test that an error is raised if unit conversion is requested on plain arrays."""
     p_wind = np.array([500]) * units.hPa
 
     fig = plt.figure(figsize=(9, 9))
@@ -496,8 +496,8 @@ def test_hodograph_wind_vectors():
     return fig
 
 
-def test_united_hodograph_range():
-    """Tests making a hodograph with a united ranged."""
+def test_hodograph_range_with_units():
+    """Tests making a hodograph with a range with units."""
     fig = plt.figure(figsize=(6, 6))
     ax = fig.add_subplot(1, 1, 1)
     Hodograph(ax, component_range=60. * units.knots)

--- a/tests/plots/test_station_plot.py
+++ b/tests/plots/test_station_plot.py
@@ -400,7 +400,7 @@ def test_barb_no_default_unit_conversion():
 @pytest.mark.parametrize('u,v', [(np.array([3]) * units('m/s'), np.array([3])),
                                  (np.array([3]), np.array([3]) * units('m/s'))])
 def test_barb_unit_conversion_exception(u, v):
-    """Test that errors are raise if unit conversion is requested on un-united data."""
+    """Test that an error is raised if unit conversion is requested on plain arrays."""
     x_pos = np.array([0])
     y_pos = np.array([0])
 
@@ -451,7 +451,7 @@ def test_stationplot_unit_conversion():
 
 
 def test_scalar_unit_conversion_exception():
-    """Test that errors are raise if unit conversion is requested on un-united data."""
+    """Test that an error is raised if unit conversion is requested on plain arrays."""
     x_pos = np.array([0])
     y_pos = np.array([0])
 

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -138,7 +138,7 @@ def test_pandas_units_on_dataframe():
 
 
 @pytest.mark.filterwarnings("ignore:Pandas doesn't allow columns to be created")
-def test_pandas_units_on_dataframe_not_all_united():
+def test_pandas_units_on_dataframe_not_all_with_units():
     """Unit attachment with units attribute with a column with no units."""
     df = pd.DataFrame(data=[[1, 4], [2, 5], [3, 6]], columns=['cola', 'colb'])
     df.units = {'cola': 'kilometers'}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
"united" doesn't mean what we want it to in these contexts. Let's go with "unit-ed" at least. I am open to changing to things like "quantity with units" or...?

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- ~[ ] Closes #xxxx~
- ~[ ] Tests added~
- ~[ ] Fully documented~
