### PR TITLE
Export parse_wpc_surface_bulletin

### DIFF
--- a/src/metpy/io/__init__.py
+++ b/src/metpy/io/__init__.py
@@ -25,5 +25,6 @@ __all__.extend(gini.__all__)  # pylint: disable=undefined-variable
 __all__.extend(metar.__all__)  # pylint: disable=undefined-variable
 __all__.extend(nexrad.__all__)  # pylint: disable=undefined-variable
 __all__.extend(station_data.__all__)  # pylint: disable=undefined-variable
+__all__.extend(text.__all__)  # pylint: disable=undefined-variable
 
 set_module(globals())

--- a/src/metpy/io/text.py
+++ b/src/metpy/io/text.py
@@ -12,6 +12,9 @@ import numpy as np
 import pandas as pd
 
 from ._tools import open_as_needed
+from ..package_tools import Exporter
+
+exporter = Exporter(globals())
 
 
 def _decode_coords(coordinates):
@@ -64,6 +67,7 @@ def _regroup_lines(iterable):
         yield parts
 
 
+@exporter.export
 def parse_wpc_surface_bulletin(bulletin, year=None):
     """Parse a coded surface bulletin from NWS WPC into a Pandas DataFrame.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
The code to export and set __all__ was missing. The function was still available from the * import, but it wasn't showing up properly in the docs.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Fully documented
