### PR TITLE
Fix resolution of grids generated by interpolate

### DIFF
--- a/src/metpy/interpolate/grid.py
+++ b/src/metpy/interpolate/grid.py
@@ -98,8 +98,8 @@ def get_xy_steps(bbox, h_dim):
     """
     x_range, y_range = get_xy_range(bbox)
 
-    x_steps = np.ceil(x_range / h_dim)
-    y_steps = np.ceil(y_range / h_dim)
+    x_steps = np.ceil(x_range / h_dim) + 1
+    y_steps = np.ceil(y_range / h_dim) + 1
 
     return int(x_steps), int(y_steps)
 

--- a/src/metpy/interpolate/grid.py
+++ b/src/metpy/interpolate/grid.py
@@ -18,10 +18,11 @@ def generate_grid(horiz_dim, bbox):
 
     Parameters
     ----------
-    horiz_dim: integer
+    horiz_dim: int or float
         Horizontal resolution
-    bbox: dictionary
-        Dictionary containing coordinates for corners of study area.
+    bbox: dict
+        Dictionary with keys 'east', 'west', 'north', 'south' with the box extents
+        in those directions.
 
     Returns
     -------
@@ -36,9 +37,7 @@ def generate_grid(horiz_dim, bbox):
     grid_x = np.linspace(bbox['west'], bbox['east'], x_steps)
     grid_y = np.linspace(bbox['south'], bbox['north'], y_steps)
 
-    gx, gy = np.meshgrid(grid_x, grid_y)
-
-    return gx, gy
+    return np.meshgrid(grid_x, grid_y)
 
 
 def generate_grid_coords(gx, gy):
@@ -63,8 +62,9 @@ def generate_grid_coords(gx, gy):
 def get_xy_range(bbox):
     r"""Return x and y ranges in meters based on bounding box.
 
-    bbox: dictionary
-        dictionary containing coordinates for corners of study area
+    bbox: dict
+        Dictionary with keys 'east', 'west', 'north', 'south' with the box extents
+        in those directions.
 
     Returns
     -------
@@ -83,9 +83,10 @@ def get_xy_range(bbox):
 def get_xy_steps(bbox, h_dim):
     r"""Return meshgrid spacing based on bounding box.
 
-    bbox: dictionary
-        Dictionary containing coordinates for corners of study area.
-    h_dim: integer
+    bbox: dict
+        Dictionary with keys 'east', 'west', 'north', 'south' with the box extents
+        in those directions.
+    h_dim: int or float
         Horizontal resolution in meters.
 
     Returns
@@ -111,14 +112,14 @@ def get_boundary_coords(x, y, spatial_pad=0):
         x coordinates.
     y: numeric
         y coordinates.
-    spatial_pad: numeric
-        Number of meters to add to the x and y dimensions to reduce
-        edge effects.
+    spatial_pad: int or float
+        Number of meters to add to the x and y dimensions to reduce edge effects.
 
     Returns
     -------
-    bbox: dictionary
-        dictionary containing coordinates for corners of study area
+    bbox: dict
+        Dictionary with keys 'east', 'west', 'north', 'south' with the box extents
+        in those directions.
 
     """
     west = np.min(x) - spatial_pad

--- a/tests/interpolate/test_grid.py
+++ b/tests/interpolate/test_grid.py
@@ -73,8 +73,8 @@ def test_get_xy_steps():
 
     x_steps, y_steps = get_xy_steps(bbox, 3)
 
-    truth_x = 3
-    truth_y = 3
+    truth_x = 4
+    truth_y = 4
 
     assert x_steps == truth_x
     assert y_steps == truth_y
@@ -105,13 +105,15 @@ def test_generate_grid():
 
     gx, gy = generate_grid(3, bbox)
 
-    truth_x = np.array([[0.0, 4.5, 9.0],
-                        [0.0, 4.5, 9.0],
-                        [0.0, 4.5, 9.0]])
+    truth_x = np.array([[0.0, 3.0, 6.0, 9.0],
+                        [0.0, 3.0, 6.0, 9.0],
+                        [0.0, 3.0, 6.0, 9.0],
+                        [0.0, 3.0, 6.0, 9.0]])
 
-    truth_y = np.array([[0.0, 0.0, 0.0],
-                        [4.5, 4.5, 4.5],
-                        [9.0, 9.0, 9.0]])
+    truth_y = np.array([[0.0, 0.0, 0.0, 0.0],
+                        [3.0, 3.0, 3.0, 3.0],
+                        [6.0, 6.0, 6.0, 6.0],
+                        [9.0, 9.0, 9.0, 9.0]])
 
     assert_array_almost_equal(gx, truth_x)
     assert_array_almost_equal(gy, truth_y)
@@ -127,13 +129,20 @@ def test_generate_grid_coords():
     gx, gy = generate_grid(3, bbox)
 
     truth = [[0.0, 0.0],
-             [4.5, 0.0],
+             [3.0, 0.0],
+             [6.0, 0.0],
              [9.0, 0.0],
-             [0.0, 4.5],
-             [4.5, 4.5],
-             [9.0, 4.5],
+             [0.0, 3.0],
+             [3.0, 3.0],
+             [6.0, 3.0],
+             [9.0, 3.0],
+             [0.0, 6.0],
+             [3.0, 6.0],
+             [6.0, 6.0],
+             [9.0, 6.0],
              [0.0, 9.0],
-             [4.5, 9.0],
+             [3.0, 9.0],
+             [6.0, 9.0],
              [9.0, 9.0]]
 
     pts = generate_grid_coords(gx, gy)
@@ -266,7 +275,13 @@ def test_interpolate_to_grid(method, assume_units, test_coords, boundary_coords)
         z = units.Quantity(z, assume_units)
         truth = units.Quantity(truth, assume_units)
 
-    _, _, img = interpolate_to_grid(xp, yp, z, hres=10, interp_type=method, **extra_kw)
+    # Value is tuned to keep the old results working after fixing an off-by-one error
+    # in the grid generation (desired value was 10) See #2319.
+    hres = 10.121
+    xg, yg, img = interpolate_to_grid(xp, yp, z, hres=hres, interp_type=method, **extra_kw)
+
+    assert np.all(np.diff(xg, axis=-1) <= hres)
+    assert np.all(np.diff(yg, axis=0) <= hres)
     assert_array_almost_equal(truth, img)
 
 

--- a/tests/interpolate/test_interpolate_tools.py
+++ b/tests/interpolate/test_interpolate_tools.py
@@ -127,4 +127,4 @@ def test_interpolate_to_grid_pandas():
     }, index=[1, 2, 3, 4, 5, 6])
     interpolate_to_grid(
         df['lon'], df['lat'], df['tmp'],
-        interp_type='natural_neighbor', hres=0.5)
+        interp_type='natural_neighbor', hres=0.6)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

`interpolate_to_grid`, due to an off-by-one error, was not actually generating grids with the requested resolution. Instead, they had one fewer point than that needed to generate the requested resolution. The previous implementation calculated the number of steps needed, but essentially omitted the starting point.

In order to avoid regenerating a bunch of test data, I adjusted the test to request a resolution matching the previous reality.

This also cleans up the documentation for some of those internal functions.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2319
- [x] Tests added
- [x] Fully documented
