### PR TITLE
unit redefinition help for /s

### DIFF
--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -44,10 +44,15 @@ def _fix_udunits_powers(string):
     return _UDUNIT_POWER.sub('**', string)
 
 
-# Fix UDUNITS-style powers and percent signs
+def _fix_udunits_div(string):
+    return 's**-1' if string == '/s' else string
+
+
+# Fix UDUNITS-style powers, percent signs, and ill-defined units
 _UDUNIT_POWER = re.compile(r'(?<=[A-Za-z\)])(?![A-Za-z\)])'
                            r'(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])')
-_unit_preprocessors = [_fix_udunits_powers, lambda string: string.replace('%', 'percent')]
+_unit_preprocessors = [_fix_udunits_powers, lambda string: string.replace('%', 'percent'),
+                       _fix_udunits_div]
 
 
 def setup_registry(reg):

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -228,7 +228,8 @@ def test_percent_units():
             '(J kg-1)(m s-1)-1', units.m / units.s,
             marks=pytest.mark.xfail(reason='hgrecco/pint#1485')
         ),
-        ('(J kg-1)(m s-1)(-1)', units.m ** 3 / units.s ** 3)
+        ('(J kg-1)(m s-1)(-1)', units.m ** 3 / units.s ** 3),
+        ('/s', units.s ** -1)
     )
 )
 def test_udunits_power_syntax(unit_str, pint_unit):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
The issue has arisen with older model output data where the stored vorticity unit is `/s`, which will then fail on any action with a unit with the error `pint.errors.DefinitionSyntaxError: missing unary operator "/"`. This solution adds a small fix in the units module to replace `/s` with `s**-1`. An example dataset that this occurs with is older GFS data available through the RDA archive.

Minimum example to produce error:
```python
from datetime import datetime

from metpy.units import units
import xarray as xr

ds = xr.open_dataset('https://rda.ucar.edu/thredds/dodsC/aggregations/g/ds083.2/1/TP')

ds.Absolute_vorticity_isobaric.metpy.sel(time=datetime(2000, 1, 4, 12), vertical=500*units.hPa).metpy.quantify()
```
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
