### PR TITLE
Conditionally define percent unit

### DIFF
--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -63,8 +63,9 @@ def setup_registry(reg):
         if pre not in reg.preprocessors:
             reg.preprocessors.append(pre)
 
-    # Add a percent unit
-    reg.define('percent = 0.01 = %')
+    # Add a percent unit if it's not already present, it was added in 0.21
+    if 'percent' not in reg:
+        reg.define('percent = 0.01 = %')
 
     # Define commonly encountered units not defined by pint
     reg.define('degrees_north = degree = degrees_N = degreesN = degree_north = degree_N '


### PR DESCRIPTION
Pint 0.21 added a definition of percent so we don't need to define our own going forward.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2809
