### PR TITLE
Standardize RH calcs on WMO8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,8 @@ line-length = 95
 exclude = ["docs", "build", "src/metpy/io/_metar_parser/metar_parser.py"]
 select = ["A", "B", "C", "D", "E", "E226", "F", "G", "I", "N", "Q", "R", "S", "T", "U", "W"]
 ignore = ["F405", "I001", "RET504", "RET505", "RET506", "RET507", "RUF100"]
+preview = true
+explicit-preview-rules = true
 
 [tool.ruff.per-file-ignores]
 "ci/filter_links.py" = ["E731", "T201", "S603", "S607"]

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -3961,6 +3961,11 @@ def _dewpoint_from_specific_humidity(pressure, specific_humidity):
     `pint.Quantity`
         Dew point temperature
 
+    .. versionchanged:: 1.6
+       Made `temperature` arg optional, to be deprecated
+
+    .. versionchanged:: 1.0
+       Changed signature from ``(specific_humidity, temperature, pressure)``
     """
     w = mixing_ratio_from_specific_humidity(specific_humidity)
     e = pressure * w / (mpconsts.nounit.epsilon + w)

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -3924,6 +3924,11 @@ def dewpoint_from_specific_humidity(*args, **kwargs):
     to calculate vapor partial pressure :math:`e` for dewpoint calculation input. See
     :func:`~dewpoint` for additional information.
     """
