### PR TITLE
LFC calc: if EL is above top of sounding, use top of sounding as EL

### DIFF
--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -719,6 +719,8 @@ def lfc(pressure, temperature, dewpoint, parcel_temperature_profile=None, dewpoi
             el_pressure, _ = find_intersections(pressure[1:], parcel_temperature_profile[1:],
                                                 temperature[1:], direction='decreasing',
                                                 log_x=True)
+            if len(el_pressure) == 0:
+                el_pressure = pressure[-1]
             if np.min(el_pressure) > this_lcl[0]:
                 x = units.Quantity(np.nan, pressure.units)
                 y = units.Quantity(np.nan, temperature.units)


### PR DESCRIPTION
If attempting to calculate the LFC of a partial sounding, particularly one where the data is cut off below the EL, calculating the LFC or CAPE causes a value error. This commit uses the top of the sounding as the EL if the EL is absent (for the LFC calculation only).

This may or may not be a fix for the issue described in #2315, I'm not sure.