### PR TITLE
Add Python 3.10 to our doc builds

### DIFF
--- a/.github/workflows/docs-conda.yml
+++ b/.github/workflows/docs-conda.yml
@@ -26,6 +26,8 @@ jobs:
             os: macOS
           - python-version: 3.9
             os: Windows
+          - python-version: '3.10'
+            os: Windows
 
     steps:
     # We check out only a limited depth and then pull tags to save time

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,9 @@ jobs:
             check-links: false
             dep-versions: requirements.txt
           - python-version: 3.9
+            check-links: false
+            dep-versions: requirements.txt
+          - python-version: '3.10'
             check-links: true
             dep-versions: requirements.txt
     outputs:
@@ -74,7 +77,7 @@ jobs:
     - name: Download doc build
       uses: actions/download-artifact@v3
       with:
-        name: Linux-3.9-docs
+        name: Linux-3.10-docs
         path: ./docs/build/html
 
     # This overrides the version "dev" with the proper version if we're building off a

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -85,7 +85,7 @@ jobs:
         need-cartopy: true
         type: doc
         version-file: Prerelease
-        python-version: 3.9
+        python-version: '3.10'
 
     - name: Build docs
       id: build


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Packages weren't ready when #2177 was merged, and this got lost. Seems like a good idea to get this active before the release and before Python 3.11 arrives.
* Add 3.10 to the relevant normal matrices
* Use 3.10 doc build for release docs
* Use 3.10 for nightly doc build

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

