### PR TITLE
Fix compatibility with future Pint

### DIFF
--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -23,7 +23,6 @@ import warnings
 
 import numpy as np
 import pint
-import pint.unit
 
 log = logging.getLogger(__name__)
 
@@ -56,9 +55,8 @@ with warnings.catch_warnings():
     warnings.simplefilter('ignore')
     units.Quantity([])
 
-# For pint 0.6, this is the best way to define a dimensionless unit. See pint #185
-units.define(pint.unit.UnitDefinition('percent', '%', (),
-             pint.converters.ScaleConverter(0.01)))
+# Add a percent unit
+units.define('percent = 0.01 = %')
 
 # Define commonly encountered units not defined by pint
 units.define('degrees_north = degree = degrees_N = degreesN = degree_north = degree_N '


### PR DESCRIPTION
#### Description Of Changes

Pint has restructured and removed the `.unit` submodule. We were only using that to get around defining a percent unit, which works using standard syntax now--and we don't need to support older Pint versions
with our workaround any more.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2494 
- ~[ ] Tests added~
- ~[ ] Fully documented~
