### PR TITLE
perf: use package metadata before scm

### DIFF
--- a/src/metpy/_version.py
+++ b/src/metpy/_version.py
@@ -2,21 +2,30 @@
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 """Tools for versioning."""
+import os
+from importlib.metadata import PackageNotFoundError, version
 
 
 def get_version():
     """Get MetPy's version.
 
-    Either get it from package metadata, or get it using version control information if
-    a development install.
+    If the package is installed (read: metpy is in site-packages), use package
+    metadata. If not, use what is provided by setuptools_scm and default to
+    package data if that also fails.
     """
+    # Inspect where this file's parent directory is located
+    moddirname = os.path.dirname(os.path.dirname(__file__))
+    # If we're in site-packages, try using package metadata
+    if moddirname.endswith('site-packages'):
+        try:
+            return version(__package__)
+        except PackageNotFoundError:
+            pass
     try:
         from setuptools_scm import get_version
         return get_version(root='../..', relative_to=__file__,
                            version_scheme='post-release')
     except (ImportError, LookupError):
-        from importlib.metadata import PackageNotFoundError, version
-
         try:
             return version(__package__)
         except PackageNotFoundError:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2024 MetPy Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Test package version."""
+import importlib
+from importlib.metadata import PackageNotFoundError
+from unittest.mock import patch
+
+import metpy
+
+def test_version():
+    """Test that MetPy version is not None."""
+    assert metpy.__version__ is not None
+
+
+def test_version_installed_with_importlib_metadata_failure():
+    """Test that version works when importlib_metadata is not available."""
+    with patch('importlib.metadata.version', side_effect=PackageNotFoundError):
+        importlib.reload(metpy)
+        assert metpy.__version__ != 'Unknown'
+
+
+def test_version_notinstalled():
+    """Test that version works when not installed."""
+    with patch('os.path.dirname', return_value='/bogus/bogus/bogus'):
+        importlib.reload(metpy)
+        assert metpy.__version__ != 'Unknown'


### PR DESCRIPTION
#### Description Of Changes

This PR attempts to only import `setuptools_scm` when MetPy is being used from a not-installed location.  I don't seem clever enough to figure out proper mocks/patches to have this fully tested.  ie, mocking `os.path.dirname` is tricky.  I dunno, as my issue stated, burn this with fire if you wish.  No hard feelings.

#### Checklist

- [x] Closes #3362
- [ ] Tests added
- [x] Fully documented