+    if (len(args) + len(kwargs)) > 2:
+        _warnings.warn(
+            'Temperature argument is unused and will be deprecated in a future version.',
+            PendingDeprecationWarning)
+
     pressure = kwargs.pop('pressure', None)
     specific_humidity = kwargs.pop('specific_humidity', None)
 

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -3558,7 +3558,7 @@ def thickness_hydrostatic_from_relative_humidity(pressure, temperature, relative
     >>> thickness_hydrostatic_from_relative_humidity(p[ip1000_500],
     ...                                              T[ip1000_500],
     ...                                              rh[ip1000_500])
-    <Quantity(5781.35394, 'meter')>
+    <Quantity(5781.16001, 'meter')>
 
     See Also
     --------

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -63,7 +63,7 @@ def relative_humidity_from_dewpoint(temperature, dewpoint):
     """
     e = saturation_vapor_pressure(dewpoint)
     e_s = saturation_vapor_pressure(temperature)
-    return (e / e_s)
+    return e / e_s
 
 
 @exporter.export

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -3945,7 +3945,7 @@ def dewpoint_from_specific_humidity(*args, **kwargs):
 
 @preprocess_and_wrap(
     wrap_like='specific_humidity',
-    broadcast=('pressure', 'specific_humidity')
+    broadcast=('specific_humidity', 'pressure')
 )
 @check_units(pressure='[pressure]', specific_humidity='[dimensionless]')
 def _dewpoint_from_specific_humidity(pressure, specific_humidity):

--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -249,10 +249,10 @@ def _check_argument_units(args, defaults, dimensionality):
                 yield arg, val, 'none', need
 
 
-def _get_changed_version(docstring):
+def _get_changed_versions(docstring):
     """Find the most recent version in which the docs say a function changed."""
     matches = re.findall(r'.. versionchanged:: ([\d.]+)', docstring)
-    return max(matches) if matches else None
+    return matches
 
 
 def _check_units_outer_helper(func, *args, **kwargs):
@@ -302,10 +302,10 @@ def _check_units_inner_helper(func, sig, defaults, dims, *args, **kwargs):
 
         # If function has changed, mention that fact
         if func.__doc__:
-            changed_version = _get_changed_version(func.__doc__)
-            if changed_version:
+            changed_versions = _get_changed_versions(func.__doc__)
+            if changed_versions:
                 msg = (
-                    f'This function changed in {changed_version}--double check '
+                    f'This function changed in version(s) {changed_versions}--double check '
                     'that the function is being called properly.\n'
                 ) + msg
         raise ValueError(msg)

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1080,7 +1080,7 @@ def test_rh_mixing_ratio():
     temperature = 20. * units.degC
     w = 0.012 * units.dimensionless
     rh = relative_humidity_from_mixing_ratio(p, temperature, w)
-    assert_almost_equal(rh, 81.72498 * units.percent, 3)
+    assert_almost_equal(rh, 82.0709069 * units.percent, 3)
 
 
 def test_mixing_ratio_from_specific_humidity():
@@ -1117,7 +1117,7 @@ def test_rh_specific_humidity():
     temperature = 20. * units.degC
     q = 0.012 * units.dimensionless
     rh = relative_humidity_from_specific_humidity(p, temperature, q)
-    assert_almost_equal(rh, 82.71759 * units.percent, 3)
+    assert_almost_equal(rh, 83.0486264 * units.percent, 3)
 
 
 def test_cape_cin():
@@ -1618,7 +1618,7 @@ def test_thickness_hydrostatic_from_relative_humidity():
     relative_humidity = np.array([81.69, 15.43, 18.95, 23.32, 28.36, 18.55]) * units.percent
     thickness = thickness_hydrostatic_from_relative_humidity(pressure, temperature,
                                                              relative_humidity)
-    assert_almost_equal(thickness, 9891.71 * units.m, 2)
+    assert_almost_equal(thickness, 9891.56669 * units.m, 2)
 
 
 def test_mixing_ratio_dimensions():

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1804,8 +1804,9 @@ def test_dewpoint_specific_humidity():
     p = 1013.25 * units.mbar
     temperature = 20. * units.degC
     q = 0.012 * units.dimensionless
-    td = dewpoint_from_specific_humidity(p, temperature, q)
-    assert_almost_equal(td, 16.973 * units.degC, 3)
+    with pytest.deprecated_call(match='Temperature argument'):
+        td = dewpoint_from_specific_humidity(p, temperature, q)
+        assert_almost_equal(td, 17.0363429 * units.degC, 3)
 
 
 def test_dewpoint_specific_humidity_old_signature():
@@ -1822,9 +1823,10 @@ def test_dewpoint_specific_humidity_kwargs():
     p = 1013.25 * units.mbar
     temperature = 20. * units.degC
     q = 0.012 * units.dimensionless
-    td = dewpoint_from_specific_humidity(
-        pressure=p, temperature=temperature, specific_humidity=q)
-    assert_almost_equal(td, 17.036 * units.degC, 3)
+    with pytest.deprecated_call(match='Temperature argument'):
+        td = dewpoint_from_specific_humidity(
+            pressure=p, temperature=temperature, specific_humidity=q)
+        assert_almost_equal(td, 17.036 * units.degC, 3)
 
 
 def test_dewpoint_specific_humidity_mixed_args_kwargs():
@@ -1832,8 +1834,10 @@ def test_dewpoint_specific_humidity_mixed_args_kwargs():
     p = 1013.25 * units.mbar
     temperature = 20. * units.degC
     q = 0.012 * units.dimensionless
-    td = dewpoint_from_specific_humidity(p, temperature=temperature, specific_humidity=q)
-    assert_almost_equal(td, 17.036 * units.degC, 3)
+    with pytest.deprecated_call(match='Temperature argument'):
+        td = dewpoint_from_specific_humidity(
+            p, temperature=temperature, specific_humidity=q)
+        assert_almost_equal(td, 17.036 * units.degC, 3)
 
 
 def test_dewpoint_specific_humidity_two_args():

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1829,7 +1829,7 @@ def test_dewpoint_specific_humidity_kwargs():
         assert_almost_equal(td, 17.036 * units.degC, 3)
 
 
-def test_dewpoint_specific_humidity_mixed_args_kwargs():
+def test_dewpoint_specific_humidity_three_mixed_args_kwargs():
     """Test mixed arg, kwarg handling for backwards compatibility MetPy>=1.6."""
     p = 1013.25 * units.mbar
     temperature = 20. * units.degC
@@ -1838,6 +1838,15 @@ def test_dewpoint_specific_humidity_mixed_args_kwargs():
         td = dewpoint_from_specific_humidity(
             p, temperature=temperature, specific_humidity=q)
         assert_almost_equal(td, 17.036 * units.degC, 3)
+
+
+def test_dewpoint_specific_humidity_two_mixed_args_kwargs():
+    """Test function's internal arg, kwarg processing handles mixed case."""
+    p = 1013.25 * units.mbar
+    q = 0.012 * units.dimensionless
+    td = dewpoint_from_specific_humidity(
+        p, specific_humidity=q)
+    assert_almost_equal(td, 17.036 * units.degC, 3)
 
 
 def test_dewpoint_specific_humidity_two_args():

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1866,6 +1866,14 @@ def test_dewpoint_specific_humidity_arrays():
     assert_almost_equal(td, np.tile(17.036 * units.degC, (3, 2)), 3)
 
 
+def test_dewpoint_specific_humidity_xarray(index_xarray_data):
+    """Test function arg handling processes xarray inputs."""
+    p = index_xarray_data.isobaric
+    q = specific_humidity_from_dewpoint(p, index_xarray_data.dewpoint)
+    td = dewpoint_from_specific_humidity(p, specific_humidity=q)
+    assert_array_almost_equal(td, index_xarray_data.dewpoint)
+
+
 def test_lfc_not_below_lcl():
     """Test sounding where LFC appears to be (but isn't) below LCL."""
     levels = np.array([1002.5, 1001.7, 1001., 1000.3, 999.7, 999., 998.2, 977.9,

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1817,6 +1817,33 @@ def test_dewpoint_specific_humidity_old_signature():
         dewpoint_from_specific_humidity(q, temperature, p)
 
 
+def test_dewpoint_specific_humidity_kwargs():
+    """Test kw-specified signature for backwards compatibility MetPy>=1.6."""
+    p = 1013.25 * units.mbar
+    temperature = 20. * units.degC
+    q = 0.012 * units.dimensionless
+    td = dewpoint_from_specific_humidity(
+        pressure=p, temperature=temperature, specific_humidity=q)
+    assert_almost_equal(td, 17.036 * units.degC, 3)
+
+
+def test_dewpoint_specific_humidity_mixed_args_kwargs():
+    """Test mixed arg, kwarg handling for backwards compatibility MetPy>=1.6."""
+    p = 1013.25 * units.mbar
+    temperature = 20. * units.degC
+    q = 0.012 * units.dimensionless
+    td = dewpoint_from_specific_humidity(p, temperature=temperature, specific_humidity=q)
+    assert_almost_equal(td, 17.036 * units.degC, 3)
+
+
+def test_dewpoint_specific_humidity_two_args():
+    """Test new signature, Temperature unneeded, MetPy>=1.6."""
+    p = 1013.25 * units.mbar
+    q = 0.012 * units.dimensionless
+    td = dewpoint_from_specific_humidity(p, q)
+    assert_almost_equal(td, 17.036 * units.degC, 3)
+
+
 def test_lfc_not_below_lcl():
     """Test sounding where LFC appears to be (but isn't) below LCL."""
     levels = np.array([1002.5, 1001.7, 1001., 1000.3, 999.7, 999., 998.2, 977.9,

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1814,7 +1814,7 @@ def test_dewpoint_specific_humidity_old_signature():
     p = 1013.25 * units.mbar
     temperature = 20. * units.degC
     q = 0.012 * units.dimensionless
-    with pytest.raises(ValueError, match='changed in 1.0'):
+    with pytest.raises(ValueError, match='changed in version'):
         dewpoint_from_specific_humidity(q, temperature, p)
 
 
@@ -2070,6 +2070,14 @@ def test_specific_humidity_from_dewpoint():
     p = 1013.25 * units.mbar
     q = specific_humidity_from_dewpoint(p, 16.973 * units.degC)
     assert_almost_equal(q, 0.012 * units.dimensionless, 3)
+
+
+def test_specific_humidity_from_dewpoint_versionchanged():
+    """Test returning singular version changed suggestion in ValueError."""
+    pressure = 1013.25 * units.mbar
+    dewpoint = 16.973 * units.degC
+    with pytest.raises(ValueError, match='changed in version'):
+        specific_humidity_from_dewpoint(dewpoint, pressure)
 
 
 def test_lcl_convergence_issue():

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1814,8 +1814,9 @@ def test_dewpoint_specific_humidity_old_signature():
     p = 1013.25 * units.mbar
     temperature = 20. * units.degC
     q = 0.012 * units.dimensionless
-    with pytest.raises(ValueError, match='changed in version'):
-        dewpoint_from_specific_humidity(q, temperature, p)
+    with pytest.deprecated_call(match='Temperature argument'):
+        with pytest.raises(ValueError, match='changed in version'):
+            dewpoint_from_specific_humidity(q, temperature, p)
 
 
 def test_dewpoint_specific_humidity_kwargs():
@@ -1836,7 +1837,7 @@ def test_dewpoint_specific_humidity_three_mixed_args_kwargs():
     q = 0.012 * units.dimensionless
     with pytest.deprecated_call(match='Temperature argument'):
         td = dewpoint_from_specific_humidity(
-            p, temperature=temperature, specific_humidity=q)
+            p, temperature, specific_humidity=q)
         assert_almost_equal(td, 17.036 * units.degC, 3)
 
 
@@ -1855,6 +1856,14 @@ def test_dewpoint_specific_humidity_two_args():
     q = 0.012 * units.dimensionless
     td = dewpoint_from_specific_humidity(p, q)
     assert_almost_equal(td, 17.036 * units.degC, 3)
+
+
+def test_dewpoint_specific_humidity_arrays():
+    """Test function arg handling can process arrays."""
+    p = 1013.25 * units.mbar
+    q = np.tile(0.012 * units.dimensionless, (3, 2))
+    td = dewpoint_from_specific_humidity(p, specific_humidity=q)
+    assert_almost_equal(td, np.tile(17.036 * units.degC, (3, 2)), 3)
 
 
 def test_lfc_not_below_lcl():


### PR DESCRIPTION
Standardize RH calculations on [WMO8](https://library.wmo.int/viewer/41650/download?file=8_I_2021_en.pdf&type=pdf&navigator=1) definition of relative humidity as

$$ RH = \frac{e}{e_s} $$

(eq 4.A.15)

such that any RH calculation with input of mixing ratio is made consistent with above as

$$ RH = \frac{w}{w_s} \frac{\epsilon + w_s}{\epsilon + w} $$

(eq 4.A.16)

As part of this process, we can also simplify `dewpoint_from_specific_humidity` to not require a temperature input. I've tried to do this in a way that allows arg and/or kwarg specification in a backwards compatible way. @dopplershift let me know your thoughts on the verbage here and how to best document this change and alert to an eventual deprecation. This does break our "check for versionchanged 1.0 and provide helpful error" handling in `_check_units_inner_helper`. ~I'm glad to change/remove that test or look into changing that handling.~ Handling slightly generalized and now issue a relatively quiet `PendingDeprecationWarning`.

~I've yet to update the test values so folks can see how much changed.~ **A few existing tests pass within tolerance but do have slightly changed values.**

#### Checklist

- [X] Closes #2951 
- [X] Tests added
- [x] Tests updated
- [X] Fully documented
