### PR TITLE
Configure dependabot for our composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,52 @@
 version: 2
 
 updates:
+  # Handle PyPI updates
   - package-ecosystem: pip
     directory: "/ci"
     schedule:
       interval: daily
       time: "06:00"
       timezone: "America/Denver"
-
     allow:
       - dependency-type: all
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "Type: Maintenance"
+      - "Area: Infrastructure"
+    commit-message:
+      prefix: "CI: "
+      include: "scope"
 
+  # Update GitHub Actions versions in workflows
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: all
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "Type: Maintenance"
+      - "Area: Infrastructure"
+    commit-message:
+      prefix: "CI: "
+      include: "scope"
+
+  # Update GitHub Actions versions in composite actions--hopefully eventually handled by a
+  # wildcard
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/build-docs"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: all
     open-pull-requests-limit: 10
     pull-request-branch-name:
       separator: "-"
@@ -22,15 +58,59 @@ updates:
       include: "scope"
 
   - package-ecosystem: "github-actions"
-    # Workflow files stored in the
-    # default location of `.github/workflows`
-    directory: "/"
+    directory: "/.github/actions/install-conda"
     schedule:
       interval: "daily"
-
     allow:
       - dependency-type: all
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "Type: Maintenance"
+      - "Area: Infrastructure"
+    commit-message:
+      prefix: "CI: "
+      include: "scope"
 
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/install-pypi"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: all
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "Type: Maintenance"
+      - "Area: Infrastructure"
+    commit-message:
+      prefix: "CI: "
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/run-tests"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: all
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "Type: Maintenance"
+      - "Area: Infrastructure"
+    commit-message:
+      prefix: "CI: "
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/setup-proj"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: all
     open-pull-requests-limit: 10
     pull-request-branch-name:
       separator: "-"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

This configures Dependabot to check for GitHub Actions updates within our composite actions (which it supports now). Hopefully one day dependabot/dependabot-core#5137 is addressed and we can avoid listing ALL our actions, but this is at least a nice step forward that keeps us from getting out of date (which has actually caused us to miss a useful update to actions/cache@v3).

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- ~[ ] Closes #xxxx~
- ~[ ] Tests added~
- ~[ ] Fully documented~
