### PR TITLE
Add links to Twitter and MetPy Mondays on PyPI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,8 @@ project_urls =
     Release Notes = https://github.com/Unidata/MetPy/releases
     Bug Tracker = https://github.com/Unidata/MetPy/issues
     Source Code = https://github.com/Unidata/MetPy
+    Twitter = https://twitter.com/MetPy
+    MetPy Mondays = https://www.youtube.com/playlist?list=PLQut5OXpV-0ir4IdllSt1iEZKTwFBa7kO
 
 [options]
 zip_safe = True


### PR DESCRIPTION
#### Description Of Changes
Both Twitter and YouTube are [explicitly supported](https://github.com/pypi/warehouse/blob/39daea188d2e1e6494c50753cd48cb5a8da3e8c4/warehouse/templates/packaging/detail.html) by PyPI (Warehouse) with icons, and they seem like useful resources to feature on our PyPI page.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
