### PR TITLE
Improve CI reporting

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -30,7 +30,10 @@ runs:
         python -m coverage combine
         python -m coverage report
         python -m coverage xml
-        cat report.html >> $GITHUB_STEP_SUMMARY
+
+    - name: Output Summary
+      shell: bash
+      run: cat report.html >> $GITHUB_STEP_SUMMARY
 
     - name: Run doctests
       if: ${{ inputs.run-doctests == 'true' }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -26,10 +26,11 @@ runs:
       # By running coverage in "parallel" mode and "combining", we can clean up the path names
       run: |
         set -e -o pipefail
-        python -m coverage run -p -m pytest --mpl -W error::metpy.deprecation.MetpyDeprecationWarning tests/ 2>&1 | tee tests-${{ inputs.key }}.log
+        python -m coverage run -p -m pytest --mpl -W error::metpy.deprecation.MetpyDeprecationWarning --html report.html --self-contained-html tests/ 2>&1 | tee tests-${{ inputs.key }}.log
         python -m coverage combine
         python -m coverage report
         python -m coverage xml
+        cat report.html >> $GITHUB_STEP_SUMMARY
 
     - name: Run doctests
       if: ${{ inputs.run-doctests == 'true' }}

--- a/ci/test_requirements.txt
+++ b/ci/test_requirements.txt
@@ -1,5 +1,6 @@
 pytest==7.1.2
 pytest-mpl==0.15.1
-netCDF4==1.5.8
+pytest-html==3.1.1
 coverage==6.3.2
 dask==2022.5.0
+netCDF4==1.5.8


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Trying to use the new [GHA job summary](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) to improve CI output. Right now, this is using [pytest-html](https://pytest-html.readthedocs.io/en/latest/user_guide.html) to generate a report from our test step.

Other alternatives are [pytest-md-report](https://github.com/thombashi/pytest-md-report) and [pytest-md](https://github.com/hackebrot/pytest-md).

Another idea with pytest-html would be to try to include some/all of the failed images there.


<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Fully documented
