### PR TITLE
add 2D calculation examples

### DIFF
--- a/examples/calculations/Absolute_Vorticity.py
+++ b/examples/calculations/Absolute_Vorticity.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 MetPy Developers.
+# Copyright (c) 2022 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """

--- a/examples/calculations/Absolute_Vorticity.py
+++ b/examples/calculations/Absolute_Vorticity.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2015-2022 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+==================
+Absolute Vorticity
+==================
+
+Use `metpy.calc.absolute_vorticity`.
+
+This example demonstrates the calculatation of absolute vorticity using the example xarray
+Dataset and plotting using Matplotlib.
+"""
+import matplotlib.pyplot as plt
+
+import metpy.calc as mpcalc
+from metpy.cbook import example_data
+
+# load example data
+ds = example_data()
+
+# Calculate the vertical vorticity of the flow
+avor = mpcalc.absolute_vorticity(ds.uwind, ds.vwind)
+
+# start figure and set axis
+fig, ax = plt.subplots(figsize=(5, 5))
+
+# plot and scale absolute vorticity by 1e5
+cf = ax.contourf(ds.lon, ds.lat, avor * 1e5, range(-80, 81, 1), cmap=plt.cm.PuOr_r)
+plt.colorbar(cf, pad=0, aspect=50)
+ax.barbs(ds.lon.values, ds.lat.values, ds.uwind, ds.vwind, color='black', length=5, alpha=0.5)
+ax.set(xlim=(260, 270), ylim=(30, 40))
+ax.set_title('Absolute Vorticity Calculation')
+
+plt.show()

--- a/examples/calculations/Advection.py
+++ b/examples/calculations/Advection.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2015-2022 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+=========
+Advection
+=========
+
+Use `metpy.calc.advection`.
+
+This example demonstrates the advection calculation by computing the temperature advection of
+the example xarray Dataset and plotting using Matplotlib.
+"""
+import matplotlib.pyplot as plt
+
+import metpy.calc as mpcalc
+from metpy.cbook import example_data
+
+# load example data
+ds = example_data()
+
+# Calculate the temperature advection of the flow
+tadv = mpcalc.advection(ds.temperature, ds.uwind, ds.vwind)
+
+# See the units that come back from the advection function
+print(tadv.data.units)
+
+# start figure and set axis
+fig, ax = plt.subplots(figsize=(5, 5))
+
+# plot isotherms
+cs = ax.contour(ds.lon, ds.lat, ds.temperature, range(4, 26, 2), colors='tab:red',
+                linestyles='dashed', linewidths=3)
+plt.clabel(cs, fmt='%d', fontsize=16)
+
+# plot temperature advection and convert units to Kelvin per 3 hours
+cf = ax.contourf(ds.lon, ds.lat, tadv.metpy.convert_units('kelvin/hour') * 3, range(-6, 7, 1),
+                 cmap=plt.cm.bwr, alpha=0.75)
+plt.colorbar(cf, pad=0, aspect=50)
+ax.barbs(ds.lon.values[::2], ds.lat.values[::2],
+         ds.uwind[::2, ::2], ds.vwind[::2, ::2],
+         color='black', length=6, alpha=0.5)
+ax.set(xlim=(260, 270), ylim=(30, 40))
+ax.set_title('Temperature Advectionn Calculation')
+
+plt.show()

--- a/examples/calculations/Advection.py
+++ b/examples/calculations/Advection.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 MetPy Developers.
+# Copyright (c) 2022 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """
@@ -41,6 +41,6 @@ ax.barbs(ds.lon.values[::2], ds.lat.values[::2],
          ds.uwind[::2, ::2], ds.vwind[::2, ::2],
          color='black', length=6, alpha=0.5)
 ax.set(xlim=(260, 270), ylim=(30, 40))
-ax.set_title('Temperature Advectionn Calculation')
+ax.set_title('Temperature Advection Calculation')
 
 plt.show()

--- a/examples/calculations/Divergence.py
+++ b/examples/calculations/Divergence.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 MetPy Developers.
+# Copyright (c) 2022 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """

