### PR TITLE
BUG: Raise error in moist_lapse on solver fail

### DIFF
--- a/ci/test_requirements.txt
+++ b/ci/test_requirements.txt
@@ -1,3 +1,4 @@
+packaging==23.1
 pytest==7.3.1
 pytest-mpl==0.16.1
 netCDF4==1.6.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ examples = [
     "shapely>=1.6.0"
 ]
 test = [
+    "packaging>=21.0",
     "pytest>=2.4",
     "pytest-mpl",
     "cartopy>=0.17.0",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
The scipy solver doesn't raise an error, but has some return codes that indicate success or failure. Use these to raise an appropriate error in that case. This avoids confusing behavior in downstream calculations, like parcel_profile.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #3004
- [x] Tests added
