### PR TITLE
CI: Remove deleted setup-proj action from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -104,19 +104,3 @@ updates:
     commit-message:
       prefix: "CI: "
       include: "scope"
-
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/setup-proj"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: all
-    open-pull-requests-limit: 10
-    pull-request-branch-name:
-      separator: "-"
-    labels:
-      - "Type: Maintenance"
-      - "Area: Infrastructure"
-    commit-message:
-      prefix: "CI: "
-      include: "scope"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
The "dependabot" tab on GitHub flagged "setup-proj" as not found, which makes sense since we deleted this awhile ago.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
