### PR TITLE
Drop Python 3.8

### DIFF
--- a/.github/workflows/docs-conda.yml
+++ b/.github/workflows/docs-conda.yml
@@ -22,8 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 3.8
-            os: macOS
           - python-version: 3.9
             os: Windows
           - python-version: '3.10'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,9 +28,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 3.8
-            check-links: false
-            dep-versions: requirements.txt
           - python-version: 3.9
             check-links: false
             dep-versions: requirements.txt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,10 +32,10 @@ jobs:
             check-links: false
             dep-versions: requirements.txt
           - python-version: '3.10'
-            check-links: true
+            check-links: false
             dep-versions: requirements.txt
           - python-version: 3.11
-            check-links: false
+            check-links: true
             dep-versions: requirements.txt
     outputs:
       doc-version: ${{ steps.build-docs.outputs.doc-version }}
@@ -77,7 +77,7 @@ jobs:
     - name: Download doc build
       uses: actions/download-artifact@v3
       with:
-        name: Linux-3.10-docs
+        name: Linux-3.11-docs
         path: ./docs/build/html
 
     # This overrides the version "dev" with the proper version if we're building off a

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11]
+        python-version: [3.9, '3.10', 3.11]
         os: [macOS, Windows]
 
     steps:

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -41,10 +41,6 @@ jobs:
     - name: Get tags
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-    - name: Remove Dask from deps
-      if: ${{ matrix.python-version == '3.11' }}
-      run: cat ci/test_requirements.txt | grep -v dask > temp && mv temp ci/test_requirements.txt
-
     - name: Install from Conda
       uses: ./.github/actions/install-conda
       with:

--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -25,11 +25,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11]
+        python-version: [3.9, '3.10', 3.11]
         dep-versions: [requirements.txt]
         no-extras: ['']
         include:
