### PR TITLE
return heat_index with temperature units

### DIFF
--- a/src/metpy/calc/basic.py
+++ b/src/metpy/calc/basic.py
@@ -332,16 +332,13 @@ def heat_index(temperature, relative_humidity, mask_undefined=True):
                    * (units.Quantity(87., 'delta_degF') - delta[sel]))
         hi[sel] = hi[sel] + rh85adj
 
-    # Convert heat index to temperature units
-    hi = hi.to(temperature.units)
-
     # See if we need to mask any undefined values
     if mask_undefined:
         mask = np.array(temperature < units.Quantity(80., 'degF'))
         if mask.any():
             hi = masked_array(hi, mask=mask)
 
-    return hi
+    return hi.to(temperature.units)
 
 
 @exporter.export

--- a/src/metpy/calc/basic.py
+++ b/src/metpy/calc/basic.py
@@ -251,7 +251,7 @@ def heat_index(temperature, relative_humidity, mask_undefined=True):
     >>> from metpy.calc import heat_index
     >>> from metpy.units import units
     >>> heat_index(30 * units.degC, 90 * units.percent)
-    <Quantity([105.3943646], 'degree_Fahrenheit')>
+    <Quantity([40.774647], 'degree_Celsius')>
     >>> heat_index(90 * units.degF, 90 * units.percent)
     <Quantity([121.901204], 'degree_Fahrenheit')>
     >>> heat_index(60 * units.degF, 90 * units.percent)
@@ -331,6 +331,9 @@ def heat_index(temperature, relative_humidity, mask_undefined=True):
         rh85adj = (0.02 * (relative_humidity[sel] * 100. - 85.)
                    * (units.Quantity(87., 'delta_degF') - delta[sel]))
         hi[sel] = hi[sel] + rh85adj
+
+    # Convert heat index to temperature units
+    hi = hi.to(temperature.units)
 
     # See if we need to mask any undefined values
     if mask_undefined:

--- a/tests/calc/test_basic.py
+++ b/tests/calc/test_basic.py
@@ -246,11 +246,12 @@ def test_heat_index_undefined_flag():
 
 
 def test_heat_index_units():
-    """Test units coming out of heat index."""
+    """Test units coming out of heat index are unchanged."""
     temp = units.Quantity([35., 20.], units.degC)
     rh = 70 * units.percent
     hi = heat_index(temp, rh)
-    assert_almost_equal(hi.to('degC'), units.Quantity([50.3405, np.nan], units.degC), 4)
+    assert hi.units == temp.units
+    assert_almost_equal(hi, units.Quantity([50.3405, np.nan], units.degC), 4)
 
 
 def test_heat_index_ratio():
@@ -258,7 +259,7 @@ def test_heat_index_ratio():
     temp = units.Quantity([35., 20.], units.degC)
     rh = 0.7
     hi = heat_index(temp, rh)
-    assert_almost_equal(hi.to('degC'), units.Quantity([50.3405, np.nan], units.degC), 4)
+    assert_almost_equal(hi, units.Quantity([50.3405, np.nan], units.degC), 4)
 
 
 def test_heat_index_vs_nws():
@@ -278,7 +279,7 @@ def test_heat_index_kelvin():
     rh = 0.7
     hi = heat_index(temp, rh)
     # NB rounded up test value here vs the above two tests
-    assert_almost_equal(hi.to('degC'), 50.3406 * units.degC, 4)
+    assert_almost_equal(hi, 50.3406 * units.degC, 4)
 
 
 def test_height_to_geopotential(array_type):


### PR DESCRIPTION
#### Description Of Changes

This pull request updates the heat_index calculation to return the same units as the temperature used in the calculation. This change ensures parity across similar equations like wind_chill and apparent_temperature where the return value has the same units as the input temperature.

#### Checklist

- [X] Closes #3299
- [X] Tests added
- [X] Fully documented
