### PR TITLE
remove nans from bunkers input

### DIFF
--- a/src/metpy/calc/indices.py
+++ b/src/metpy/calc/indices.py
@@ -298,6 +298,9 @@ def bunkers_storm_motion(pressure, u, v, height):
        Renamed ``heights`` parameter to ``height``
 
     """
+    # remove nans from input data
+    pressure, u, v, height = _remove_nans(pressure, u, v, height)
+
     # mean wind from sfc-6km
     wind_mean = weighted_continuous_average(pressure, u, v, height=height,
                                             depth=units.Quantity(6000, 'meter'))

--- a/tests/calc/test_indices.py
+++ b/tests/calc/test_indices.py
@@ -175,6 +175,18 @@ def test_bunkers_motion():
              6.90054376] * units('m/s')
     assert_almost_equal(motion.flatten(), truth, 8)
 
+def test_bunkers_motion_with_nans():
+    """Test Bunkers storm motion with observed sounding."""
+    data = get_upper_air_data(datetime(2016, 5, 22, 0), 'DDC')
+    data['u_wind'][24:26] = np.nan
+    data['v_wind'][24:26] = np.nan
+    motion = concatenate(bunkers_storm_motion(data['pressure'],
+                         data['u_wind'], data['v_wind'],
+                         data['height']))
+    truth = [2.09232447, 0.97612357, 11.25513401, 12.85227283, 6.67372924,
+             6.9141982] * units('m/s')
+    assert_almost_equal(motion.flatten(), truth, 8)
+
 
 def test_bulk_shear():
     """Test bulk shear with observed sounding."""

--- a/tests/calc/test_indices.py
+++ b/tests/calc/test_indices.py
@@ -175,13 +175,16 @@ def test_bunkers_motion():
              6.90054376] * units('m/s')
     assert_almost_equal(motion.flatten(), truth, 8)
 
+
 def test_bunkers_motion_with_nans():
     """Test Bunkers storm motion with observed sounding."""
     data = get_upper_air_data(datetime(2016, 5, 22, 0), 'DDC')
-    data['u_wind'][24:26] = np.nan
-    data['v_wind'][24:26] = np.nan
+    u_with_nan = data['u_wind']
+    u_with_nan[24:26] = np.nan
+    v_with_nan = data['v_wind']
+    v_with_nan[24:26] = np.nan
     motion = concatenate(bunkers_storm_motion(data['pressure'],
-                         data['u_wind'], data['v_wind'],
+                         u_with_nan, v_with_nan,
                          data['height']))
     truth = [2.09232447, 0.97612357, 11.25513401, 12.85227283, 6.67372924,
              6.9141982] * units('m/s')


### PR DESCRIPTION
This fixes bunkers storm motion returning nan when given a nan in the input data. 

I don't believe any documentation is necessary for this as it is not documented in other functions that remove nans automatically.
