### PR TITLE
add functionality to hodograph

### DIFF
--- a/src/metpy/plots/skewt.py
+++ b/src/metpy/plots/skewt.py
@@ -18,6 +18,7 @@ from matplotlib.patches import Circle
 from matplotlib.projections import register_projection
 import matplotlib.spines as mspines
 from matplotlib.ticker import MultipleLocator, NullFormatter, ScalarFormatter
+from matplotlib.font_manager import FontManager
 import matplotlib.transforms as transforms
 import numpy as np
 
@@ -781,23 +782,28 @@ class Hodograph:
         # == sqrt(2) * max_range, which is the distance at the corner
         self.max_range = 1.4142135 * component_range
 
-    def add_grid(self, increment=10., **kwargs):
-        r"""Add grid lines to hodograph.
+    def add_grid(self, increment=10., ring_labels=True, grid_ticks=False, **kwargs):
+        """
+        Add grid lines to the hodograph plot.
 
-        Creates lines for the x- and y-axes, as well as circles denoting wind speed values.
+        This method creates lines for the x- and y-axes, as well as circles denoting wind speed values.
 
         Parameters
         ----------
         increment : int, optional
-            The value increment between rings
-        kwargs
-            Other kwargs to control appearance of lines
+            The value increment between rings denoting wind speed values.
+        ring_labels : bool, optional
+            Whether to include labels for each ring denoting wind speed values.
+        grid_ticks : bool, optional
+            Whether to include grid ticks along the axes.
+        **kwargs
+            Additional keyword arguments to control the appearance of the lines.
 
         See Also
         --------
-        :class:`matplotlib.patches.Circle`
-        :meth:`matplotlib.axes.Axes.axhline`
-        :meth:`matplotlib.axes.Axes.axvline`
+        matplotlib.patches.Circle
+        matplotlib.axes.Axes.axhline
+        matplotlib.axes.Axes.axvline
 
         """
         # Some default arguments. Take those, and update with any
@@ -817,10 +823,27 @@ class Hodograph:
             c = Circle((0, 0), radius=r, **circle_args)
             self.ax.add_patch(c)
             self.rings.append(c)
+            
+            if ring_labels:
+                default_fontsize = FontManager().get_default_size()
+                max_fontsize = default_fontsize - 2
+                label_size = min(max_fontsize, default_fontsize - 2)
+                # Calculate label coordinates dynamically based on the circle radius
+                label_x = -r - 2
+                if self.max_range < 50:
+                    label_y = - 5  # Adjust the factor as needed
+                else:
+                    label_y = - 10
+                self.ax.annotate(f'{int(r)}', xy=(label_x, label_y), xycoords='data', va='center',
+                                zorder=Line2D.zorder + 1, fontsize=label_size)
 
         # Add lines for x=0 and y=0
         self.yaxis = self.ax.axvline(0, **grid_args)
         self.xaxis = self.ax.axhline(0, **grid_args)
+
+        if not grid_ticks:
+            self.ax.set_xticks([])
+            self.ax.set_yticks([])
 
     @staticmethod
     def _form_line_args(kwargs):


### PR DESCRIPTION
Added `ring_labels` and `grid_ticks` parameters to the `add_grid` function in the `Hodograph` class. This enhancement enables the customization of wind speed labels/ticks and grid ticks on the hodograph.

#### Checklist

- [x] Tests done (only flake8)
- [x] Fully documented

#### Description

This pull request introduces the `ring_labels` and `grid_ticks` parameters to the `add_grid` function in the `Hodograph` class. When `ring_labels` is set to `True` (default), wind speed labels/ticks are added to the `axhline` of the hodograph. When `grid_ticks` is set to `True`, x and y ticks are included along the axes.

#### Example Usage

```python
h = Hodograph(ax_hod, component_range=50.)
h.add_grid(increment=10, alpha=0.5, ls="-", ring_labels=True, grid_ticks=True)
```

Kindly review this pull request and consider merging it into the main branch. 
Thank you!

<img width="310" alt="Screenshot 2023-07-08 at 12 12 56 AM" src="https://github.com/Unidata/MetPy/assets/35923822/79e644f0-860a-41dc-b944-dea934ed5ecc">
<img width="285" alt="Screenshot 2023-07-08 at 12 11 55 AM" src="https://github.com/Unidata/MetPy/assets/35923822/ce0be87e-9841-47c8-b023-e15d137bb3f3">
<img width="810" alt="Screenshot 2023-07-08 at 12 11 06 AM" src="https://github.com/Unidata/MetPy/assets/35923822/0ee2d7d3-2968-4997-beff-a498e47c0bca">
