### PR TITLE
Implement convective condensation level (CCL)

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,4 +1,4 @@
-importlib_resources==5.7.1
+importlib_resources==5.8.0
 matplotlib==3.5.2
 numpy==1.22.4
 pandas==1.4.2

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -6,5 +6,5 @@ pooch==1.6.0
 pint==0.19.2
 pyproj==3.3.1
 scipy==1.8.1
-traitlets==5.2.2.post1
+traitlets==5.3.0
 xarray==2022.3.0

--- a/docs/_templates/overrides/metpy.calc.rst
+++ b/docs/_templates/overrides/metpy.calc.rst
@@ -70,6 +70,7 @@ Soundings
       bulk_shear
       bunkers_storm_motion
       cape_cin
+      ccl
       critical_angle
       cross_totals
       el

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -445,8 +445,8 @@ def lcl(pressure, temperature, dewpoint, max_iters=50, eps=1e-5):
 
 @exporter.export
 @preprocess_and_wrap()
-@check_units('[pressure]', '[temperature]', '[temperature]', '[length]')
-def ccl(pressure, temperature, dewpoint, mixed_layer_depth=None, which='top'):
+@check_units('[pressure]', '[temperature]', '[temperature]')
+def ccl(pressure, temperature, dewpoint, height=None, mixed_layer_depth=None, which='top'):
     r"""Calculate the convective condensation level (CCL).
 
     This function is implemented by simplifying the mixing ratio and
@@ -512,7 +512,7 @@ def ccl(pressure, temperature, dewpoint, mixed_layer_depth=None, which='top'):
     # If the mixed layer is not defined, take the starting dewpoint to be the
     # first element of the dewpoint array.
     if mixed_layer_depth is None:
-        dewpoint_start = dewpoint[0]
+        p_start, dewpoint_start = pressure[0], dewpoint[0]
         vapor_pressure_start = saturation_vapor_pressure(dewpoint_start)
         r_start = mixing_ratio(vapor_pressure_start, p_start)
 

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -9,7 +9,6 @@ import scipy.integrate as si
 import scipy.optimize as so
 import xarray as xr
 
-from .basic import add_height_to_pressure
 from .exceptions import InvalidSoundingError
 from .tools import (_greater_or_close, _less_or_close, _remove_nans, find_bounding_indices,
                     find_intersections, first_derivative, get_layer)
@@ -446,7 +445,7 @@ def lcl(pressure, temperature, dewpoint, max_iters=50, eps=1e-5):
 @exporter.export
 @preprocess_and_wrap()
 @check_units('[pressure]', '[temperature]', '[temperature]', '[length]')
-def ccl(pressure, temperature, dewpoint, mixed_layer_depth=None, which='top'):
+def ccl(pressure, temperature, dewpoint, height=None, mixed_layer_depth=None, which='top'):
     r"""Calculate the convective condensation level (CCL).
 
     This function is implemented by simplifying the mixing ratio and
@@ -470,9 +469,12 @@ def ccl(pressure, temperature, dewpoint, mixed_layer_depth=None, which='top'):
     dewpoint : `pint.Quantity`
         Dewpoint at the levels given by `pressure`
 
+    height : `pint.Quantity`, optional
+        Atmospheric heights at the levels given by `pressure`
+
     mixed_layer_depth : `pint.Quantity`, optional
-        The depth of the mixed layer, defaults to` None`. If provided, should be
-        in a unit of length.
+        The thickness of the mixed layer as a pressure or height above the bottom
+        of the layer (default None)
 
     which: str, optional
         Pick which CCL value to return; must be one of 'top', 'bottom', or 'all'.
@@ -507,26 +509,20 @@ def ccl(pressure, temperature, dewpoint, mixed_layer_depth=None, which='top'):
     dewpoint, temperature = dewpoint.to(units.degC), temperature.to(units.degC)
     pressure = pressure.to(units.hPa)
 
-    p_start = pressure[0]
-
     # If the mixed layer is not defined, take the starting dewpoint to be the
     # first element of the dewpoint array.
     if mixed_layer_depth is None:
-        dewpoint_start = dewpoint[0]
+        p_start, dewpoint_start = dewpoint[0], pressure[0]
         vapor_pressure_start = saturation_vapor_pressure(dewpoint_start)
         r_start = mixing_ratio(vapor_pressure_start, p_start)
 
     # If it is defined, sample 10 values from the mixed layer and calculate the
     # corresponding mixing ratio. Take the numeric average of these 10 values.
     else:
