### PR TITLE
Change default SPECI parsing

### DIFF
--- a/src/metpy/io/gempak.py
+++ b/src/metpy/io/gempak.py
@@ -2662,7 +2662,8 @@ class GempakSurface(GempakFile):
 
         return station
 
-    def nearest_time(self, date_time, station_id=None, station_number=None):
+    def nearest_time(self, date_time, station_id=None, station_number=None,
+                     parse_special=False):
         """Get nearest observation to given time for selected stations.
 
         Parameters
@@ -2676,6 +2677,10 @@ class GempakSurface(GempakFile):
 
         station_number : int or Sequence[int]
             Station number of the surface station.
+
+        parse_special : bool
+            If True, parse special observations that are stored
+            as raw METAR text. Default is False.
 
         Returns
         -------
@@ -2709,7 +2714,7 @@ class GempakSurface(GempakFile):
         time_matched = []
         if station_id:
             for stn in station_id:
-                matched = self.sfjson(station_id=stn)
+                matched = self.sfjson(station_id=stn, parse_special=parse_special)
 
                 nearest = min(
                     matched,
@@ -2720,7 +2725,7 @@ class GempakSurface(GempakFile):
 
         if station_number:
             for stn in station_id:
-                matched = self.sfjson(station_number=stn)
+                matched = self.sfjson(station_number=stn, parse_special=parse_special)
 
                 nearest = min(
                     matched,
@@ -2732,7 +2737,8 @@ class GempakSurface(GempakFile):
         return time_matched
 
     def sfjson(self, station_id=None, station_number=None,
-               date_time=None, state=None, country=None):
+               date_time=None, state=None, country=None,
+               parse_special=False):
         """Select surface stations and output as list of JSON objects.
 
         Subset the data by parameter values. The default is to not
@@ -2755,6 +2761,10 @@ class GempakSurface(GempakFile):
 
         country : str or Sequence[str]
             Country where surface station is located.
+
+        parse_special : bool
+            If True, parse special observations that are stored
+            as raw METAR text. Default is False.
 
         Returns
         -------
@@ -2842,7 +2852,7 @@ class GempakSurface(GempakFile):
 
         stnarr = []
         for stn in data:
-            if 'SPCL' in stn:
+            if 'SPCL' in stn and parse_special:
                 stn = self._decode_special_observation(stn, self.prod_desc.missing_float)
             props = {'date_time': datetime.combine(stn.pop('DATE'), stn.pop('TIME')),
                      'station_id': stn.pop('STID') + stn.pop('STD2'),

--- a/src/metpy/io/gempak.py
+++ b/src/metpy/io/gempak.py
@@ -2663,7 +2663,7 @@ class GempakSurface(GempakFile):
         return station
 
     def nearest_time(self, date_time, station_id=None, station_number=None,
-                     parse_special=False):
+                     include_special=False):
         """Get nearest observation to given time for selected stations.
 
         Parameters
@@ -2678,7 +2678,7 @@ class GempakSurface(GempakFile):
         station_number : int or Sequence[int]
             Station number of the surface station.
 
-        parse_special : bool
+        include_special : bool
             If True, parse special observations that are stored
             as raw METAR text. Default is False.
 
@@ -2714,7 +2714,7 @@ class GempakSurface(GempakFile):
         time_matched = []
         if station_id:
             for stn in station_id:
-                matched = self.sfjson(station_id=stn, parse_special=parse_special)
+                matched = self.sfjson(station_id=stn, include_special=include_special)
 
                 nearest = min(
                     matched,
@@ -2725,7 +2725,7 @@ class GempakSurface(GempakFile):
 
         if station_number:
             for stn in station_id:
-                matched = self.sfjson(station_number=stn, parse_special=parse_special)
+                matched = self.sfjson(station_number=stn, include_special=include_special)
 
                 nearest = min(
                     matched,
@@ -2738,7 +2738,7 @@ class GempakSurface(GempakFile):
 
     def sfjson(self, station_id=None, station_number=None,
                date_time=None, state=None, country=None,
-               parse_special=False):
+               include_special=False):
         """Select surface stations and output as list of JSON objects.
 
         Subset the data by parameter values. The default is to not
@@ -2762,7 +2762,7 @@ class GempakSurface(GempakFile):
         country : str or Sequence[str]
             Country where surface station is located.
 
-        parse_special : bool
+        include_special : bool
             If True, parse special observations that are stored
             as raw METAR text. Default is False.
 
@@ -2852,7 +2852,7 @@ class GempakSurface(GempakFile):
 
         stnarr = []
         for stn in data:
-            if 'SPCL' in stn and parse_special:
+            if 'SPCL' in stn and include_special:
                 stn = self._decode_special_observation(stn, self.prod_desc.missing_float)
             props = {'date_time': datetime.combine(stn.pop('DATE'), stn.pop('TIME')),
                      'station_id': stn.pop('STID') + stn.pop('STD2'),

--- a/tests/io/test_gempak.py
+++ b/tests/io/test_gempak.py
@@ -305,7 +305,7 @@ def test_special_surface_observation():
     gsf = GempakSurface(sfc)
     stn = gsf.nearest_time('202109071601',
                            station_id='MSN',
-                           include_special==True)[0]['values']
+                           include_special=True)[0]['values']
 
     assert_almost_equal(stn['pmsl'], 1003.81, 2)
     assert stn['alti'] == 29.66

--- a/tests/io/test_gempak.py
+++ b/tests/io/test_gempak.py
@@ -305,7 +305,7 @@ def test_special_surface_observation():
     gsf = GempakSurface(sfc)
     stn = gsf.nearest_time('202109071601',
                            station_id='MSN',
-                           parse_special=True)[0]['values']
+                           include_special==True)[0]['values']
 
     assert_almost_equal(stn['pmsl'], 1003.81, 2)
     assert stn['alti'] == 29.66

--- a/tests/io/test_gempak.py
+++ b/tests/io/test_gempak.py
@@ -303,7 +303,9 @@ def test_special_surface_observation():
     sfc = get_test_data('gem_surface_with_text.sfc')
 
     gsf = GempakSurface(sfc)
-    stn = gsf.nearest_time('202109071604', station_id='MSN')[0]['values']
+    stn = gsf.nearest_time('202109071601',
+                           station_id='MSN',
+                           parse_special=True)[0]['values']
 
     assert_almost_equal(stn['pmsl'], 1003.81, 2)
     assert stn['alti'] == 29.66


### PR DESCRIPTION
Per discussion in #2759, the option to parse SPECI observations was made into a user parameter and is off by default.

This was the most reasonable approach to extracting METAR data that I could think of. Sometimes GEMPAK will also have the standard METAR data as text. If I parsed that, the timestamps would be more precise. However, as @sgdecker had alluded to, users do not want to have to dig for the top of the hour observations. You do have AWOS that do standard reports every 20 minutes, but those are going to be less susceptible to the GEMPAK file time bin issue than SPECI reports. Unless there is a strong desire to also have the ability to parse standard observation text, then this should work for most people.

#### Checklist

- [x] Tests added
- [x] Fully documented
