### PR TITLE
Remove use of deprecated set-output in actions

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Set doc version
       id: docversion
       shell: bash -l {0}
-      run: echo "::set-output name=doc_version::$(python -c 'import metpy,re; print(re.search(r"(\d+\.\d+)", metpy.__version__)[0])')"
+      run: echo "doc_version=$(python -c 'import metpy,re; print(re.search(r"(\d+\.\d+)", metpy.__version__)[0])')" >> $GITHUB_OUTPUT
 
     - name: Build docs
       shell: bash -l {0}

--- a/.github/workflows/backport-prs.yml
+++ b/.github/workflows/backport-prs.yml
@@ -33,7 +33,7 @@ jobs:
         id: get-branch
         run: |
           git fetch --no-tags --depth=100 origin 'refs/heads/*.x:refs/remotes/origin/*.x'
-          echo "::set-output name=backport-branch::$(git branch -r | grep '.*.x' | sort -V | tail -n 1 | cut -d / -f 2)"
+          echo "backport-branch=$(git branch -r | grep '.*.x' | sort -V | tail -n 1 | cut -d / -f 2)" >> $GITHUB_OUTPUT
 
       - name: Apply PR commits to ${{ steps.get-branch.outputs.backport-branch}} branch
         run: |


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
GitHub [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) the `set-output` command for security reasons. The [new way](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter) is to echo to `$GITHUB_OUTPUT`.


<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

