### PR TITLE
Add Miller 1972 pdf to docs

### DIFF
--- a/docs/api/references.rst
+++ b/docs/api/references.rst
@@ -135,7 +135,7 @@ References
 
 .. [Miller1972] Miller, R. C, 1972: *Notes on Analysis and Severe-Storm Forecasting Procedures
            of the Air Force Global Weather Central*. `AD0744042
-           <https://apps.dtic.mil/sti/citations/AD0744042>`_.
+           <../_static/Miller1972.pdf>`_.
 
 .. [Moritz2000] Moritz, H., 2000: Geodetic Reference System 1980.
            *Journal of Geodesy* **74**, 128-133, doi:`10.1007/s001900050278


### PR DESCRIPTION
Original technical document available [at DTIC](https://apps.dtic.mil/sti/citations/AD0744042) has caused multiple nightly linkchecker failures. This adds the 11.8 MB document to our small in-docs collection of PDFs and points to the new location.

- [X] Closes #2886 
