### PR TITLE
Bump image threshold

### DIFF
--- a/tests/plots/test_declarative.py
+++ b/tests/plots/test_declarative.py
@@ -836,7 +836,7 @@ def test_declarative_arrow_changes():
     return pc.figure
 
 
-@pytest.mark.mpl_image_compare(remove_text=True, tolerance=0.434)
+@pytest.mark.mpl_image_compare(remove_text=True, tolerance=0.491)
 @needs_cartopy
 def test_declarative_barb_earth_relative():
     """Test making a contour plot."""


### PR DESCRIPTION
Looks like running against numpy 1.24.0rc1 has tweaked the starting point of the barbs by a pixel. Just bump the threshold here.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2799
- [x] Tests updated
