### PR TITLE
Fix linkcheck

### DIFF
--- a/ci/filter_links.py
+++ b/ci/filter_links.py
@@ -40,6 +40,6 @@ if __name__ == '__main__':
         if check_link(link):
             ret = 1
             print(f'{link["filename"]}:{link["lineno"]}: {link["uri"]} -> '
-                  f'{link["status"]} {link["code"]}')
+                  f'{link["status"]} {link["info"]}')
 
     sys.exit(ret)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -389,3 +389,8 @@ linkcheck_allowed_redirects = {
     r'https://github.com/Unidata/MetPy/issues/new/choose': r'https://github.com/login.*choose',
     r'https://doi.org/.*': r'https://.*'
 }
+
+linkcheck_request_headers = {
+    r'https://docs.github.com/': {'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux i686; '
+                                                'rv:24.0) Gecko/20100101 Firefox/24.0'}
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Work-around GitHub docs failing linkchecker. For some reason the GitHub docs site is giving a 403 for things like cURL and the Sphinx linkchecker. Give it a "real" user agent to get around this for now.

Also tweak our linkcheck handler script for CI to give better output. In this case, "code" was 0, so might as well just use "info" instead.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2430 
- ~[ ] Tests added~
- ~[ ] Fully documented~
