### PR TITLE
Use xfail for test that doesn't fail on arm64.

### DIFF
--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Test the `thermo` module."""
 
+import platform
 import sys
 import warnings
 
@@ -197,6 +198,8 @@ def test_moist_lapse_starting_points(start, direction):
     assert_almost_equal(temp, truth, 4)
 
 
+@pytest.mark.xfail(platform.machine() == 'aarch64',
+                   reason='ValueError is not raised on aarch64')
 @pytest.mark.xfail(sys.platform == 'win32', reason='solve_ivp() does not error on Windows')
 @pytest.mark.xfail(packaging.version.parse(scipy.__version__) < packaging.version.parse('1.7'),
                    reason='solve_ivp() does not error on Scipy < 1.7')


### PR DESCRIPTION
Original patch form Bas Couwenberg <sebastic@debian.org>. See https://salsa.debian.org/debian-gis-team/metpy/-/blob/7a187608c6a65a2f6686fb11ad286913a9b979cb/debian/patches/arm64.patch

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

Fixes a test failure on arm64.
Issue detected in debian/sid.
See also https://ci.debian.net/data/autopkgtest/testing/arm64/m/metpy/36313527/log.gz

```
149s ============================= test session starts ==============================
149s platform linux -- Python 3.11.4, pytest-7.4.0, pluggy-1.2.0
149s Matplotlib: 3.6.3
149s Freetype: 2.13.0
149s Dep Versions: Matplotlib 3.6.3, NumPy 1.24.2, Pandas 1.5.3, Pint 0.19.2, Pooch v1.7.0
149s 	PyProj 3.6.0, SciPy 1.10.1, Traitlets 5.5.0, Xarray 999
149s rootdir: /tmp/autopkgtest-lxc.r4cyxgxh/downtmp/autopkgtest_tmp/build
149s plugins: mpl-0.0.0
149s collected 1218 items / 256 deselected / 962 selected
149s 
149s tests/test_cbook.py ..                                                   [  0%]
149s tests/test_deprecation.py .                                              [  0%]
149s tests/test_packaging.py .                                                [  0%]
149s tests/test_testing.py ....                                               [  0%]
149s tests/test_xarray.py ................................................... [  6%]
150s ........................................................................ [ 13%]
153s .............................................                            [ 18%]
153s tests/calc/test_basic.py s...s....s...s...s....s........s.......s....s.. [ 23%]
153s ......s....s....s...s....s...s...s...s......s........s.....s..........s. [ 30%]
153s ...s...s.....s....s...                                                   [ 32%]
154s tests/calc/test_calc_tools.py .......................................... [ 37%]
154s ........................................................................ [ 44%]
154s ............................                                             [ 47%]
160s tests/calc/test_cross_sections.py ............                           [ 48%]
160s tests/calc/test_indices.py ....                                          [ 49%]
160s tests/calc/test_kinematics.py .......................................... [ 53%]
161s ..........................                                               [ 56%]
161s tests/calc/test_thermo.py ................................F............. [ 61%]
162s ........................................................................ [ 68%]
163s ........................................................................ [ 76%]
163s ......                                                                   [ 76%]
163s tests/calc/test_turbulence.py ...........................                [ 79%]
163s tests/interpolate/test_geometry.py ............                          [ 80%]
163s tests/interpolate/test_grid.py .......                                   [ 81%]
163s tests/interpolate/test_interpolate_tools.py ......                       [ 82%]
163s tests/interpolate/test_one_dimension.py ..................               [ 84%]
163s tests/interpolate/test_points.py ...                                     [ 84%]
164s tests/interpolate/test_slices.py .......                                 [ 85%]
164s tests/io/test_tools.py ..                                                [ 85%]
164s tests/plots/test_cartopy_utils.py .......                                [ 86%]
164s tests/plots/test_ctables.py ..........                                   [ 87%]
164s tests/plots/test_declarative.py ...........                              [ 88%]
165s tests/plots/test_mapping.py .....................                        [ 90%]
165s tests/plots/test_mpl.py .                                                [ 90%]
165s tests/plots/test_patheffects.py ........                                 [ 91%]
165s tests/plots/test_plot_areas.py .....                                     [ 91%]
166s tests/plots/test_skewt.py ....................................           [ 95%]
167s tests/plots/test_station_plot.py .........................               [ 98%]
167s tests/plots/test_util.py .............                                   [ 99%]
167s tests/plots/test_wx_symbols.py ....                                      [100%]
167s 
167s =================================== FAILURES ===================================
167s ___________________________ test_moist_lapse_failure ___________________________
167s 
167s     @pytest.mark.xfail(sys.platform == 'win32', reason='solve_ivp() does not error on Windows')
167s     @pytest.mark.xfail(packaging.version.parse(scipy.__version__) < packaging.version.parse('1.7'),
167s                        reason='solve_ivp() does not error on Scipy < 1.7')
167s     def test_moist_lapse_failure():
167s         """Test moist_lapse under conditions that cause the ODE solver to fail."""
167s         p = np.logspace(3, -1, 10) * units.hPa
167s >       with pytest.raises(ValueError) as exc:
167s E       Failed: DID NOT RAISE <class 'ValueError'>
167s 
167s tests/calc/test_thermo.py:206: Failed
167s =============================== warnings summary ===============================

[...]

167s =========================== short test summary info ============================
167s FAILED tests/calc/test_thermo.py::test_moist_lapse_failure - Failed: DID NOT ...
167s === 1 failed, 936 passed, 25 skipped, 256 deselected, 212 warnings in 20.75s ===
```
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->