### PR TITLE
Fix interpolate_to_slice unit handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ docs/api/generated
 docs/api/areas.rst
 examples/scripts
 test_output/
+docs/sg_execution_times.rst

--- a/src/metpy/interpolate/slices.py
+++ b/src/metpy/interpolate/slices.py
@@ -7,6 +7,7 @@ import numpy as np
 import xarray as xr
 
 from ..package_tools import Exporter
+from ..units import is_quantity
 from ..xarray import check_axis
 
 exporter = Exporter(globals())
@@ -49,6 +50,7 @@ def interpolate_to_slice(data, points, interp_type='linear'):
                          'your data has been parsed by MetPy with proper x and y '
                          'dimension coordinates.') from None
 
+    need_quantify = is_quantity(data.data)
     data = data.metpy.dequantify()
     data_sliced = data.interp({
         x.name: xr.DataArray(points[:, 0], dims='index', attrs=x.attrs),
@@ -56,7 +58,7 @@ def interpolate_to_slice(data, points, interp_type='linear'):
     }, method=interp_type)
     data_sliced.coords['index'] = range(len(points))
 
-    return data_sliced.metpy.quantify()
+    return data_sliced.metpy.quantify() if need_quantify else data_sliced
 
 
 @exporter.export

--- a/tests/interpolate/test_slices.py
+++ b/tests/interpolate/test_slices.py
@@ -95,16 +95,24 @@ def test_ds_xy():
     return ds.metpy.parse_cf()
 
 
-def test_interpolate_to_slice_against_selection(test_ds_lonlat):
+@pytest.mark.parametrize('bad_units', [False, True])
+def test_interpolate_to_slice_against_selection(test_ds_lonlat, bad_units):
     """Test interpolate_to_slice on a simple operation."""
     data = test_ds_lonlat['temperature']
+
+    # interpolate_to_slice shouldn't care about units
+    if bad_units:
+        # Needed so we can go back to using attribute metadata
+        data = data.metpy.dequantify()
+        data.attrs['units'] = 'my_bad_units'
+
     path = np.array([[265.0, 30.],
                      [265.0, 36.],
                      [265.0, 42.]])
     test_slice = interpolate_to_slice(data, path)
     true_slice = data.sel({'lat': [30., 36., 42.], 'lon': 265.0})
     # Coordinates differ, so just compare the data
-    assert_array_almost_equal(true_slice.metpy.unit_array, test_slice.metpy.unit_array, 5)
+    assert_array_almost_equal(true_slice.data, test_slice.data, 5)
 
 
 @needs_cartopy


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
The fixup in #3255 inadvertently added unit parsing to all code paths in `interpolate_to_slice`. This breaks any usages that passed in data with unknown units, such as dBZ with pyart. Since `interpolate_to_slice` has no need to do any unit handling, avoid this unless we're actually given a quantity.

Also update `.gitignore` for a new file being spit out by sphinx-gallery (or at least new outside the existing ignored directories).

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #3341
- [x] Tests added