-        p_top = add_height_to_pressure(p_start, mixed_layer_depth)
-        p_sample = np.linspace(p_start, p_top, 10)
-
-        dewpoint_profile = interpolate_1d(p_sample, pressure, dewpoint)
-        vapor_pressure_profile = saturation_vapor_pressure(dewpoint_profile)
-
-        r_profile = mixing_ratio(vapor_pressure_profile, p_sample)
-        r_start = np.mean(r_profile)
+        vapor_pressure_profile = saturation_vapor_pressure(dewpoint)
+        r_profile = mixing_ratio(vapor_pressure_profile, pressure)
+        r_start = mixed_layer(pressure, r_profile, height=height,
+                              depth=mixed_layer_depth)[0]
 
     a_p = np.log(r_start * pressure / (
         mpconsts.default.sat_pressure_0c * (mpconsts.nounit.epsilon + r_start)))
@@ -546,7 +542,7 @@ def ccl(pressure, temperature, dewpoint, mixed_layer_depth=None, which='top'):
                          'and "all".')
 
     x, y = x.to(pressure.units), y.to(temperature.units)
-    return x, y, potential_temperature(x, y)
+    return x, y, potential_temperature(x, y).to(temperature.units)
 
 
 @exporter.export

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -445,8 +445,8 @@ def lcl(pressure, temperature, dewpoint, max_iters=50, eps=1e-5):
 
 @exporter.export
 @preprocess_and_wrap()
