### PR TITLE
Increase minimum setuptools version to v61

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
#### Description Of Changes

MetPy stores project metadata in pyproject.toml following [PEP 621](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html).  It uses `setuptools` as the build backend.  Setuptools added support for PEP 621 in v61.0.0: https://setuptools.pypa.io/en/stable/history.html#v61-0-0

However, `pyproject.toml` only mandates `setuptools>=42`.  In practice I doubt it is really a problem, as the most recent version of setuptools is usually pulled in automatically when building metpy, although it is possible to contrive a problematic scenario by installing an older version of setuptools (`setuptools==60`, e.g.) and using `pip install`'s `--no-build-isolation` option.  

Anyway, it is trivial to fix the issue, so there is little reason not to IMHO.

#### Checklist

- ~[ ] Closes #xxxx~
- ~[ ] Tests added~
- ~[ ] Fully documented~
