### PR TITLE
Avoid pandas warning

### DIFF
--- a/tests/calc/test_basic.py
+++ b/tests/calc/test_basic.py
@@ -709,14 +709,14 @@ def test_smooth_window_1d_dataarray():
     temperature = xr.DataArray(
         [37., 32., 34., 29., 28., 24., 26., 24., 27., 30.],
         dims=('time',),
-        coords={'time': pd.date_range('2020-01-01', periods=10, freq='H')},
+        coords={'time': pd.date_range('2020-01-01', periods=10, freq='h')},
         attrs={'units': 'degF'})
     smoothed = smooth_window(temperature, window=np.ones(3) / 3, normalize_weights=False)
     truth = xr.DataArray(
         [37., 34.33333333, 31.66666667, 30.33333333, 27., 26., 24.66666667,
          25.66666667, 27., 30.] * units.degF,
         dims=('time',),
-        coords={'time': pd.date_range('2020-01-01', periods=10, freq='H')}
+        coords={'time': pd.date_range('2020-01-01', periods=10, freq='h')}
     )
     xr.testing.assert_allclose(smoothed, truth)
 


### PR DESCRIPTION
Apparently with Pandas 2.2.0 (tested with the just released rc0) freq='H' is deprecated, in favor of freq='h'. Since this works across our versions, go ahead and change.

Otherwise we see:

```
=================================== FAILURES ===================================
_______________________ test_smooth_window_1d_dataarray ________________________

    def test_smooth_window_1d_dataarray():
        """Test smooth_window on 1D DataArray."""
        temperature = xr.DataArray(
            [37., 32., 34., 29., 28., 24., 26., 24., 27., 30.],
            dims=('time',),
>           coords={'time': pd.date_range('2020-01-01', periods=10, freq='H')},
            attrs={'units': 'degF'})

tests/calc/test_basic.py:712: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.12.1/x64/lib/python3.12/site-packages/pandas/core/indexes/datetimes.py:1008: in date_range
    dtarr = DatetimeArray._generate_range(
/opt/hostedtoolcache/Python/3.12.1/x64/lib/python3.12/site-packages/pandas/core/arrays/datetimes.py:424: in _generate_range
    freq = to_offset(freq)
offsets.pyx:4730: in pandas._libs.tslibs.offsets.to_offset
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   FutureWarning: 'H' is deprecated and will be removed in a future version, please use 'h' instead.

offsets.pyx:4842: FutureWarning
=========================== short test summary info ============================
FAILED tests/calc/test_basic.py::test_smooth_window_1d_dataarray - FutureWarning: 'H' is deprecated and will be removed in a future version, please use 'h' instead.
============ 1 failed, 1510 passed, 1 xfailed in 467.89s (0:07:47) =============
```
(see current nightly failure in #3268)

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #3268
