### PR TITLE
Add a method for plotting a range on a SkewT

### DIFF
--- a/src/metpy/plots/skewt.py
+++ b/src/metpy/plots/skewt.py
@@ -737,6 +737,76 @@ class SkewT:
         return self.shade_area(pressure[idx], t_parcel[idx], t[idx], which='negative',
                                **kwargs)
 
+    def plot_vertical_range(self, y0, y1, x, *, width=0.04, align='mid', **kwargs):
+        """Plot a vertical range indicator.
+
+        Draws a vertical staff, capped at either end by a horizontal line, used to denote
+        vertical regions of interest on the plot. The vertical extent of the range is
+        given by ``y0`` and ``y1`` and is centered at ``x``.
+
+        Parameters
+        ----------
+        y0 : float or int
+            Starting point of the staff in data coordinates
+        y1 : float or int
+            Ending point of the staff in data coordinates
+        x : float
+            Horizontal location given in normalized axes coordinates, where 0 and 1 represent
+            the left and right edges, respectively.
+        width : float
+            Width of the caps, given in normalized axes coordinates where 1.0 is the full
+            width of the axes. Optional and defaults to 0.04.
+        align : {'left', 'mid', 'right'}
+            Where in the cap the staff should be aligned, optional. Defaults to 'mid'.
+        kwargs
+            Other keyword arguments, such as ``colors`` or ``linewidths``, to pass to
+            :class:`matplotlib.collections.LineCollection` to control the appearance.
+
+        Returns
+        -------
+        :class:`matplotlib.collections.LineCollection`
+
+        See Also
+        --------
+        :class:`matplotlib.collections.LineCollection`
+
+        Notes
+        -----
+        The indicator is drawn using a single :class:`~matplotlib.collections.LineCollection`
+        instance, in the order of vertical staff, cap at y0, cap at y1, forcing the caps
+        to draw on top the staff. This is important when providing multiple colors.
+
+        If the ``colors`` argument is not passed in, the default color is ``'black'``.
+
+        """
+        # Override matplotlib's default color (tab:blue) since that doesn't work well
+        # for this on our default colors.
+        if 'colors' not in kwargs:
+            kwargs['colors'] = 'black'
+
+        # Configure how the top bars are aligned to the middle staff
+        if align == 'left':
+            left = x
+            right = x + width
+        elif align == 'mid':
+            left = x - width / 2
+            right = x + width / 2
+        elif align == 'right':
+            left = x - width
+            right = x
+        else:
+            raise ValueError('align should be one of "left", "right", or "mid".')
+
+        # Need to convert units before giving to LineCollection
+        y0 = self.ax.convert_yunits(y0)
+        y1 = self.ax.convert_yunits(y1)
+
+        # Create the collection where the x is given in axes coords, y in data coords.
+        lc = LineCollection([[(x, y0), (x, y1)],  # staff
+                             [(left, y0), (right, y0)], [(left, y1), (right, y1)]],  # caps
+                            transform=self.ax.get_yaxis_transform(), **kwargs)
+        return self.ax.add_collection(lc)
+
 
 @exporter.export
 class Hodograph:


### PR DESCRIPTION
#### Description Of Changes
This adds a `plot_vertical_range` method to `SkewT` to allow plotting up an indicator of a vertical range of interest, similar to those done in NSHARP/SHARPpy:

<img width="588" alt="image" src="https://user-images.githubusercontent.com/221526/163923684-001aeb2a-9c44-4111-9c55-2a70ea57ff78.png">

The code to add to our `Advanced_example.py` for that image are:
```python
skew.plot_vertical_range(lcl_pressure, lfc_pressure, 0.25)
skew.ax.text(0.25, lfc_pressure - 20 * units.hPa, 'CIN 250 J/kg', ha='center',
             fontdict={'size': 'large'}, transform=skew.ax.get_yaxis_transform())

skew.plot_vertical_range(105, 260, 0.4, width=0.06, colors=['tab:red'], linewidths=[3, 1.5, 1.5])
skew.ax.text(0.42, 180, 'No Data', color='tab:red', fontdict={'size': 'large'},
             transform=skew.ax.get_yaxis_transform())
```
As you can see, the labels right now are added by hand. So the todo's and questions to be answered are:
- [ ] naming? I'm not sure how I feel about `plot_vertical_range()`. `draw_vertical_range()`? Is a "vertical range" even the right terminology?
- [ ] Is it worth adding labelling? To what extent? Depending on how much control we add, it could really bloat the API.
- [ ] add tests
- [ ] Include in example(s) (?)

#### Checklist

- [ ] Tests added
- [x] Fully documented
