### PR TITLE
Fix checking dimensionless units in tests

### DIFF
--- a/tests/calc/test_basic.py
+++ b/tests/calc/test_basic.py
@@ -104,7 +104,7 @@ def test_direction_with_north_and_calm(array_type):
 def test_direction_dimensions():
     """Verify wind_direction returns degrees."""
     d = wind_direction(3. * units('m/s'), 4. * units('m/s'))
-    assert str(d.units) == 'degree'
+    assert d.units == units('degree')
 
 
 def test_oceanographic_direction(array_type):

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1747,14 +1747,14 @@ def test_mixing_ratio_dimensions():
     """Verify mixing ratio returns a dimensionless number."""
     p = 998. * units.mbar
     e = 73.75 * units.hPa
-    assert str(mixing_ratio(e, p).units) == 'dimensionless'
+    assert mixing_ratio(e, p).units == units('dimensionless')
 
 
 def test_saturation_mixing_ratio_dimensions():
     """Verify saturation mixing ratio returns a dimensionless number."""
     p = 998. * units.mbar
     temp = 20 * units.celsius
-    assert str(saturation_mixing_ratio(p, temp).units) == 'dimensionless'
+    assert saturation_mixing_ratio(p, temp).units == units('dimensionless')
 
 
 def test_mixing_ratio_from_rh_dimensions():
@@ -1762,8 +1762,8 @@ def test_mixing_ratio_from_rh_dimensions():
     p = 1000. * units.mbar
     temperature = 0. * units.degC
     rh = 100. * units.percent
-    assert (str(mixing_ratio_from_relative_humidity(p, temperature, rh).units)
-            == 'dimensionless')
+    assert (mixing_ratio_from_relative_humidity(p, temperature, rh).units
+            == units('dimensionless'))
 
 
 @pytest.fixture

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -195,7 +195,7 @@ def test_is_quantity_multiple():
 def test_gpm_unit():
     """Test that the gpm unit does alias to meters."""
     x = 1 * units('gpm')
-    assert str(x.units) == 'meter'
+    assert x.units == units('meter')
 
 
 def test_assert_nan():
@@ -212,7 +212,7 @@ def test_assert_nan_checks_units():
 
 def test_percent_units():
     """Test that percent sign units are properly parsed and interpreted."""
-    assert str(units('%').units) == 'percent'
+    assert units('%').units == units('percent')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Broken currently on Pint git (See #3368). Don't rely on the string representation of dimensionless quantities, but rely on proper object equality. This is better regardless of whether it represents a long-term change for Pint, since `units('dimensionless') == units('')`.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #3368 
- [x] Tests updated