-@check_units('[pressure]', '[temperature]', '[temperature]')
-def ccl(pressure, temperature, dewpoint, height=None, mixed_layer_depth=None, which='top'):
+@check_units('[pressure]', '[temperature]', '[temperature]', '[length]')
+def ccl(pressure, temperature, dewpoint, mixed_layer_depth=None, which='top'):
     r"""Calculate the convective condensation level (CCL).
 
     This function is implemented by simplifying the mixing ratio and
@@ -512,7 +512,7 @@ def ccl(pressure, temperature, dewpoint, height=None, mixed_layer_depth=None, wh
     # If the mixed layer is not defined, take the starting dewpoint to be the
     # first element of the dewpoint array.
     if mixed_layer_depth is None:
-        p_start, dewpoint_start = pressure[0], dewpoint[0]
+        dewpoint_start = dewpoint[0]
         vapor_pressure_start = saturation_vapor_pressure(dewpoint_start)
         r_start = mixing_ratio(vapor_pressure_start, p_start)
 

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -541,8 +541,6 @@ def ccl(pressure, temperature, dewpoint, mixed_layer_depth=None, which='top'):
         x, y = x[-1], y[-1]
     elif which == 'bottom':
         x, y = x[0], y[0]
-    elif which == 'all':
-        pass
     else:
         raise ValueError('Invalid option for "which". Valid options are "top", "bottom", '
                          'and "all".')

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -541,7 +541,7 @@ def ccl(pressure, temperature, dewpoint, mixed_layer_depth=None, which='top'):
         x, y = x[-1], y[-1]
     elif which == 'bottom':
         x, y = x[0], y[0]
-    else:
+    elif which not in ['top', 'bottom', 'all']:
         raise ValueError('Invalid option for "which". Valid options are "top", "bottom", '
                          'and "all".')
 

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -10,7 +10,7 @@ import pytest
 import xarray as xr
 
 from metpy.calc import (brunt_vaisala_frequency, brunt_vaisala_frequency_squared,
-                        brunt_vaisala_period, cape_cin, cross_totals, density, dewpoint,
+                        brunt_vaisala_period, cape_cin, ccl, cross_totals, density, dewpoint,
                         dewpoint_from_relative_humidity, dewpoint_from_specific_humidity,
                         dry_lapse, dry_static_energy, el, equivalent_potential_temperature,
                         exner_function, gradient_richardson_number, InvalidSoundingError,
@@ -397,6 +397,125 @@ def test_lcl_nans():
                                                    np.nan, 836.4098648012595]) * units.hPa)
     assert_array_almost_equal(lcl_temp, np.array([np.nan, 18.82281982535794,
                                                   np.nan, 18.82281982535794]) * units.degC)
+
+
+def test_ccl_basic():
+    """First test of CCL calculation. Data: ILX, June 17 2022 00Z."""
+    pressure = np.array([993.0, 984.0, 957.0, 948.0, 925.0, 917.0, 886.0, 868.0, 850.0,
+                         841.0, 813.0, 806.0, 798.0, 738.0, 732.0, 723.0, 716.0, 711.0,
+                         700.0, 623.0, 621.0, 582.0, 541.0, 500.0, 468.0]) * units.mbar
+    temperature = np.array([34.6, 33.7, 31.1, 30.1, 27.8, 27.1, 24.3, 22.6, 21.4,
+                            20.8, 19.6, 19.4, 18.7, 13.0, 13.0, 13.4, 13.5, 13.6,
+                            13.0, 5.2, 5.0, 1.5, -2.4, -6.7, -10.7]) * units.degC
+    dewpoint = np.array([19.6, 19.4, 18.7, 18.4, 17.8, 17.5, 16.3, 15.6, 12.4, 10.8,
+                         -0.4, -3.6, -3.8, -5.0, -6.0, -15.6, -13.2, -11.4, -11.0,
+                         -5.8, -6.2, -14.8, -24.3, -34.7, -38.1]) * units.degC
+    ccl_p, ccl_t, t_c = ccl(pressure, temperature, dewpoint)
+    assert_almost_equal(ccl_p, 763.006048 * units.mbar, 5)
+    assert_almost_equal(ccl_t, 15.429946 * units.degC, 5)
+    assert_almost_equal(t_c, 38.616596 * units.degC, 5)
+
+
+def test_ccl_nans():
+    """Tests CCL handles nans."""
+    pressure = np.array([993.0, 984.0, 957.0, np.nan, 925.0, 917.0, np.nan, 868.0, 850.0,
+                         841.0, 813.0, 806.0, 798.0, 738.0, 732.0, 723.0, 716.0, 711.0,
+                         700.0, 623.0, 621.0, 582.0, 541.0, 500.0, 468.0]) * units.mbar
+    temperature = np.array([34.6, np.nan, 31.1, np.nan, 27.8, 27.1, 24.3, 22.6, 21.4,
+                            20.8, 19.6, 19.4, 18.7, 13.0, 13.0, 13.4, 13.5, 13.6,
+                            13.0, 5.2, 5.0, 1.5, -2.4, -6.7, -10.7]) * units.degC
+    dewpoint = np.array([19.6, 19.4, 18.7, np.nan, 17.8, 17.5, 16.3, 15.6, 12.4, 10.8,
+                         -0.4, -3.6, -3.8, -5.0, -6.0, -15.6, -13.2, -11.4, -11.0,
+                         -5.8, -6.2, -14.8, -24.3, -34.7, -38.1]) * units.degC
+    ccl_p, ccl_t, t_c = ccl(pressure, temperature, dewpoint)
+    assert_almost_equal(ccl_p, 763.006048 * units.mbar, 5)
+    assert_almost_equal(ccl_t, 15.429946 * units.degC, 5)
+    assert_almost_equal(t_c, 38.616596 * units.degC, 5)
+
+
+def test_ccl_unit():
+    """Tests CCL pressure and temperature is returned in the correct unit."""
+    pressure = (np.array([993.0, 984.0, 957.0, 948.0, 925.0, 917.0, 886.0, 868.0, 850.0,
+                         841.0, 813.0, 806.0, 798.0, 738.0, 732.0, 723.0, 716.0, 711.0,
+                         700.0, 623.0, 621.0, 582.0, 541.0, 500.0, 468.0]) * 100) * units.Pa
+    temperature = (np.array([34.6, 33.7, 31.1, 30.1, 27.8, 27.1, 24.3, 22.6, 21.4,
+                             20.8, 19.6, 19.4, 18.7, 13.0, 13.0, 13.4, 13.5, 13.6,
+                             13.0, 5.2, 5.0, 1.5, -2.4, -6.7, -10.7]) + 273.15) * units.kelvin
+    dewpoint = (np.array([19.6, 19.4, 18.7, 18.4, 17.8, 17.5, 16.3, 15.6, 12.4, 10.8,
+                          -0.4, -3.6, -3.8, -5.0, -6.0, -15.6, -13.2, -11.4, -11.0,
+                          -5.8, -6.2, -14.8, -24.3, -34.7, -38.1]) + 273.15) * units.kelvin
+
+    ccl_p, ccl_t, t_c = ccl(pressure, temperature, dewpoint)
+    assert_almost_equal(ccl_p, (763.006048 * 100) * units.Pa, 3)
+    assert_almost_equal(ccl_t, (15.429946 + 273.15) * units.kelvin, 3)
+    assert_almost_equal(t_c, (38.616596 + 273.15) * units.kelvin, 3)
+
+
+def test_multiple_ccl():
+    """Tests the case where there are multiple CCLs. Data: BUF, May 18 2022 12Z."""
+    pressure = np.array([992.0, 990.0, 983.0, 967.0, 950.0, 944.0, 928.0, 925.0, 922.0,
+                         883.0, 877.7, 858.0, 853.0, 850.0, 835.0, 830.0, 827.0, 826.0,
+                         813.6, 808.0, 799.0, 784.0, 783.3, 769.0, 760.0, 758.0, 754.0,
+                         753.0, 738.0, 725.7, 711.0, 704.0, 700.0, 685.0, 672.0, 646.6,
+                         598.6, 596.0, 587.0, 582.0, 567.0, 560.0, 555.0, 553.3, 537.0,
+                         526.0, 521.0, 519.0, 515.0, 500.0]) * units.mbar
+    temperature = np.array([6.8, 6.2, 7.8, 7.6, 7.2, 7.6, 6.6, 6.4, 6.2, 3.2, 2.8, 1.2,
+                            1.0, 0.8, -0.3, -0.1, 0.4, 0.6, 0.9, 1.0, 0.6, -0.3, -0.3,
+                            -0.7, -1.5, -1.3, 0.2, 0.2, -1.1, -2.1, -3.3, -2.3, -1.7, 0.2,
+                            -0.9, -3.0, -7.3, -7.5, -8.1, -8.3, -9.5, -10.1, -10.7,
+                            -10.8, -12.1, -12.5, -12.7, -12.9, -13.5, -15.5]) * units.degC
+    dewpoint = np.array([5.1, 5.0, 4.2, 2.7, 2.2, 0.6, -2.4, -2.6, -2.8, -3.8, -3.6,
+                        -3.1, -5.0, -4.2, -1.8, -4.3, -7.6, -6.4, -8.2, -9.0, -10.4,
+                        -9.3, -9.6, -14.7, -11.5, -12.3, -25.8, -25.8, -19.1, -19.6,
+                        -20.3, -42.3, -39.7, -46.8, -46.8, -46.7, -46.5, -46.5,
+                        -52.1, -36.3, -47.5, -30.1, -29.7, -30.4, -37.1, -49.5,
+                        -36.7, -28.9, -28.5, -22.5]) * units.degC
+
+    ccl_p, ccl_t, t_c = ccl(pressure, temperature, dewpoint)
+    assert_almost_equal(ccl_p, 680.191653 * units.mbar, 5)
+    assert_almost_equal(ccl_t, -0.204408 * units.degC, 5)
+    assert_almost_equal(t_c, 31.566319 * units.degC, 5)
+
+    ccl_p, ccl_t, t_c = ccl(pressure, temperature, dewpoint, which='bottom')
+    assert_almost_equal(ccl_p, 886.835325 * units.mbar, 5)
+    assert_almost_equal(ccl_t, 3.500840 * units.degC, 5)
+    assert_almost_equal(t_c, 13.158340 * units.degC, 5)
+
+    ccl_p, ccl_t, t_c = ccl(pressure, temperature, dewpoint, which='all')
+    assert_array_almost_equal(ccl_p, np.array([886.835325, 680.191653]) * units.mbar, 5)
+    assert_array_almost_equal(ccl_t, np.array([3.500840, -0.204408]) * units.degC, 5)
+    assert_array_almost_equal(t_c, np.array([13.158340, 31.566319]) * units.degC, 5)
+
+
+def test_ccl_with_ml():
+    """Test CCL calculation with a specified mixed-layer depth."""
+    pressure = np.array([992.0, 990.0, 983.0, 967.0, 950.0, 944.0, 928.0, 925.0, 922.0,
+                         883.0, 877.7, 858.0, 853.0, 850.0, 835.0, 830.0, 827.0, 826.0,
+                         813.6, 808.0, 799.0, 784.0, 783.3, 769.0, 760.0, 758.0, 754.0,
+                         753.0, 738.0, 725.7, 711.0, 704.0, 700.0, 685.0, 672.0, 646.6,
+                         598.6, 596.0, 587.0, 582.0, 567.0, 560.0, 555.0, 553.3, 537.0,
+                         526.0, 521.0, 519.0, 515.0, 500.0]) * units.mbar
+    temperature = np.array([6.8, 6.2, 7.8, 7.6, 7.2, 7.6, 6.6, 6.4, 6.2, 3.2, 2.8, 1.2,
+                            1.0, 0.8, -0.3, -0.1, 0.4, 0.6, 0.9, 1.0, 0.6, -0.3, -0.3,
+                            -0.7, -1.5, -1.3, 0.2, 0.2, -1.1, -2.1, -3.3, -2.3, -1.7, 0.2,
+                            -0.9, -3.0, -7.3, -7.5, -8.1, -8.3, -9.5, -10.1, -10.7,
+                            -10.8, -12.1, -12.5, -12.7, -12.9, -13.5, -15.5]) * units.degC
+    dewpoint = np.array([5.1, 5.0, 4.2, 2.7, 2.2, 0.6, -2.4, -2.6, -2.8, -3.8, -3.6,
+                        -3.1, -5.0, -4.2, -1.8, -4.3, -7.6, -6.4, -8.2, -9.0, -10.4,
+                        -9.3, -9.6, -14.7, -11.5, -12.3, -25.8, -25.8, -19.1, -19.6,
+                        -20.3, -42.3, -39.7, -46.8, -46.8, -46.7, -46.5, -46.5,
+                        -52.1, -36.3, -47.5, -30.1, -29.7, -30.4, -37.1, -49.5,
+                        -36.7, -28.9, -28.5, -22.5]) * units.degC
+
+    ccl_p, ccl_t, t_c = ccl(pressure, temperature, dewpoint,
+                            mixed_layer_depth=500 * units.m, which='all')
+
+    assert_array_almost_equal(ccl_p, np.array(
+        [849.476714, 777.672978, 736.820907, 647.160197]) * units.mbar, 5)
+    assert_array_almost_equal(ccl_t, np.array(
+        [0.761954, -0.456521, -1.195136, -2.952801]) * units.degC, 5)
+    assert_array_almost_equal(t_c, np.array(
+        [13.831182, 19.855389, 23.601839, 32.819031]) * units.degC, 5)
 
 
 def test_lfc_basic():

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -511,11 +511,11 @@ def test_ccl_with_ml():
                             mixed_layer_depth=500 * units.m, which='all')
 
     assert_array_almost_equal(ccl_p, np.array(
-        [849.476714, 777.672978, 736.820907, 647.160197]) * units.mbar, 5)
+        [850.600930, 784.325312, 737.767377, 648.076147]) * units.mbar, 5)
     assert_array_almost_equal(ccl_t, np.array(
-        [0.761954, -0.456521, -1.195136, -2.952801]) * units.degC, 5)
+        [0.840118, -0.280299, -1.118757, -2.875716]) * units.degC, 5)
     assert_array_almost_equal(t_c, np.array(
-        [13.831182, 19.855389, 23.601839, 32.819031]) * units.degC, 5)
+        [13.804624, 19.332071, 23.576331, 32.782670]) * units.degC, 5)
 
 
 def test_lfc_basic():

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -511,11 +511,11 @@ def test_ccl_with_ml():
                             mixed_layer_depth=500 * units.m, which='all')
 
     assert_array_almost_equal(ccl_p, np.array(
-        [850.600930, 784.325312, 737.767377, 648.076147]) * units.mbar, 5)
+        [849.476714, 777.672978, 736.820907, 647.160197]) * units.mbar, 5)
     assert_array_almost_equal(ccl_t, np.array(
-        [0.840118, -0.280299, -1.118757, -2.875716]) * units.degC, 5)
+        [0.761954, -0.456521, -1.195136, -2.952801]) * units.degC, 5)
     assert_array_almost_equal(t_c, np.array(
-        [13.804624, 19.332071, 23.576331, 32.782670]) * units.degC, 5)
+        [13.831182, 19.855389, 23.601839, 32.819031]) * units.degC, 5)
 
 
 def test_lfc_basic():


### PR DESCRIPTION
#### Description Of Changes
This PR implemented the convective condensation level (CCL), with options to use either the surface mixing ratio or the average mixing ratio over a shallow layer near the surface, according to the definition of CCL by [AMS](https://glossary.ametsoc.org/wiki/Convective_condensation_level). 

I also wrote a bunch of tests to make sure that what I implemented is correct using UWYO sounding. I can't seem to find any existing software to compare my CCL calculations to, so I just eyeballed the desired values from the Skew-T diagrams. 

#### Checklist

- [x] Closes #1731
- [x] Tests added
- [x] Fully documented
