### PR TITLE
DOC: manually add PST version json

### DIFF
--- a/pst-versions.json
+++ b/pst-versions.json
@@ -1,0 +1,30 @@
+[
+    {
+        "version": "dev",
+        "url": "https://unidata.github.io/MetPy/dev/"
+    },
+    {
+        "version": "latest",
+        "url": "https://unidata.github.io/MetPy/latest/"
+    },
+    {
+        "name": "v1.5",
+        "version": "1.5",
+        "url": "https://unidata.github.io/MetPy/v1.5/"
+    },
+    {
+        "name": "v1.4",
+        "version": "1.4",
+        "url": "https://unidata.github.io/MetPy/v1.4/"
+    },
+    {
+        "name": "v1.3",
+        "version": "1.3",
+        "url": "https://unidata.github.io/MetPy/v1.3/"
+    },
+    {
+        "name": "v1.2",
+        "version": "1.2",
+        "url": "https://unidata.github.io/MetPy/v1.2/"
+    }
+]


### PR DESCRIPTION
Enables #2974 to pass and go in. After release we can update this to generate via workflow a la `versions.json`. These two will need to separately exist until we stop "supporting" doc versions using the old version switcher.