### PR TITLE
Add Galvez-Davison Index calculation

### DIFF
--- a/docs/_templates/overrides/metpy.calc.rst
+++ b/docs/_templates/overrides/metpy.calc.rst
@@ -79,6 +79,7 @@ Soundings
       cross_totals
       downdraft_cape
       el
+      galvez_davison_index
       k_index
       lcl
       lfc

--- a/docs/api/references.rst
+++ b/docs/api/references.rst
@@ -86,6 +86,10 @@ References
            Services and Supporting Research, 2003.
            `FCM-R19-2003 <../_static/FCM-R19-2003-WindchillReport.pdf>`_, 75 pp.
 
+.. [Galvez2015] Galvez, J. M. and Michel Davison, 2015. “The Gálvez-Davison Index for Tropical 
+            Convection.” `GDI_Manuscript_V20161021 
+            <https://www.wpc.ncep.noaa.gov/international/gdi/GDI_Manuscript_V20161021.pdf>`_.
+
 .. [Galway1956] Galway, J. G., 1956: The Lifted Index as a Predictor of Latent Instability.
            *American Meteorology Society*,
            doi:`10.1175/1520-0477-37.10.528

--- a/docs/api/references.rst
+++ b/docs/api/references.rst
@@ -86,8 +86,8 @@ References
            Services and Supporting Research, 2003.
            `FCM-R19-2003 <../_static/FCM-R19-2003-WindchillReport.pdf>`_, 75 pp.
 
-.. [Galvez2015] Galvez, J. M. and Michel Davison, 2015. “The Gálvez-Davison Index for Tropical 
-            Convection.” `GDI_Manuscript_V20161021 
+.. [Galvez2015] Galvez, J. M. and Michel Davison, 2015. “The Gálvez-Davison Index for Tropical
+            Convection.” `GDI_Manuscript_V20161021
             <https://www.wpc.ncep.noaa.gov/international/gdi/GDI_Manuscript_V20161021.pdf>`_.
 
 .. [Galway1956] Galway, J. G., 1956: The Lifted Index as a Predictor of Latent Instability.

--- a/examples/calculations/Sounding_Calculations.py
+++ b/examples/calculations/Sounding_Calculations.py
@@ -96,6 +96,7 @@ u, v = mpcalc.wind_components(sped, wdir)
 # Compute common sounding index parameters
 ctotals = mpcalc.cross_totals(p, T, Td)
 kindex = mpcalc.k_index(p, T, Td)
+gdi = mpcalc.galvez_davison_index(p, T, Td)
 showalter = mpcalc.showalter_index(p, T, Td)
 total_totals = mpcalc.total_totals_index(p, T, Td)
 vert_totals = mpcalc.vertical_totals(p, T)

--- a/examples/calculations/Sounding_Calculations.py
+++ b/examples/calculations/Sounding_Calculations.py
@@ -89,6 +89,11 @@ sped = df['speed'].values * units.knot
 height = df['height'].values * units.meter
 
 ###########################################
+# Compute needed variables from our data file and attach units
+relhum = mpcalc.relative_humidity_from_dewpoint(T, Td)
+mixrat = mpcalc.mixing_ratio_from_relative_humidity(p, T, relhum)
+
+###########################################
 # Compute the wind components
 u, v = mpcalc.wind_components(sped, wdir)
 
@@ -96,7 +101,7 @@ u, v = mpcalc.wind_components(sped, wdir)
 # Compute common sounding index parameters
 ctotals = mpcalc.cross_totals(p, T, Td)
 kindex = mpcalc.k_index(p, T, Td)
-gdi = mpcalc.galvez_davison_index(p, T, Td)
+gdi = mpcalc.galvez_davison_index(p, T, mixrat, p[0])
 showalter = mpcalc.showalter_index(p, T, Td)
 total_totals = mpcalc.total_totals_index(p, T, Td)
 vert_totals = mpcalc.vertical_totals(p, T)

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -14,7 +14,6 @@ from .tools import (_greater_or_close, _less_or_close, _remove_nans, find_boundi
                     find_intersections, first_derivative, get_layer)
 from .. import _warnings, constants as mpconsts
 from ..cbook import broadcast_indices
