### PR TITLE
MNT: Update SkewXAxis for Matplotlib 3.6

### DIFF
--- a/src/metpy/plots/skewt.py
+++ b/src/metpy/plots/skewt.py
@@ -129,12 +129,15 @@ class SkewXAxis(maxis.XAxis):
         return SkewXTick(self.axes, None, major=major)
 
     # Needed to properly handle tight bbox
-    def _get_tick_bboxes(self, ticks, renderer):
+    def _get_ticklabel_bboxes(self, ticks, renderer):
         """Return lists of bboxes for ticks' label1's and label2's."""
         return ([tick.label1.get_window_extent(renderer)
                  for tick in ticks if tick.label1.get_visible() and tick.lower_in_bounds],
                 [tick.label2.get_window_extent(renderer)
                  for tick in ticks if tick.label2.get_visible() and tick.upper_in_bounds])
+
+    # Older name used on Matplotlib < 3.6
+    _get_tick_bboxes = _get_ticklabel_bboxes
 
     def get_view_interval(self):
         """Get the view interval."""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
An internal method we use (to fix tight bboxes) was renamed in Matplotlib 3.6. Update the name and add an alias for older matplotlib versions.

This, together with us now using the recently released Cartopy 0.21, should fix all issues with nightly builds.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2627
- ~[ ] Tests added~
- ~[ ] Fully documented~