--- a/examples/calculations/Divergence.py
+++ b/examples/calculations/Divergence.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2015-2022 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+==========
+Divergence
+==========
+
+Use `metpy.calc.divergence`.
+
+This example demonstrates the calculation of total deformation using the example xarray
+Dataset and plotting using Matplotlib.
+"""
+import matplotlib.pyplot as plt
+
+import metpy.calc as mpcalc
+from metpy.cbook import example_data
+
+# load example data
+ds = example_data()
+
+# Calculate the total deformation of the flow
+div = mpcalc.divergence(ds.uwind, ds.vwind)
+
+# start figure and set axis
+fig, ax = plt.subplots(figsize=(5, 5))
+
+# plot divergence and scale by 1e5
+cf = ax.contourf(ds.lon, ds.lat, div * 1e5, range(-15, 16, 1), cmap=plt.cm.bwr_r)
+plt.colorbar(cf, pad=0, aspect=50)
+ax.barbs(ds.lon.values, ds.lat.values, ds.uwind, ds.vwind, color='black', length=5, alpha=0.5)
+ax.set(xlim=(260, 270), ylim=(30, 40))
+ax.set_title('Horizontal Divergence Calculation')
+
+plt.show()

--- a/examples/calculations/QVector.py
+++ b/examples/calculations/QVector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 MetPy Developers.
+# Copyright (c) 2022 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """
@@ -25,7 +25,6 @@ tadv = mpcalc.advection(ds.temperature, ds.uwind, ds.vwind)
 
 # Calculate the q-vectors
 u_qvect, v_qvect = mpcalc.q_vector(ds.uwind, ds.vwind, ds.temperature, 850 * units.hPa)
-print(u_qvect.data.units)
 
 # start figure and set axis
 fig, ax = plt.subplots(figsize=(5, 5))
@@ -45,7 +44,7 @@ qvec = ax.quiver(ds.lon.values[::2], ds.lat.values[::2],
                  u_qvect[::2, ::2] * 1e13, v_qvect[::2, ::2] * 1e13,
                  color='black', scale=1000, alpha=0.5, width=0.01)
 