-from ..constants import Cp_d
 from ..interpolate.one_dimension import interpolate_1d
 from ..package_tools import Exporter
 from ..units import check_units, concatenate, process_units, units
@@ -4631,14 +4630,15 @@ def galvez_davison_index(pressure, temperature, mixing_ratio, surface_pressure,
     alpha = units.Quantity(-10, 'K')  # Empirical adjustment
 
     # Latent heat of vaporization of water - different from MetPy constant
-    #  Using different value, from paper, since GDI unlikely to be used to
-    #  derive other metrics
-    l_0 = units.Quantity(2.69E6, 'J/kg')
+    #  Using different value, from MetPy, since GDI unlikely to be used to
+    #  derive other metrics and a more appropriate value for tropical
+    #  atmosphere.
+    l_0 = units.Quantity(2.69e6, 'J/kg')
 
     # Temperature math from here on requires kelvin units
-    eptp_a = th_a * np.exp((l_0 * r_a) / (Cp_d * t850))
-    eptp_b = th_b * np.exp((l_0 * r_b) / (Cp_d * t850)) + alpha
-    eptp_c = th_c * np.exp((l_0 * r_c) / (Cp_d * t850)) + alpha
+    eptp_a = th_a * np.exp((l_0 * r_a) / (mpconsts.Cp_d * t850))
+    eptp_b = th_b * np.exp((l_0 * r_b) / (mpconsts.Cp_d * t850)) + alpha
+    eptp_c = th_c * np.exp((l_0 * r_c) / (mpconsts.Cp_d * t850)) + alpha
 
     if t950.size == 1:
         is_array = False

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -4506,7 +4506,11 @@ def galvez_davison_index(pressure, temperature, dewpoint, vertical_dim=0):
     """
     Calculate GDI from the pressure temperature and dewpoint.
 
-    GDI formula derived from [Galvez2015](https://www.wpc.ncep.noaa.gov/international/gdi/GDI_Manuscript_V20150910.pdf)_:
+    Calculation of the GDI relies on temperatures and mixing ratios at 950,
+    850, 700, and 500 hPa. These four levels define three layers: A) Boundary,
+    B) Trade Wind Inversion (TWI), C) Mid-Troposphere.
+
+    GDI formula derived from [Galvez2015]_:
 
     .. math:: GDI = CBI + MWI + II + TC
 
@@ -4517,20 +4521,24 @@ def galvez_davison_index(pressure, temperature, dewpoint, vertical_dim=0):
     * :math:`II` is the Inversion Index
     * :math:`TC` is the Terrain Correction [optional]
 
-    Calculation of the GDI relies on temperatures and mixing ratios at 950,
-     850, 700, and 500 hPa. These four levels define three layers: A) Boundary,
-     B) Trade Wind Inversion (TWI), C) Mid-Troposphere.
+    .. list-table:: GDI Values & Corresponding Convective Regimes
+        :widths: 15 75
+        :header-rows: 1
 
-    ----------------------------------------------------------------------------------
-    GDI Value   | Expected Convective Regime
-    ----------------------------------------------------------------------------------
-    >=45        | Scattered to widespread thunderstorms likely.
-    35 to 45    | Scattered thunderstorms and/or scattered to widespread rain showers.
-    25 to 35    | Isolated to scattered thunderstorms and/or scattered showers.
-    15 to 25    | Isolated thunderstorms and/or isolated to scattered showers.
-    5 to 10     | Isolated to scattered showers.
-    <5          | Strong TWI likely, light rain possible.
-    ----------------------------------------------------------------------------------
+        * - GDI Value
+          - Expected Convective Regime
+        * - >=45
+          - Scattered to widespread thunderstorms likely.
+        * - 35 to 45
+          - Scattered thunderstorms and/or scattered to widespread rain showers.
+        * - 25 to 35
+          - Isolated to scattered thunderstorms and/or scattered showers.
+        * - 15 to 25
+          - Isolated thunderstorms and/or isolated to scattered showers.
+        * - 5 to 10
+          - Isolated to scattered showers.
+        * - <5
+          - Strong TWI likely, light rain possible.
 
     Parameters
     ----------

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -4584,7 +4584,7 @@ def galvez_davison_index(pressure, temperature, mixing_ratio, surface_pressure,
     >>> # calculate mixing ratio
     >>> mixrat = mixing_ratio_from_relative_humidity(p, T, rh)
     >>> galvez_davison_index(p, T, mixrat, p[0])
-    <Quantity(-8.06886508, 'dimensionless')>
+    <Quantity(-8.78797532, 'dimensionless')>
     """
     # Calculate potential temperature
     potential_temp = potential_temperature(pressure, temperature)

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -4637,12 +4637,12 @@ def galvez_davison_index(pressure, temperature, dewpoint, vertical_dim=0):
     # Latent heat of vaporization of water - different from MetPy constant
     #  Using different value, from paper, since GDI unlikely to be used to
     #  derive other metrics
-    Lo = 2.69E6 * (units.joule / units.kilogram)
+    l_0 = 2.69E6 * (units.joule / units.kilogram)
 
     # Temperature math from here on requires kelvin units
-    eptp_a = th_a * np.exp((Lo * r_a) / (Cp_d * t850))
-    eptp_b = th_b * np.exp((Lo * r_b) / (Cp_d * t850)) + alpha
-    eptp_c = th_c * np.exp((Lo * r_c) / (Cp_d * t850)) + alpha
+    eptp_a = th_a * np.exp((l_0 * r_a) / (Cp_d * t850))
+    eptp_b = th_b * np.exp((l_0 * r_b) / (Cp_d * t850)) + alpha
+    eptp_c = th_c * np.exp((l_0 * r_c) / (Cp_d * t850)) + alpha
 
     if t950.size == 1:
         is_array = False
@@ -4670,7 +4670,7 @@ def galvez_davison_index(pressure, temperature, dewpoint, vertical_dim=0):
     column_buoyancy_index = column_buoyancy_index.magnitude
 
     # Calculate Mid-tropospheric Warming Index
-    tau = 263.15 * units.kelvin  # Threshhold
+    tau = 263.15 * units.kelvin  # Threshold
     mu = -7 * (1 / units.kelvin)  # Empirical adjustment
 
     t_diff = t500 - tau

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -4622,8 +4622,8 @@ def galvez_davison_index(pressure, temperature, mixing_ratio, surface_pressure,
     # Calculate adjusted equivalent potential temperatures
     alpha = units.Quantity(-10, 'K')
     eptp_a = th950 * np.exp(l_0 * r950 / (mpconsts.Cp_d * t850))
-    eptp_b = ((th850 + th700) / 2 *
-              np.exp(l_0 * (r850 + r700) / 2 / (mpconsts.Cp_d * t850)) + alpha)
+    eptp_b = ((th850 + th700) / 2
+              * np.exp(l_0 * (r850 + r700) / 2 / (mpconsts.Cp_d * t850)) + alpha)
     eptp_c = th500 * np.exp(l_0 * r500 / (mpconsts.Cp_d * t850)) + alpha
 
     # Calculate Column Buoyanci Index (CBI)
@@ -4661,10 +4661,15 @@ def galvez_davison_index(pressure, temperature, mixing_ratio, surface_pressure,
     terrain_correction = 18 - 9000 / (surface_pressure.m_as('hPa') - 500)
 
     # Calculate G.D.I.
-    return (column_buoyancy_index
-            + mid_tropospheric_warming_index
-            + inversion_index
-            + terrain_correction)
+    gdi = (column_buoyancy_index
+           + mid_tropospheric_warming_index
+           + inversion_index
+           + terrain_correction)
+
+    if gdi.size == 1:
+        return gdi[0]
+    else:
+        return gdi
 
 
 @exporter.export

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -2463,7 +2463,9 @@ def test_gdi():
                          -34.1, -37.3, -32.3, -34.1, -37.3, -41.1, -37.7, -58.1,
                          -57.5]) * units.degC
 
-    gdi = galvez_davison_index(pressure, temperature, dewpoint)
+    relative_humidity = relative_humidity_from_dewpoint(temperature, dewpoint)
+    mixrat = mixing_ratio_from_relative_humidity(pressure, temperature, relative_humidity)
+    gdi = galvez_davison_index(pressure, temperature, mixrat, pressure[0])
 
     # Compare with value from hand calculation
     assert_almost_equal(gdi, 6.635, decimal=1)
@@ -2471,10 +2473,16 @@ def test_gdi():
 
 def test_gdi_xarray(index_xarray_data_expanded):
     """Test the GDI calculation with a grid of xarray data."""
+    pressure = index_xarray_data_expanded.isobaric
+    temperature = index_xarray_data_expanded.temperature
+    dewpoint = index_xarray_data_expanded.dewpoint
+    relative_humidity = relative_humidity_from_dewpoint(temperature, dewpoint)
+    mixrat = mixing_ratio_from_relative_humidity(pressure, temperature, relative_humidity)
     result = galvez_davison_index(
-        index_xarray_data_expanded.isobaric,
-        index_xarray_data_expanded.temperature,
-        index_xarray_data_expanded.dewpoint
+        pressure,
+        temperature,
+        mixrat,
+        pressure[0]
     )
 
     assert_array_almost_equal(
@@ -2494,10 +2502,16 @@ def test_gdi_no_950_raises_valueerror(index_xarray_data):
     Ensure error is raised if this data is not provided.
     """
     with pytest.raises(ValueError):
+        pressure = index_xarray_data.isobaric
+        temperature = index_xarray_data.temperature
+        dewpoint = index_xarray_data.dewpoint
+        relative_humidity = relative_humidity_from_dewpoint(temperature, dewpoint)
+        mixrat = mixing_ratio_from_relative_humidity(pressure, temperature, relative_humidity)
         galvez_davison_index(
-            index_xarray_data.isobaric,
-            index_xarray_data.temperature,
-            index_xarray_data.dewpoint
+            pressure,
+            temperature,
+            mixrat,
+            pressure[0]
         )
 
 

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -39,7 +39,7 @@ from metpy.calc import (brunt_vaisala_frequency, brunt_vaisala_frequency_squared
                         wet_bulb_potential_temperature, wet_bulb_temperature)
 from metpy.calc.thermo import _find_append_zero_crossings, galvez_davison_index
 from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_nan,
-                           version_check, wet_bulb_temperature)
+                           version_check)
 from metpy.units import is_quantity, masked_array, units
 
 
@@ -2311,9 +2311,9 @@ def index_xarray_data():
 
 @pytest.fixture()
 def index_xarray_data_expanded():
-    """Create data for testing that index calculations work with xarray data.
+    """Create expanded data for testing that index calculations work with xarray data.
 
-    Expanded for Galvez Davison Index calculation, which requires 950hPa pressure
+    Specifically for Galvez Davison Index calculation, which requires 950hPa pressure
     """
     pressure = xr.DataArray(
         [950., 850., 700., 500.], dims=('isobaric',), attrs={'units': 'hPa'}
@@ -2350,7 +2350,7 @@ def index_xarray_data_expanded():
 
     return xr.Dataset({'temperature': temp, 'profile': profile, 'dewpoint': dewp,
                        'wind_direction': dirw, 'wind_speed': speed},
-                      coords={'isobaric': pressure, 'time': ['2020-01-01T00:00Z']})
+                      coords={'isobaric': pressure, 'time': ['2023-01-01T00:00Z']})
 
 
 def test_lifted_index():

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -37,9 +37,9 @@ from metpy.calc import (brunt_vaisala_frequency, brunt_vaisala_frequency_squared
                         vertical_velocity_pressure, virtual_potential_temperature,
                         virtual_temperature, virtual_temperature_from_dewpoint,
                         wet_bulb_potential_temperature, wet_bulb_temperature)
-from metpy.calc.thermo import _find_append_zero_crossings
+from metpy.calc.thermo import _find_append_zero_crossings, galvez_davison_index
 from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_nan,
-                           version_check)
+                           version_check, wet_bulb_temperature)
 from metpy.units import is_quantity, masked_array, units
 
 
