### PR TITLE
Shapely build

### DIFF
--- a/.github/actions/install-pypi/action.yml
+++ b/.github/actions/install-pypi/action.yml
@@ -37,7 +37,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get install libgeos-dev
-        python -m pip install --no-binary :all: shapely
+        python -m pip install --no-binary shapely -c ci/${{ inputs.version-file }} shapely
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/install-pypi/action.yml
+++ b/.github/actions/install-pypi/action.yml
@@ -35,9 +35,7 @@ runs:
     - name: Install CartoPy build dependencies
       if: ${{ inputs.need-cartopy == 'true' }}
       shell: bash
-      run: |
-        sudo apt-get install libgeos-dev
-        python -m pip install --no-binary shapely -c ci/${{ inputs.version-file }} shapely
+      run: sudo apt-get install libgeos-dev
 
     - name: Install dependencies
       shell: bash
@@ -46,7 +44,7 @@ runs:
     - name: Install extra dependencies
       if: ${{ inputs.need-cartopy == 'true' }}
       shell: bash
-      run: python -m pip install -r ci/extra_requirements.txt -c ci/${{ inputs.version-file }}
+      run: python -m pip install --no-binary shapely -r ci/extra_requirements.txt -c ci/${{ inputs.version-file }}
 
     - name: Download Cartopy Maps
       if: ${{ inputs.need-cartopy == 'true' }}

--- a/.github/actions/install-pypi/action.yml
+++ b/.github/actions/install-pypi/action.yml
@@ -37,6 +37,10 @@ runs:
       shell: bash
       run: sudo apt-get install libgeos-dev
 
+    - name: Disable Shapely Wheels
+      shell: bash
+      run: echo "PIP_NO_BINARY=shapely" >> $GITHUB_ENV
+
     - name: Install dependencies
       shell: bash
       run: python -m pip install -r ci/${{ inputs.type }}_requirements.txt -c ci/${{ inputs.version-file }}
@@ -44,7 +48,7 @@ runs:
     - name: Install extra dependencies
       if: ${{ inputs.need-cartopy == 'true' }}
       shell: bash
-      run: python -m pip install --no-binary shapely -r ci/extra_requirements.txt -c ci/${{ inputs.version-file }}
+      run: python -m pip install -r ci/extra_requirements.txt -c ci/${{ inputs.version-file }}
 
     - name: Download Cartopy Maps
       if: ${{ inputs.need-cartopy == 'true' }}

--- a/.github/actions/install-pypi/action.yml
+++ b/.github/actions/install-pypi/action.yml
@@ -37,7 +37,6 @@ runs:
       shell: bash
       run: |
         sudo apt-get install libgeos-dev
-        python -m pip install --upgrade pip setuptools
         python -m pip install --no-binary :all: shapely
 
     - name: Install dependencies


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

Tweak Shapely installation so that the dependencies it installs matches our desired versions *and* not force them to be built from source. This will hopefully reduce the *7* minutes we spend every CI installing Shapely.

Also eliminate updating `pip` and `setuptools`, it just seems superfluous since we're not relying on any new stuff there.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- ~[ ] Closes #xxxx~
- ~[ ] Tests added~
- ~[ ] Fully documented~
