### PR TITLE
Practical units for dry adiabatic lapse rate constant

### DIFF
--- a/src/metpy/constants/default.py
+++ b/src/metpy/constants/default.py
@@ -56,7 +56,7 @@ with exporter:
     # General meteorology constants
     P0 = pot_temp_ref_press = units.Quantity(1000., 'mbar')
     kappa = poisson_exponent = (Rd / Cp_d).to('dimensionless')
-    gamma_d = dry_adiabatic_lapse_rate = g / Cp_d
+    gamma_d = dry_adiabatic_lapse_rate = (g / Cp_d).to('K / km')
     epsilon = molecular_weight_ratio = (Mw / Md).to('dimensionless')
 
 del Exporter


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

Updates units for dry adiabatic lapse rate `Quantity` from 'K * kg * m / J / s **2' to 'K / km'.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #3082

