### PR TITLE
Remove unused setuptools config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,12 +137,5 @@ max-complexity = 61
 [tool.ruff.pydocstyle]
 convention = "numpy"
 
-[tools.setuptools]
-zip-safe = true
-platforms = ["any"]
-
-[tools.setuptools.packages.find]
-where = ["src"]
-
 [tool.setuptools_scm]
 version_scheme = "post-release"


### PR DESCRIPTION
The `tools` (as opposed to `tool`) table is not valid in `pyproject.toml`. Doesn't look like we'd gain anything from correctly specifying `zip-safe` and `platforms`.

setuptools was also [automatically discovering](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#auto-discovery) our project layout since `where` was inappropriately considered. I've removed all these; I'm glad to re-add `where` correctly if we feel the explicitness helps.
