### PR TITLE
adds RGB image ability to declarative

### DIFF
--- a/src/metpy/plots/declarative.py
+++ b/src/metpy/plots/declarative.py
@@ -1173,11 +1173,19 @@ class PlotScalar(Plots2D):
                 if selector is not None:
                     subset[dim_coord] = selector
             data_subset = data.metpy.sel(**subset).squeeze()
-            if data_subset.ndim != 2:
-                raise ValueError(
-                    'Must provide a combination of subsetting values to give 2D data subset '
-                    'for plotting'
-                )
+            if (data_subset.ndim != 2):
+                if data_subset.ndim == 3:
+                    if (data_subset.shape[-1] not in (3, 4)):
+                        raise ValueError(
+                            'Must provide a combination of subsetting values to give either 2D'
+                            ' data or 3D data subset for plotting with third dimension size 3'
+                            ' or 4'
+                        )
+                else:
+                    raise ValueError(
+                        'Must provide a combination of subsetting values to give 2D data '
+                        'subset for plotting'
+                    )
             # Handle unit conversion (both direct unit specification and scaling)
             if self.plot_units is not None:
                 data_subset = data_subset.metpy.convert_units(self.plot_units)

--- a/tests/plots/test_declarative.py
+++ b/tests/plots/test_declarative.py
@@ -46,6 +46,50 @@ def test_declarative_image():
     return pc.figure
 
 
+@needs_cartopy
+def test_declarative_three_dims_error():
+    """Test making an image plot with three dimensions."""
+    data = xr.open_dataset(get_test_data('narr_example.nc', as_file_obj=False))
+
+    img = ImagePlot()
+    img.data = data
+    img.field = 'Temperature'
+    img.colormap = 'coolwarm'
+
+    panel = MapPanel()
+    panel.plots = [img]
+
+    pc = PanelContainer()
+    pc.panel = panel
+
+    with pytest.raises(ValueError, match='subset for plotting'):
+        pc.draw()
+
+
+@needs_cartopy
+def test_declarative_four_dims_error():
+    """Test making a contour plot with four dimensions."""
+    data = xr.open_dataset(get_test_data('CAM_test.nc', as_file_obj=False))
+
+    contour = ContourPlot()
+    contour.data = data
+    contour.field = 'PN'
+    contour.linecolor = 'black'
+    contour.contours = list(range(0, 1200, 4))
+
+    panel = MapPanel()
+    panel.plots = [contour]
+    panel.layout = (1, 1, 1)
+    panel.layers = ['coastline', 'borders', 'states', 'land']
+    panel.plots = [contour]
+
+    pc = PanelContainer()
+    pc.panels = [panel]
+
+    with pytest.raises(ValueError, match='subset for plotting'):
+        pc.draw()
+
+
 @pytest.mark.mpl_image_compare(remove_text=True, tolerance=0)
 @needs_cartopy
 def test_declarative_contour():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This PR adds a new attribute to the declarative syntax to indicate the plotting of an RGB image through a boolean setting. This preserves the check for 2D for all data, adds new check for if `rgb_image` is set to `True` and check to ensure it is 3D.

Open to suggestions on naming and description of attribute.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2468
- [x] Tests added
- [x] Fully documented