@@ -2309,6 +2309,50 @@ def index_xarray_data():
                       coords={'isobaric': pressure, 'time': ['2020-01-01T00:00Z']})
 
 
+@pytest.fixture()
+def index_xarray_data_expanded():
+    """Create data for testing that index calculations work with xarray data.
+
+    Expanded for Galvez Davison Index calculation, which requires 950hPa pressure
+    """
+    pressure = xr.DataArray(
+        [950., 850., 700., 500.], dims=('isobaric',), attrs={'units': 'hPa'}
+    )
+    temp = xr.DataArray([[[[306., 305., 304.], [303., 302., 301.]],
+                          [[296., 295., 294.], [293., 292., 291.]],
+                          [[286., 285., 284.], [283., 282., 281.]],
+                          [[276., 275., 274.], [273., 272., 271.]]]] * units.K,
+                        dims=('time', 'isobaric', 'y', 'x'))
+
+    profile = xr.DataArray([[[[299., 298., 297.], [296., 295., 294.]],
+                             [[289., 288., 287.], [286., 285., 284.]],
+                             [[279., 278., 277.], [276., 275., 274.]],
+                             [[269., 268., 267.], [266., 265., 264.]]]] * units.K,
+                           dims=('time', 'isobaric', 'y', 'x'))
+
+    dewp = xr.DataArray([[[[304., 303., 302.], [301., 300., 299.]],
+                          [[294., 293., 292.], [291., 290., 289.]],
+                          [[284., 283., 282.], [281., 280., 279.]],
+                          [[274., 273., 272.], [271., 270., 269.]]]] * units.K,
+                        dims=('time', 'isobaric', 'y', 'x'))
+
+    dirw = xr.DataArray([[[[135., 135., 135.], [135., 135., 135.]],
+                          [[180., 180., 180.], [180., 180., 180.]],
+                          [[225., 225., 225.], [225., 225., 225.]],
+                          [[270., 270., 270.], [270., 270., 270.]]]] * units.degree,
+                        dims=('time', 'isobaric', 'y', 'x'))
+
+    speed = xr.DataArray([[[[15., 15., 15.], [15., 15., 15.]],
+                           [[20., 20., 20.], [20., 20., 20.]],
+                           [[25., 25., 25.], [25., 25., 25.]],
+                           [[50., 50., 50.], [50., 50., 50.]]]] * units.knots,
+                         dims=('time', 'isobaric', 'y', 'x'))
+
+    return xr.Dataset({'temperature': temp, 'profile': profile, 'dewpoint': dewp,
+                       'wind_direction': dirw, 'wind_speed': speed},
+                      coords={'isobaric': pressure, 'time': ['2020-01-01T00:00Z']})
+
+
 def test_lifted_index():
     """Test the Lifted Index calculation."""
     pressure = np.array([1014., 1000., 997., 981.2, 947.4, 925., 914.9, 911.,
@@ -2396,6 +2440,65 @@ def test_k_index_xarray(index_xarray_data):
                      index_xarray_data.dewpoint)
     assert_array_almost_equal(result,
                               np.array([[[312., 311., 310.], [309., 308., 307.]]]) * units.K)
+
+
+def test_gdi():
+    """Test the Galvez Davison Index calculation."""
+    pressure = np.array([1014., 1000., 997., 981.2, 947.4, 925., 914.9, 911.,
+                         902., 883., 850., 822.3, 816., 807., 793.2, 770.,
+                         765.1, 753., 737.5, 737., 713., 700., 688., 685.,
+                         680., 666., 659.8, 653., 643., 634., 615., 611.8,
+                         566.2, 516., 500., 487., 484.2, 481., 475., 460.,
+                         400.]) * units.hPa
+    temperature = np.array([24.2, 24.2, 24., 23.1, 21., 19.6, 18.7, 18.4,
+                            19.2, 19.4, 17.2, 15.3, 14.8, 14.4, 13.4, 11.6,
+                            11.1, 10., 8.8, 8.8, 8.2, 7., 5.6, 5.6,
+                            5.6, 4.4, 3.8, 3.2, 3., 3.2, 1.8, 1.5,
+                            -3.4, -9.3, -11.3, -13.1, -13.1, -13.1, -13.7, -15.1,
+                            -23.5]) * units.degC
+    dewpoint = np.array([23.2, 23.1, 22.8, 22., 20.2, 19., 17.6, 17.,
+                         16.8, 15.5, 14., 11.7, 11.2, 8.4, 7., 4.6,
+                         5., 6., 4.2, 4.1, -1.8, -2., -1.4, -0.4,
+                         -3.4, -5.6, -4.3, -2.8, -7., -25.8, -31.2, -31.4,
+                         -34.1, -37.3, -32.3, -34.1, -37.3, -41.1, -37.7, -58.1,
+                         -57.5]) * units.degC
+
+    gdi = galvez_davison_index(pressure, temperature, dewpoint)
+
+    # Compare with value from hand calculation
+    assert_almost_equal(gdi, 6.635, decimal=1)
+
+
+def test_gdi_xarray(index_xarray_data_expanded):
+    """Test the GDI calculation with a grid of xarray data."""
+    result = galvez_davison_index(
+        index_xarray_data_expanded.isobaric,
+        index_xarray_data_expanded.temperature,
+        index_xarray_data_expanded.dewpoint
+    )
+
+    assert_array_almost_equal(
+        result,
+        np.array(
+            [[
+                [191.3749159, 158.8527877, 131.0999557],
+                [107.5620913, 87.7547436, 71.2538119]
+            ]]
+        ) * units.dimensionless
+    )
+
+
+def test_gdi_no_950_raises_valueerror(index_xarray_data):
+    """GDI requires a 950hPa or higher measurement.
+
+    Ensure error is raised if this data is not provided.
+    """
+    with pytest.raises(ValueError):
+        galvez_davison_index(
+            index_xarray_data.isobaric,
+            index_xarray_data.temperature,
+            index_xarray_data.dewpoint
+        )
 
 
 def test_gradient_richardson_number():

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -2487,12 +2487,8 @@ def test_gdi_xarray(index_xarray_data_expanded):
 
     assert_array_almost_equal(
         result,
-        np.array(
-            [[
-                [191.3749159, 158.8527877, 131.0999557],
-                [107.5620913, 87.7547436, 71.2538119]
-            ]]
-        ) * units.dimensionless
+        np.array([[[189.5890429, 157.4307982, 129.9739099],
+                   [106.6763526, 87.0637477, 70.7202505]]])
     )
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

Adds calculation for [Galvez-Davison Index for tropical convection](https://www.wpc.ncep.noaa.gov/international/gdi/).

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #2911 
- [x] Tests added
- [x] Fully documented
    - Docstrings (src and test)
    - Added function to `/docs/_templates/overrides/metpy.calc.rst`
    - Added function example to `/docs/examples/calculations/Sounding_Calculations.py`

This is all visible in the changelist but wanted to document the things I had to change. I didn't see any of this in the Contributor's Guide, ideally we can add it under documentation to make it easier for contributors to document future feature additions.