### PR TITLE
CI: Roll back to Pandas 1.5.3

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,7 +1,7 @@
 importlib_resources==5.12.0
 matplotlib==3.7.1
 numpy==1.24.2
-pandas==2.0.0
+pandas==1.5.3
 pooch==1.7.0
 pint==0.20.1
 pyproj==3.5.0


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

Xarray only supports pandas 2 on current `main`, so that will require a new release. conda-forge patched metadata and now there's no environment to resolve with xarray + pandas v2. With xarray dropping 3.8, we'll have to follow suit for in order to enable pandas 2 on CI as well (still not enough IMO to do this for the next release).

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->