### PR TITLE
ENH: Add dBZ as a unit in the registry

### DIFF
--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -82,7 +82,7 @@ def setup_registry(reg):
                '= degreeN')
     reg.define('degrees_east = degree = degrees_E = degreesE = degree_east = degree_E '
                '= degreeE')
-    reg.define('dBZ = 1 ; logbase: 10; logfactor: 10')
+    reg.define('dBz = 1e-18 m^3; logbase: 10; logfactor: 10 = dBZ')
 
     # Alias geopotential meters (gpm) to just meters
     reg.define('@alias meter = gpm')

--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -82,6 +82,7 @@ def setup_registry(reg):
                '= degreeN')
     reg.define('degrees_east = degree = degrees_E = degreesE = degree_east = degree_E '
                '= degreeE')
+    reg.define('dBZ = 1 ; logbase: 10; logfactor: 10')
 
     # Alias geopotential meters (gpm) to just meters
     reg.define('@alias meter = gpm')

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal,
-assert_nan)
+                           assert_nan)
 from metpy.units import (check_units, concatenate, is_quantity,
                          pandas_dataframe_to_unit_arrays, units)
 

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -8,9 +8,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from metpy.testing import (assert_array_almost_equal, assert_array_equal,
-                           assert_nan, assert_almost_equal)
-
+from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal,
+assert_nan)
 from metpy.units import (check_units, concatenate, is_quantity,
                          pandas_dataframe_to_unit_arrays, units)
 

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -176,7 +176,7 @@ def test_added_degrees_units():
     assert units('degrees_north').to_base_units().units == units.radian
     assert units('degrees_east') == units('degrees')
     assert units('degrees_east').to_base_units().units == units.radian
-    assert units("dBZ") == units("dB")
+    assert units('dBZ') == units('dB')
 
 
 def test_is_quantity():

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -176,7 +176,7 @@ def test_added_degrees_units():
     assert units('degrees_north').to_base_units().units == units.radian
     assert units('degrees_east') == units('degrees')
     assert units('degrees_east').to_base_units().units == units.radian
-    assert units('dBZ') == units('dB')
+    assert_almost_equal(0 * units.dBz, 1 * units('mm^6/m^3'))
 
 
 def test_is_quantity():

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -176,6 +176,7 @@ def test_added_degrees_units():
     assert units('degrees_north').to_base_units().units == units.radian
     assert units('degrees_east') == units('degrees')
     assert units('degrees_east').to_base_units().units == units.radian
+    assert units("dBZ") == units("dB")
 
 
 def test_is_quantity():

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -8,7 +8,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from metpy.testing import assert_array_almost_equal, assert_array_equal, assert_nan
+from metpy.testing import (assert_array_almost_equal, assert_array_equal,
+                           assert_nan, assert_almost_equal)
+
 from metpy.units import (check_units, concatenate, is_quantity,
                          pandas_dataframe_to_unit_arrays, units)
 


### PR DESCRIPTION
#### Description Of Changes
Fixes #3341 

Adds "dBZ" as a unit within the unit registry, with this being equivalent to dB, while still being its own separate unit.

#### Checklist

- [x] Closes #3341 
- [x] Tests added
- [x] Fully documented
