### PR TITLE
set default METAR year, month from UTC date

### DIFF
--- a/src/metpy/io/metar.py
+++ b/src/metpy/io/metar.py
@@ -5,7 +5,7 @@
 # Import the necessary libraries
 from collections import namedtuple
 import contextlib
-from datetime import datetime
+from datetime import datetime, timezone
 import warnings
 
 import numpy as np
@@ -432,7 +432,7 @@ def _metars_to_dataframe(metar_iter, *, year=None, month=None):
 
     # Defaults year and/or month to present reported date if not provided
     if year is None or month is None:
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         year = now.year if year is None else year
         month = now.month if month is None else month
 


### PR DESCRIPTION
closes #2700

#### Description Of Changes

METAR is a horrible format that provides just a UTC day, so we have to make life choices to figure out what the month and year is for this day.  MetPy previously assumed a default year and month matching the current system localized date and not the current UTC date.

#### Checklist

- [x] Closes #2700
- ~~Tests added~~ 
- Fully documented

No idea how this can be tested outside of doing naugthy things to python's datetime module?