-          - python-version: 3.8
+          - python-version: 3.9
             dep-versions: Minimum
             no-extras: 'No Extras'
           - python-version: 3.11

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ on a future ``1.x`` version.
 For additional MetPy examples not included in this repository, please see the [Unidata Python
 Gallery](https://unidata.github.io/python-gallery/).
 
-We support Python >= 3.8.
+We support Python >= 3.9.
 
 Need Help?
 ----------

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,4 +1,3 @@
-importlib_resources==5.12.0
 matplotlib==3.7.2
 numpy==1.24.4
 pandas==1.5.3

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ MetPy
 =====
 
 MetPy is a collection of tools in Python for reading, visualizing, and performing calculations
-with weather data. MetPy supports Python >= 3.8 and is freely available under a permissive
+with weather data. MetPy supports Python >= 3.9 and is freely available under a permissive
 `open source license <https://github.com/Unidata/MetPy/blob/main/LICENSE>`_.
 
 If you're new to MetPy, check out our :doc:`Getting Started <userguide/startingguide>` guide.

--- a/docs/userguide/installguide.rst
+++ b/docs/userguide/installguide.rst
@@ -7,7 +7,7 @@ Requirements
 ------------
 In general, MetPy tries to support minor versions of dependencies released within the last two
 years. For Python itself, that generally means supporting the last two minor releases; MetPy
-currently supports Python >= 3.8.
+currently supports Python >= 3.9.
 
 .. literalinclude:: ../../pyproject.toml
    :start-after: importlib_resources

--- a/docs/userguide/installguide.rst
+++ b/docs/userguide/installguide.rst
@@ -10,7 +10,7 @@ years. For Python itself, that generally means supporting the last two minor rel
 currently supports Python >= 3.9.
 
 .. literalinclude:: ../../pyproject.toml
-   :start-after: importlib_resources
+   :start-at: matplotlib
    :end-at: xarray
 
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "importlib_resources>=1.3.0; python_version < '3.9'",
     "matplotlib>=3.3.0",
     "numpy>=1.18.0",
     "pandas>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,12 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "matplotlib>=3.3.0",
-    "numpy>=1.18.0",
-    "pandas>=1.0.0",
+    "numpy>=1.20.0",
+    "pandas>=1.2.0",
     "pint>=0.15",
     "pooch>=1.2.0",
-    "pyproj>=2.6.1",
-    "scipy>=1.4.0",
+    "pyproj>=3.0.0",
+    "scipy>=1.6.0",
     "traitlets>=5.0.5",
     "xarray>=0.18.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Matplotlib",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -24,7 +23,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "License :: OSI Approved :: BSD License"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "importlib_resources>=1.3.0; python_version < '3.9'",
     "matplotlib>=3.3.0",

--- a/src/metpy/interpolate/one_dimension.py
+++ b/src/metpy/interpolate/one_dimension.py
@@ -107,8 +107,7 @@ def interpolate_1d(x, xp, *args, axis=0, fill_value=np.nan, return_list_always=F
     sort_x = np.argsort(x)
 
     # The shape after all arrays are broadcast to each other
-    # Can't use broadcast_shapes until numpy >=1.20 is our minimum
-    final_shape = np.broadcast(xp, *args).shape
+    final_shape = np.broadcast_shapes(xp.shape, *(a.shape for a in args))
 
     # indices for sorting
     sorter = broadcast_indices(sort_args, final_shape, axis)

--- a/src/metpy/io/gempak.py
+++ b/src/metpy/io/gempak.py
@@ -728,11 +728,11 @@ class GempakFile:
         # parts = self._buffer.set_mark()
         self.parts = []
         parts_info = [('name', '4s', self._decode_strip),
-                      (None, '{:d}x'.format((self.prod_desc.parts - 1) * BYTES_PER_WORD)),
+                      (None, f'{(self.prod_desc.parts - 1) * BYTES_PER_WORD:d}x'),
                       ('header_length', 'i'),
-                      (None, '{:d}x'.format((self.prod_desc.parts - 1) * BYTES_PER_WORD)),
+                      (None, f'{(self.prod_desc.parts - 1) * BYTES_PER_WORD:d}x'),
                       ('data_type', 'i', DataTypes),
-                      (None, '{:d}x'.format((self.prod_desc.parts - 1) * BYTES_PER_WORD)),
+                      (None, f'{(self.prod_desc.parts - 1) * BYTES_PER_WORD:d}x'),
                       ('parameter_count', 'i')]
         parts_info.extend([(None, None)])
         parts_fmt = NamedStruct(parts_info, self.prefmt, 'Parts')

--- a/src/metpy/plots/_util.py
+++ b/src/metpy/plots/_util.py
@@ -87,10 +87,7 @@ def _add_logo(fig, x=10, y=25, zorder=100, which='metpy', size='small', **kwargs
        The `matplotlib.image.FigureImage` instance created
 
     """
-    try:
-        from importlib.resources import files as importlib_resources_files
-    except ImportError:  # Can remove when we require Python > 3.8
-        from importlib_resources import files as importlib_resources_files
+    import importlib.resources
 
     fname_suffix = {'small': '_75x75.png',
                     'large': '_150x150.png'}
@@ -101,7 +98,7 @@ def _add_logo(fig, x=10, y=25, zorder=100, which='metpy', size='small', **kwargs
     except KeyError:
         raise ValueError('Unknown logo size or selection') from None
 
-    with (importlib_resources_files('metpy.plots') / '_static' / fname).open('rb') as fobj:
+    with (importlib.resources.files('metpy.plots') / '_static' / fname).open('rb') as fobj:
         logo = imread(fobj)
     return fig.figimage(logo, x, y, zorder=zorder, **kwargs)
 

--- a/src/metpy/plots/ctables.py
+++ b/src/metpy/plots/ctables.py
@@ -132,12 +132,9 @@ class ColortableRegistry(dict):
             The path to the directory with the color tables
 
         """
-        try:
-            from importlib.resources import files as importlib_resources_files
-        except ImportError:  # Can remove when we require Python > 3.8
-            from importlib_resources import files as importlib_resources_files
+        import importlib.resources
 
-        for entry in (importlib_resources_files(pkg) / path).iterdir():
+        for entry in (importlib.resources.files(pkg) / path).iterdir():
             if entry.suffix == TABLE_EXT:
                 with entry.open() as stream:
                     self.add_colortable(stream, entry.with_suffix('').name)

--- a/src/metpy/plots/wx_symbols.py
+++ b/src/metpy/plots/wx_symbols.py
@@ -6,12 +6,7 @@
 See WMO No.306 Attachment IV for more info on the symbols.
 """
 
-try:
-    from importlib.resources import (as_file as importlib_resources_as_file,
-                                     files as importlib_resources_files)
-except ImportError:  # Can remove when we require Python > 3.8
-    from importlib_resources import (files as importlib_resources_files,
-                                     as_file as importlib_resources_as_file)
+import importlib.resources
 
 import matplotlib.font_manager as fm
 import numpy as np
@@ -21,8 +16,8 @@ from ..package_tools import Exporter
 exporter = Exporter(globals())
 
 # Create a matplotlib font object pointing to our weather symbol font
-fontfile = importlib_resources_files('metpy.plots') / 'fonts/wx_symbols.ttf'
-with importlib_resources_as_file(fontfile) as fname:
+fontfile = importlib.resources.files('metpy.plots') / 'fonts/wx_symbols.ttf'
+with importlib.resources.as_file(fontfile) as fname:
     # Need to pass str, not Path, for older matplotlib
     wx_symbol_font = fm.FontProperties(fname=str(fname))
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
* Declare supported Python as >=3.9
* Remove 3.8 from CI builds
* Remove no-longer-needed `importlib_resources`
* Run `pyupgrade --py39-plus`
* Bump minimum versions for Python 3.9 support
  - Numpy 1.20.0
  - Scipy 1.6.0
  - PyProj 3.0.0
  - Pandas 1.2.0
* Clean up some lingering work-arounds for Python 3.11 in CI configs
* Update `interpolate_1d` to use `np.broadcast_shapes` since we're now on numpy >=1.20

This paves the way to rebase and merge a bunch of dependabot updates.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Fully documented
