### PR TITLE
Fix caching of PROJ build

### DIFF
--- a/.github/actions/setup-proj/action.yml
+++ b/.github/actions/setup-proj/action.yml
@@ -16,7 +16,7 @@ runs:
       uses: actions/cache@v3
       id: cache-proj
       with:
-        path: ~/${{ inputs.install-path }}
+        path: ${{ inputs.install-path }}
         key: proj-${{ runner.os }}-${{ inputs.version }}-0
 
     - name: Download and build PROJ
@@ -28,7 +28,7 @@ runs:
         pushd proj-build
         mkdir build
         cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/${{ inputs.install-path }} -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release \
+        cmake .. -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/${{ inputs.install-path }} -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release \
           -DENABLE_IPO=ON -DENABLE_CURL=OFF -DBUILD_CCT:BOOL=OFF -DBUILD_CS2CS:BOOL=OFF -DBUILD_GEOD:BOOL=OFF \
           -DBUILD_GIE:BOOL=OFF -DBUILD_PROJINFO:BOOL=OFF -DBUILD_PROJSYNC:BOOL=OFF -DBUILD_TESTING:BOOL=OFF
         cmake --build . -j6
@@ -38,7 +38,7 @@ runs:
     - name: Update environment
       shell: bash
       run: |
-        echo "CPATH=$CPATH:$HOME/${{ inputs.install-path }}/include" >> $GITHUB_ENV
-        echo "LIBRARY_PATH=$LIBRARY_PATH:$HOME/${{ inputs.install-path }}/lib" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/${{ inputs.install-path }}/lib" >> $GITHUB_ENV
-        echo "$HOME/${{ inputs.install-path }}/bin" >> $GITHUB_PATH
+        echo "CPATH=$CPATH:$GITHUB_WORKSPACE/${{ inputs.install-path }}/include" >> $GITHUB_ENV
+        echo "LIBRARY_PATH=$LIBRARY_PATH:$GITHUB_WORKSPACE/${{ inputs.install-path }}/lib" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/${{ inputs.install-path }}/lib" >> $GITHUB_ENV
+        echo "$GITHUB_WORKSPACE/${{ inputs.install-path }}/bin" >> $GITHUB_PATH

--- a/.github/actions/setup-proj/action.yml
+++ b/.github/actions/setup-proj/action.yml
@@ -4,9 +4,9 @@ inputs:
   version:
     description: 'What version of PROJ to install'
     required: true
-    default: 8.1.1
+    default: 8.2.1
   install-path:
-    description: 'Where to install PROJ relative to home'
+    description: 'Where to install PROJ relative to workspace'
     required: false
     default: local
 runs:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

With #2525 merged, we're properly storing the PROJ build into cache. This PR aims to fix loading that cache.

~Just as soon as I figure out what's wrong.~
EDIT: So the core problem is that apparently at some point the path that got cached was `~`. When you request based on a key, but with a different path, it helpfully just says "Nope didn't find it", but then when it tries to save it says "This already exists". Combined with the non-existent UI, it was essentially chance that I figured out what the problem was.

This PR changes from explicitly doing things relative to `~`/`$HOME` and instead just does it relative to the workspace directory, which is the default. This should keep this from happening in the future--I'm still not at all clear on how this happened.

This also bumps us to the latest 8.x version of PROJ to force a rebuild of the cached copy.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- ~[ ] Closes #xxxx~
- ~[ ] Tests added~
- ~[ ] Fully documented~