-qk = ax.quiverkey(qvec, 0.8, 0.9, 200, r'$200 m^2/kg/s}$', labelpos='E',
+qk = ax.quiverkey(qvec, 0.8, 0.9, 200, r'$200 m^2/kg/s$', labelpos='E',
                   coordinates='figure')
 
 ax.set(xlim=(260, 270), ylim=(30, 40))

--- a/examples/calculations/QVector.py
+++ b/examples/calculations/QVector.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2015-2022 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+========
+Q-Vector
+========
+
+Use `metpy.calc.q_vector`.
+
+This example demonstrates the q_vector calculation by computing them from the example xarray
+Dataset and plotting using Matplotlib.
+"""
+import matplotlib.pyplot as plt
+
+import metpy.calc as mpcalc
+from metpy.cbook import example_data
+from metpy.units import units
+
+# load example data
+ds = example_data()
+
+# Calculate the temperature advection of the flow
+tadv = mpcalc.advection(ds.temperature, ds.uwind, ds.vwind)
+
+# Calculate the q-vectors
+u_qvect, v_qvect = mpcalc.q_vector(ds.uwind, ds.vwind, ds.temperature, 850 * units.hPa)
+print(u_qvect.data.units)
+
+# start figure and set axis
+fig, ax = plt.subplots(figsize=(5, 5))
+
+# plot isotherms
+cs = ax.contour(ds.lon, ds.lat, ds.temperature, range(4, 26, 2), colors='tab:red',
+                linestyles='dashed', linewidths=3)
+plt.clabel(cs, fmt='%d', fontsize=16)
+
+# plot temperature advection in Kelvin per 3 hours
+cf = ax.contourf(ds.lon, ds.lat, tadv.metpy.convert_units('kelvin/hour') * 3, range(-6, 7, 1),
+                 cmap=plt.cm.bwr, alpha=0.75)
+plt.colorbar(cf, pad=0, aspect=50)
+
+# plot Q-vectors as arrows, every other arrow
+qvec = ax.quiver(ds.lon.values[::2], ds.lat.values[::2],
+                 u_qvect[::2, ::2] * 1e13, v_qvect[::2, ::2] * 1e13,
+                 color='black', scale=1000, alpha=0.5, width=0.01)
+
+qk = ax.quiverkey(qvec, 0.8, 0.9, 200, r'$200 m^2/kg/s}$', labelpos='E',
+                  coordinates='figure')
+
+ax.set(xlim=(260, 270), ylim=(30, 40))
+ax.set_title('Q-Vector Calculation')
+
+plt.show()

--- a/examples/calculations/Shearing_Deformation.py
+++ b/examples/calculations/Shearing_Deformation.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2015-2022 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+====================
+Shearing Deformation
+====================
+
+Use `metpy.calc.shearing_deformation`.
+
+This example demonstrates the calculation of shearing deformation using the example xarray
+Dataset and plotting using Matplotlib.
+"""
+import matplotlib.pyplot as plt
+
+import metpy.calc as mpcalc
+from metpy.cbook import example_data
+
+# load example data
+ds = example_data()
+
+# Calculate the shearing deformation of the flow
+shr_def = mpcalc.shearing_deformation(ds.uwind, ds.vwind)
+
+# start figure and set axis
+fig, ax = plt.subplots(figsize=(5, 5))
+
+# plot shearing deformation and scale by 1e5
+cf = ax.contourf(ds.lon, ds.lat, shr_def * 1e5, range(-80, 81, 1), cmap=plt.cm.PuOr_r)
+plt.colorbar(cf, pad=0, aspect=50)
+ax.barbs(ds.lon.values, ds.lat.values, ds.uwind, ds.vwind, color='black', length=5, alpha=0.5)
+ax.set(xlim=(260, 270), ylim=(30, 40))
+ax.set_title('Shearing Deformation Calculation')
+
+plt.show()

--- a/examples/calculations/Shearing_Deformation.py
+++ b/examples/calculations/Shearing_Deformation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 MetPy Developers.
+# Copyright (c) 2022 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """

--- a/examples/calculations/Stretching_Deformation.py
+++ b/examples/calculations/Stretching_Deformation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 MetPy Developers.
+# Copyright (c) 2022 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """

--- a/examples/calculations/Stretching_Deformation.py
+++ b/examples/calculations/Stretching_Deformation.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2015-2022 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+======================
+Stretching Deformation
+======================
+
+Use `metpy.calc.stretching_deformation`.
+
+This example demonstrates the calculation of stretching deformation using the example xarray
+Dataset and plotting using Matplotlib.
+"""
+import matplotlib.pyplot as plt
+
+import metpy.calc as mpcalc
+from metpy.cbook import example_data
+
+# load example data
+ds = example_data()
+
+# Calculate the stretching deformation of the flow
+str_def = mpcalc.stretching_deformation(ds.uwind, ds.vwind)
+
+# start figure and set axis
+fig, ax = plt.subplots(figsize=(5, 5))
+
+# plot stretching deformation and scale by 1e5
+cf = ax.contourf(ds.lon, ds.lat, str_def * 1e5, range(-80, 81, 1), cmap=plt.cm.PuOr_r)
+plt.colorbar(cf, pad=0, aspect=50)
+ax.barbs(ds.lon.values, ds.lat.values, ds.uwind, ds.vwind, color='black', length=5, alpha=0.5)
+ax.set(xlim=(260, 270), ylim=(30, 40))
+ax.set_title('Stretching Deformation Calculation')
+
+plt.show()

--- a/examples/calculations/Total_Deformation.py
+++ b/examples/calculations/Total_Deformation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 MetPy Developers.
+# Copyright (c) 2022 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """

--- a/examples/calculations/Total_Deformation.py
+++ b/examples/calculations/Total_Deformation.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2015-2022 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+=================
+Total Deformation
+=================
+
+Use `metpy.calc.total_deformation`.
+
+This example demonstrates the calculation of total deformation using the example xarray
+Dataset and plotting using Matplotlib.
+"""
+import matplotlib.pyplot as plt
+
+import metpy.calc as mpcalc
+from metpy.cbook import example_data
+
+# load example data
+ds = example_data()
+
+# Calculate the total deformation of the flow
+total_def = mpcalc.total_deformation(ds.uwind, ds.vwind)
+
+# start figure and set axis
+fig, ax = plt.subplots(figsize=(5, 5))
+
+# plot stretching deformation and scale by 1e5
+cf = ax.contourf(ds.lon, ds.lat, total_def * 1e5, range(-80, 81, 1), cmap=plt.cm.PuOr_r)
+plt.colorbar(cf, pad=0, aspect=50)
+ax.barbs(ds.lon.values, ds.lat.values, ds.uwind, ds.vwind, color='black', length=5, alpha=0.5)
+ax.set(xlim=(260, 270), ylim=(30, 40))
+ax.set_title('Total Deformation Calculation')
+
+plt.show()

--- a/examples/calculations/Vorticity.py
+++ b/examples/calculations/Vorticity.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 MetPy Developers.
+# Copyright (c) 2022 MetPy Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """
@@ -8,7 +8,7 @@ Vorticity
 
 Use `metpy.calc.vorticity`.
 
-This example demonstrates the calculatation of relative vorticity using the example xarray
+This example demonstrates the calculation of relative vorticity using the example xarray
 Dataset and plotting using Matplotlib.
 """
 import matplotlib.pyplot as plt

--- a/examples/calculations/Vorticity.py
+++ b/examples/calculations/Vorticity.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2015-2022 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+=========
+Vorticity
+=========
+
+Use `metpy.calc.vorticity`.
+
+This example demonstrates the calculatation of relative vorticity using the example xarray
+Dataset and plotting using Matplotlib.
+"""
+import matplotlib.pyplot as plt
+
+import metpy.calc as mpcalc
+from metpy.cbook import example_data
+
+# load example data
+ds = example_data()
+
+# Calculate the vertical vorticity of the flow
+vor = mpcalc.vorticity(ds.uwind, ds.vwind)
+
+# start figure and set axis
+fig, ax = plt.subplots(figsize=(5, 5))
+
+# scale vorticity by 1e5 for plotting purposes
+cf = ax.contourf(ds.lon, ds.lat, vor * 1e5, range(-80, 81, 1), cmap=plt.cm.PuOr_r)
+plt.colorbar(cf, pad=0, aspect=50)
+ax.barbs(ds.lon.values, ds.lat.values, ds.uwind, ds.vwind, color='black', length=5, alpha=0.5)
+ax.set(xlim=(260, 270), ylim=(30, 40))
+ax.set_title('Relative Vorticity Calculation')
+
+plt.show()

--- a/examples/calculations/Wind_Speed.py
+++ b/examples/calculations/Wind_Speed.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2015-2022 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+==========
+Wind Speed
+==========
+
+Use `metpy.calc.wind_speed`.
+
+This example demonstrates the calculation of wind speed using the example xarray Dataset and
+plotting using Matplotlib.
+"""
+import matplotlib.pyplot as plt
+
+import metpy.calc as mpcalc
+from metpy.cbook import example_data
+
+# load example data
+ds = example_data()
+
+# Calculate the total deformation of the flow
+wind_speed = mpcalc.wind_speed(ds.uwind, ds.vwind)
+
+# start figure and set axis
+fig, ax = plt.subplots(figsize=(5, 5))
+
+# plot wind speed
+cf = ax.contourf(ds.lon, ds.lat, wind_speed, range(5, 80, 5), cmap=plt.cm.BuPu)
+plt.colorbar(cf, pad=0, aspect=50)
+ax.barbs(ds.lon.values, ds.lat.values, ds.uwind, ds.vwind, color='black', length=5, alpha=0.5)
+ax.set(xlim=(260, 270), ylim=(30, 40))
+ax.set_title('Wind Speed Calculation')
+
+plt.show()

--- a/src/metpy/cbook.py
+++ b/src/metpy/cbook.py
@@ -44,7 +44,7 @@ def example_data():
     """Access sample xarray Dataset example for calculating and plotting 2D variables."""
     import xarray as xr
 
-    # make data based on Matplotlib exaple data for wind barbs
+    # make data based on Matplotlib example data for wind barbs
     x, y = np.meshgrid(np.linspace(-3, 3, 25), np.linspace(-3, 3, 25))
     z = (1 - x / 2 + x**5 + y**3) * np.exp(-x**2 - y**2)
 

--- a/src/metpy/cbook.py
+++ b/src/metpy/cbook.py
@@ -40,6 +40,39 @@ def get_test_data(fname, as_file_obj=True, mode='rb'):
     return path
 
 
+def example_data():
+    """Access sample xarray Dataset example for calculating and plotting 2D variables."""
+    import xarray as xr
+
+    # make data based on Matplotlib exaple data for wind barbs
+    x, y = np.meshgrid(np.linspace(-3, 3, 25), np.linspace(-3, 3, 25))
+    z = (1 - x / 2 + x**5 + y**3) * np.exp(-x**2 - y**2)
+
+    # make u and v out of the z equation
+    u = -np.diff(z[:, 1:], axis=0) * 100 + 10
+    v = np.diff(z[1:, :], axis=1) * 100 + 10
+
+    # make t as colder air to the north
+    t = (np.linspace(15, 5, 24) * np.ones((24, 24))).T
+
+    # Make lat/lon data over the mid-latitudes
+    lats = np.linspace(30, 40, 24)
+    lons = np.linspace(360 - 100, 360 - 90, 24)
+
+    # place data into an xarray dataset object
+    lat = xr.DataArray(lats, attrs={'standard_name': 'latitude', 'units': 'degrees_north'})
+    lon = xr.DataArray(lons, attrs={'standard_name': 'longitude', 'units': 'degrees_east'})
+    uwind = xr.DataArray(u, coords=(lat, lon), dims=['lat', 'lon'],
+                         attrs={'standard_name': 'u-component_of_wind', 'units': 'm s-1'})
+    vwind = xr.DataArray(v, coords=(lat, lon), dims=['lat', 'lon'],
+                         attrs={'standard_name': 'u-component_of_wind', 'units': 'm s-1'})
+    temperature = xr.DataArray(t, coords=(lat, lon), dims=['lat', 'lon'],
+                               attrs={'standard_name': 'temperature', 'units': 'degC'})
+    return xr.Dataset({'uwind': uwind,
+                       'vwind': vwind,
+                       'temperature': temperature})
+
+
 class Registry:
     """Provide a generic function registry.
 

--- a/src/metpy/cbook.py
+++ b/src/metpy/cbook.py
@@ -41,7 +41,7 @@ def get_test_data(fname, as_file_obj=True, mode='rb'):
 
 
 def example_data():
-    """Access sample xarray Dataset example for calculating and plotting 2D variables."""
+    """Create a sample xarray Dataset with 2D variables."""
     import xarray as xr
 
     # make data based on Matplotlib example data for wind barbs

--- a/tests/test_cbook.py
+++ b/tests/test_cbook.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Test functionality of MetPy's utility code."""
 
-from metpy.cbook import Registry
+from metpy.cbook import example_data, Registry
 
 
 def test_registry():
@@ -14,3 +14,11 @@ def test_registry():
     reg.register('mine')(a)
 
     assert reg['mine'] is a
+
+
+def test_example_data():
+    """Test that the example data has the proper keys."""
+    ds = example_data()
+    var_names = list(ds.variables)
+
+    assert 'temperature' in var_names


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This PR adds example calculations using fake data, which has been added to the cbook as a function. This was done to reduce the amount of code needed for each calculation to define the same data and put into an xarray format.

Examples included are:
 - Vorticity
 - Absolute Vorticity
 - Shearing Deformation
 - Stretching Deformation
 - Total Deformation
 - Divergence
 - Wind Speed
 - Advection
 - Q-Vector
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Partially Closes #2277 
