### PR TITLE
Fix interpolation with mixed types

### DIFF
--- a/src/metpy/interpolate/one_dimension.py
+++ b/src/metpy/interpolate/one_dimension.py
@@ -239,4 +239,6 @@ def _strip_matching_units(*args):
     if all(hasattr(arr, 'units') for arr in args):
         return [arr.to(args[0].units).magnitude for arr in args]
     else:
-        return args
+        # Handle the case where we get mixed 'dimensionless' and bare array. This happens e.g.
+        # when you pass in a DataArray with no units for one arg.
+        return [arr.m_as('dimensionless') if hasattr(arr, 'units') else arr for arr in args]

--- a/tests/interpolate/test_one_dimension.py
+++ b/tests/interpolate/test_one_dimension.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 import pytest
+import xarray as xr
 
 from metpy.interpolate import interpolate_1d, interpolate_nans_1d, log_interpolate_1d
 from metpy.testing import assert_array_almost_equal
@@ -42,6 +43,16 @@ def test_interpolate_nans_1d_invalid():
 def test_log_interpolate_1d():
     """Test interpolating with log x-scale."""
     x_log = np.array([1e3, 1e4, 1e5, 1e6])
+    y_log = np.log(x_log) * 2 + 3
+    x_interp = np.array([5e3, 5e4, 5e5])
+    y_interp_truth = np.array([20.0343863828, 24.6395565688, 29.2447267548])
+    y_interp = log_interpolate_1d(x_interp, x_log, y_log)
+    assert_array_almost_equal(y_interp, y_interp_truth, 7)
+
+
+def test_log_interpolate_1d_mixed():
+    """Test log interpolation with a mix of compatible input types."""
+    x_log = xr.DataArray([1e3, 1e4, 1e5, 1e6])
     y_log = np.log(x_log) * 2 + 3
     x_interp = np.array([5e3, 5e4, 5e5])
     y_interp_truth = np.array([20.0343863828, 24.6395565688, 29.2447267548])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
When given a DataArray and a numpy array, neither with units, a Quantity would be passed into the core calculation, triggering an exception on `apply_along_axis`. Instead, handle trying to convert and drop units on a "dimensionless" Quantity, since that's what we get for a DataArray with no units.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #1889
- [x] Tests added
