### PR TITLE
Fix formatting of "Returns" from most_unstable_parcel

### DIFF
--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -2400,7 +2400,16 @@ def most_unstable_parcel(pressure, temperature, dewpoint, height=None, bottom=No
     Returns
     -------
     `pint.Quantity`
-        Pressure, temperature, and dewpoint of most unstable parcel in the profile
+        Pressure of the most unstable parcel in the profile
+
+    `pint.Quantity`
+        Temperature of the most unstable parcel in the profile
+
+    `pint.Quantity`
+        Dewpoint of the most unstable parcel in the profile
+
+    int
+        The index of the most unstable parcel within the original data
 
     Examples
     --------
@@ -2426,9 +2435,6 @@ def most_unstable_parcel(pressure, temperature, dewpoint, height=None, bottom=No
     >>> most_unstable_parcel(p, T, Td, depth=50*units.hPa)
     (<Quantity(1008.0, 'hectopascal')>, <Quantity(29.3, 'degree_Celsius')>,
     <Quantity(26.5176931, 'degree_Celsius')>, 0)
-
-    integer
-        Index of the most unstable parcel in the given profile
 
     See Also
     --------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
The example for this function accidentally got placed in the middle of the Returns section. Also expand out the multiple returns to be more in-line with how we usually do it.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Fully documented
