### PR TITLE
define dtype for station info lat-lon

### DIFF
--- a/src/metpy/io/station_data.py
+++ b/src/metpy/io/station_data.py
@@ -191,8 +191,9 @@ def add_station_lat_lon(df, stn_var=None):
         raise KeyError('Second argument not provided to add_station_lat_lon, but none of '
                        f'{names_to_try} were found.')
 
-    df['latitude'] = None
-    df['longitude'] = None
+    df['latitude'] = np.nan
+    df['longitude'] = np.nan
+
     if stn_var is None:
         stn_var = key_finder(df)
     for stn in df[stn_var].unique():

--- a/tests/io/test_station_data.py
+++ b/tests/io/test_station_data.py
@@ -23,6 +23,7 @@ def test_add_lat_lon_station_data():
     assert_almost_equal(df.loc[df.station == 'KDEN'].longitude.values[0], -104.65)
     assert_almost_equal(df.loc[df.station == 'PAAA'].latitude.values[0], np.nan)
     assert_almost_equal(df.loc[df.station == 'PAAA'].longitude.values[0], np.nan)
+    assert df['longitude'].dtype == np.float64
 
 
 def test_add_lat_lon_station_data_optional():


### PR DESCRIPTION
#### Description Of Changes
This PR seeks to fix issue #2872 by explicitly declaring the type of the latitude and longitude columns of the Pandas DataFrame that gets returned when using the `add_station_lat_lon` function.

#### Checklist

- [x] Closes #2872
- [x] Tests added
