### PR TITLE
Add axis labels to some sounding examples

### DIFF
--- a/examples/Advanced_Sounding.py
+++ b/examples/Advanced_Sounding.py
@@ -60,6 +60,10 @@ skew.plot_barbs(p, u, v)
 skew.ax.set_ylim(1000, 100)
 skew.ax.set_xlim(-40, 60)
 
+# Set some better labels than the default
+skew.ax.set_xlabel(f'Temperature ({T.units:~P})')
+skew.ax.set_ylabel(f'Pressure ({p.units:~P})')
+
 # Calculate LCL height and plot as black dot. Because `p`'s first value is
 # ~1000 mb and its last value is ~250 mb, the `0` index is selected for
 # `p`, `T`, and `Td` to lift the parcel from the surface. If `p` was inverted,

--- a/examples/plots/Simple_Sounding.py
+++ b/examples/plots/Simple_Sounding.py
@@ -58,6 +58,10 @@ skew.plot(p, T, 'r')
 skew.plot(p, Td, 'g')
 skew.plot_barbs(p, u, v)
 
+# Set some better labels than the default
+skew.ax.set_xlabel('Temperature (\N{DEGREE CELSIUS})')
+skew.ax.set_ylabel('Pressure (mb)')
+
 # Add the relevant special lines
 skew.plot_dry_adiabats()
 skew.plot_moist_adiabats()
@@ -77,6 +81,10 @@ skew = SkewT()
 # log scaling in Y, as dictated by the typical meteorological plot
 skew.plot(p, T, 'r')
 skew.plot(p, Td, 'g')
+
+# Set some better labels than the default
+skew.ax.set_xlabel('Temperature (\N{DEGREE CELSIUS})')
+skew.ax.set_ylabel('Pressure (mb)')
 
 # Set spacing interval--Every 50 mb from 1000 to 100 mb
 my_interval = np.arange(100, 1000, 50) * units('mbar')


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This "documents" how to change the default Skew-T axis labels. It intentionally shows one hard-coding the units, including the appropriate unicode syntax, as well as one using Pint to format it based on the input data. This way both approaches are out there for users to see.

This was motivated by a support question asking about this and noted that they (correctly) couldn't find any documentation.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Fully documented
