### PR TITLE
Improve GEMPAK "thinned GFS" files

### DIFF
--- a/src/metpy/plots/mapping.py
+++ b/src/metpy/plots/mapping.py
@@ -44,6 +44,11 @@ class CFProjection:
                 if cf_name in source}
 
     @property
+    def name(self):
+        """Return the name of the projection."""
+        return self._attrs.get('grid_mapping_name', 'unknown')
+
+    @property
     def cartopy_globe(self):
         """Initialize a `cartopy.crs.Globe` from the metadata."""
         if 'earth_radius' in self._attrs:
@@ -76,11 +81,10 @@ class CFProjection:
     def to_cartopy(self):
         """Convert to a CartoPy projection."""
         globe = self.cartopy_globe
-        proj_name = self._attrs['grid_mapping_name']
         try:
-            proj_handler = self.projection_registry[proj_name]
+            proj_handler = self.projection_registry[self.name]
         except KeyError:
-            raise ValueError(f'Unhandled projection: {proj_name}') from None
+            raise ValueError(f'Unhandled projection: {self.name}') from None
 
         return proj_handler(self._attrs, globe)
 
@@ -96,7 +100,7 @@ class CFProjection:
 
     def __str__(self):
         """Get a string representation of the projection."""
-        return 'Projection: ' + self._attrs['grid_mapping_name']
+        return f'Projection: {self.name}'
 
     def __getitem__(self, item):
         """Return a given attribute."""

--- a/tests/plots/test_mapping.py
+++ b/tests/plots/test_mapping.py
@@ -54,6 +54,30 @@ def test_bad_projection_raises():
     assert 'Unhandled projection' in str(exc.value)
 
 
+def test_unhandled_projection():
+    """Test behavior when given a projection with no CF equivalent from PROJ."""
+    attrs = {
+        'crs_wkt': 'PROJCRS["unknown",BASEGEOGCRS["unknown",DATUM["unknown",ELLIPSOID['
+                   '"unknown",6371200,0,LENGTHUNIT["metre",1,ID["EPSG",9001]]]],'
+                   'PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",'
+                   '8901]]],CONVERSION["unknown",METHOD["Equidistant Cylindrical ('
+                   'Spherical)",ID["EPSG",1029]],PARAMETER["Latitude of 1st standard '
+                   'parallel",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],'
+                   'PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",'
+                   '0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,'
+                   'LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,'
+                   'LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["(E)",east,'
+                   'ORDER[1],LENGTHUNIT["metre",1,ID["EPSG",9001]]],AXIS["(N)",north,'
+                   'ORDER[2],LENGTHUNIT["metre",1,ID["EPSG",9001]]]]'}
+    cfproj = CFProjection(attrs)
+
+    assert str(cfproj) == 'Projection: unknown'
+    with pytest.raises(ValueError) as exc:
+        cfproj.to_cartopy()
+
+    assert 'Unhandled projection' in str(exc.value)
+
+
 def test_globe():
     """Test handling building a cartopy globe."""
     attrs = {'grid_mapping_name': 'lambert_conformal_conic', 'earth_radius': 6367000,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
The problem is that the original GEMPAK CED and MCD ([modified] cylindrical equidistant) projections, while supported by PROJ, aren't defined in the CF metadata spec (as of 1.10). This is a work-around that makes __str__ not fail, and gives a better error, when CFProjection is given a set of metadata it can't handle.

This fixes the notebook experience so that just trying to print/take a repr doesn't result in errors. Fixing plotting is out of scope because I'm loath to try add things that aren't supported by the CF spec within our "CFProjection" class. I'm actually not even sure what the right one to use in Cartopy would be.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2121
- [x] Tests added
