### PR TITLE
Point nonmult units link to pint stable

### DIFF
--- a/tutorials/unit_tutorial.py
+++ b/tutorials/unit_tutorial.py
@@ -18,7 +18,7 @@ paper! This simplifies the MetPy API by eliminating the need to specify units
 various functions. Instead, only the final results need to be converted to desired units. For
 more information on unit support, see the documentation for
 `Pint <https://pint.readthedocs.io>`_. Particular attention should be paid to the support
-for `temperature units <https://pint.readthedocs.io/en/latest/nonmult.html>`_.
+for `temperature units <https://pint.readthedocs.io/en/stable/nonmult.html>`_.
 
 In this tutorial we'll show some examples of working with units and get you on your way to
 utilizing the computation functions in MetPy.


### PR DESCRIPTION
This will need to point to `https://pint.readthedocs.io/en/stable/user/nonmult.html` if/when they release with these doc changes; I believe they're still iterating for now.

Closes #2721 