### PR TITLE
CI: Swap over to PyPI trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
     environment:
       name: PyPI
       url: https://pypi.org/project/MetPy/
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     runs-on: ubuntu-latest
     steps:
     - name: Download packages
@@ -57,5 +59,3 @@ jobs:
 
     - name: Publish Package
       uses: pypa/gh-action-pypi-publish@v1.8.5
-      with:
-        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

Instead of using a fixed, shared API secret key, you [configure a GitHub actions workflow](https://docs.pypi.org/trusted-publishers/) (and environment) on PyPI to be allowed to publish to the project. Through this GitHub and PyPI exhange short-lived tokens for publication. Thankfully this is automatic when using the [PyPA publication action](https://github.com/pypa/gh-action-pypi-publish#trusted-publishing) that we've already been using.

I've already deactivated the previous API key (which was tied to my personal PyPI account) and removed it from our GitHub configs. Another benefit of this is that everything is tied to project infrastructure rather than individual users.

I've already configured our PyPI project to use our GitHub actions workflow and environment.
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
