### PR TITLE
Improve isentropic interpolation

### DIFF
--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -2624,7 +2624,7 @@ def isentropic_interpolation(levels, pressure, temperature, *args, vertical_dim=
         One-dimensional array of desired potential temperature surfaces
 
     pressure : array-like
-        One-dimensional array of pressure levels
+        Array of pressure
 
     temperature : array-like
         Array of temperature
@@ -2691,10 +2691,17 @@ def isentropic_interpolation(levels, pressure, temperature, *args, vertical_dim=
     pressure = pressure.to('hPa')
     temperature = temperature.to('kelvin')
 
+    # Construct slices for broadcasting with temperature (used for pressure & theta levels)
     slices = [np.newaxis] * temperature.ndim
     slices[vertical_dim] = slice(None)
     slices = tuple(slices)
-    pressure = units.Quantity(np.broadcast_to(pressure[slices].magnitude, temperature.shape),
+
+    # For 1-D pressure, we assume it's the vertical coordinate and know how it should broadcast
+    # to the same shape as temperature. Otherwise, just assume it's ready for broadcast, or
+    # it has the same shape and is a no-op.
+    if pressure.ndim == 1:
+        pressure = pressure[slices]
+    pressure = units.Quantity(np.broadcast_to(pressure.magnitude, temperature.shape),
                               pressure.units)
 
     # Sort input data

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1293,9 +1293,12 @@ def test_isentropic_pressure_p_increase_rh_out():
     assert_almost_equal(isentprs[1], truerh, 3)
 
 
-def test_isentropic_pressure_interp():
+@pytest.mark.parametrize('press_3d', [False, True])
+def test_isentropic_pressure_interp(press_3d):
     """Test calculation of isentropic pressure function."""
     lev = [100000., 95000., 90000., 85000.] * units.Pa
+    if press_3d:
+        lev = np.lib.stride_tricks.broadcast_to(lev[:, None, None], (4, 5, 5))
     tmp = np.ones((4, 5, 5))
     tmp[0, :] = 296.
     tmp[1, :] = 292.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This addresses some limitations in `isentropic_interpolation` and `isentropic_interpolation_as_dataset` identified in #3315, which is trying to use the functionality on WRF output natively on a sigma vertical coordinate.

* Don't blindly assume that the vertical coordinate is pressure in `isentropic_interpolation_as_dataset` but check the dimensionality and issue a more useful `ValueError`
* Tweak the handling of pressure in `isentropic_interpolation` to work with a *passed-in* 3D pressure field, since internally we were already using a 3D pressure field
* Allow `isentropic_interpolation_as_dataset` to work with data on non-pressure coordinates by accepting a `pressure` kw-only argument in this case, which overrides using the vertical coordinate.
* 
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #3315
- [x] Tests added
- [x] Fully documented
