### PR TITLE
Add a dependabot group for flake8 and friends

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,12 @@ updates:
     commit-message:
       prefix: "CI: "
       include: "scope"
+    groups:
+      flake8:
+        patterns:
+          - "flake8*"
+          - "pycodestyle"
+          - "pyflakes"
 
   # Update GitHub Actions versions in workflows
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Dependabot now has support for [grouping](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/) dependencies for PRs. This adds a group for flake8 and friends, since they generally need to go in together. This should allow a single PR that stands a chance of working.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
