### PR TITLE
Move codecov upload to a separate job

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,3 @@
-codecov:
-  notify:
-    after_n_builds: 9
-
 coverage:
   status:
     patch:

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -45,8 +45,10 @@ runs:
         name: ${{ inputs.key }}-images
         path: test_output/
 
-    - name: Upload coverage
-      if: ${{ always() && inputs.upload-coverage == 'true' }}
-      uses: codecov/codecov-action@v3
+    - name: Upload coverage artifact
+      if: ${{ inputs.upload-coverage == 'true' }}
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.key }}
+        path: coverage.xml
+        retention-days: 7

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -49,3 +49,20 @@ jobs:
       with:
         run-doctests: ${{ runner.os != 'Windows' }}
         key: conda-${{ matrix.python-version }}-${{ runner.os }}
+
+  codecov:
+    name: CodeCov Upload
+    needs: CondaTests
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          name: ${{ github.workflow }}

--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -75,3 +75,20 @@ jobs:
       with:
         run-doctests: ${{ matrix.dep-versions == 'requirements.txt' && matrix.no-extras != 'No Extras' }}
         key: pypi-${{ matrix.python-version }}-${{ matrix.dep-versions }}-${{ matrix.no-extras }}-${{ runner.os }}
+
+  codecov:
+    needs: PyPITests
+    name: CodeCov Upload
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          name: ${{ github.workflow }}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Switch CodeCov upload to use its own job on GitHub Actions rather than as a step after running tests. This effectively batches the upload after running the Conda/PyPI tests. This should reduce the number of calls, putting less stress on the system (the error is about API calls) and result in fewer opportunities to fail. It also makes it easier to retry just the upload with no need to re-run the tests.

Inspired by cylc/cylc-flow#5459.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

