### PR TITLE
Add flake8 requirements to linting

### DIFF
--- a/ci/extra_requirements.txt
+++ b/ci/extra_requirements.txt
@@ -1,1 +1,2 @@
 cartopy==0.20.2
+shapely==1.8.2

--- a/ci/linting_requirements.txt
+++ b/ci/linting_requirements.txt
@@ -13,6 +13,7 @@ flake8-mutable==1.2.0
 flake8-pie==0.15.0
 flake8-print==5.0.0
 flake8-quotes==3.3.1
+flake8-requirements==1.5.3
 flake8-simplify==0.19.2
 pep8-naming==0.12.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,9 +54,19 @@ install_requires =
 where = src
 
 [options.extras_require]
-doc = sphinx; sphinx-gallery>=0.4; myst-parser; netCDF4
-examples = cartopy>=0.15.0; matplotlib>=2.2.0
-test = pytest>=2.4; pytest-mpl; cartopy>=0.17.0; netCDF4
+doc =
+    sphinx
+    sphinx-gallery>=0.4
+    myst-parser
+    netCDF4
+examples =
+    cartopy>=0.15.0
+    matplotlib>=2.2.0
+test =
+    pytest>=2.4
+    pytest-mpl
+    cartopy>=0.17.0
+    netCDF4
 
 [build_sphinx]
 source-dir = docs/source

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,11 +62,13 @@ doc =
 examples =
     cartopy>=0.15.0
     matplotlib>=2.2.0
+    shapely>=1.6.0
 test =
     pytest>=2.4
     pytest-mpl
     cartopy>=0.17.0
     netCDF4
+    shapely>=1.6.0
 
 [build_sphinx]
 source-dir = docs/source

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,8 +60,9 @@ doc =
     myst-parser
     netCDF4
 examples =
-    cartopy>=0.15.0
-    matplotlib>=2.2.0
+    cartopy>=0.17.0
+    geopandas>=0.6.0
+    matplotlib>=3.3.0
     shapely>=1.6.0
 test =
     pytest>=2.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,6 +89,7 @@ multiline-quotes = double
 rst-roles = class, data, doc, func, meth, mod
 rst-directives = plot, versionchanged
 docstring-convention = numpy
+known-modules = matplotlib:[matplotlib,mpl_toolkits],netcdf4:[netCDF4]
 exclude = docs build src/metpy/io/_metar_parser/metar_parser.py
 select = A B C D E F G H I J K L M N O P Q R S T U V W X Y Z B902
 ignore = F405 W503 RST902 SIM106
@@ -100,9 +101,11 @@ per-file-ignores = examples/*.py: D MPY001 T003 T201
                    src/metpy/io/*.py: RST306
                    src/metpy/future.py: RST307
                    src/metpy/constants/*.py: RST306
+                   src/metpy/_version.py: I900
                    docs/doc-server.py: T201
                    tests/*.py: MPY001
                    ci/filter_links.py: E731 T201
+                   tools/flake8-metpy/test_flake8_metpy.py: I900
 
 [flake8:local-plugins]
 extension = MPY = flake8_metpy:MetPyChecker


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This helps catch times we don't have libraries properly declared in `setup.cfg`--it's not configured currently to checkout files in `ci/` since you can't do both.

This caught us missing an explicit dependency on Shapely (we were getting it transitively through Cartopy) as well as not listing geopandas in `setup.cfg` for the examples.


<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [ ] ~Closes #xxxx~
- [ ] ~Tests added~
- [ ] ~Fully documented~
