### PR TITLE
Provide alternate recipe to build docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,7 @@ Then, still from within your ``devel`` environment,
 
 * Navigate to the docs folder ``cd docs``
 * Remove any old builds and build the current docs ``make clean html``
+  * (Try ``make cleanall html`` if ``make clean html`` fails)
 * Open ``docs/build/html/index.html`` and see your changes!
 
 ### `doc-server.py`


### PR DESCRIPTION
#### Description Of Changes

As indicated in #3321, sometimes `make clean html` fails.  In those instances, `make cleanall html` may work, so this commit provides that additional information in the Contributor's Guide.

#### Checklist

- [x] Closes #3321
- [x] Fully documented
