### PR TITLE
Ensure degree units by default for lat/lon in xarray

### DIFF
--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -134,7 +134,12 @@ class MetPyDataArrayAccessor:
         if is_quantity(self._data_array.variable._data):
             return self._data_array.variable._data.units
         else:
-            return units.parse_units(self._data_array.attrs.get('units', 'dimensionless'))
+            axis = self._data_array.attrs.get('_metpy_axis', '')
+            if 'latitude' in axis or 'longitude' in axis:
+                default_unit = 'degrees'
+            else:
+                default_unit = 'dimensionless'
+            return units.parse_units(self._data_array.attrs.get('units', default_unit))
 
     @property
     def magnitude(self):

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -173,6 +173,20 @@ def test_convert_coordinate_units(test_ds_generic):
     assert result['b'].metpy.units == units.percent
 
 
+def test_latlon_default_units(test_var_multidim_full):
+    """Test that lat/lon are given degree units by default."""
+    del test_var_multidim_full.lat.attrs['units']
+    del test_var_multidim_full.lon.attrs['units']
+
+    lat = test_var_multidim_full.metpy.latitude.metpy.unit_array
+    assert lat.units == units.degrees
+    assert lat.max() > 50 * units.degrees
+
+    lon = test_var_multidim_full.metpy.longitude.metpy.unit_array
+    assert lon.units == units.degrees
+    assert lon.min() < -100 * units.degrees
+
+
 def test_quantify(test_ds_generic):
     """Test quantify method for converting data to Quantity."""
     original = test_ds_generic['test'].values


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

We intentionally want to assume degrees for our various lat/lon handling with e.g. `lat_lon_grid_deltas`, but for xarray we by default were giving 'dimensionless' units when no unit attribute is present (which can happen when attributes are dropped by various xarray functionality).

See also #2811, #2836, and #2848.

The solution here ended up being more clean than I feared. (cc @jthielen)

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2028
- [x] Tests added