### PR TITLE
Fix version for docs on maintenance branch

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -28,6 +28,8 @@ runs:
     - name: Build docs
       shell: bash -l {0}
       id: builddocs
+      env:
+        DOC_VERSION: ${{ steps.docversion.outputs.doc_version }}
       # set -e makes sure bash fails on the first failing command, which isn't the case due to
       # starting with -l
       run: |

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -206,6 +206,10 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'pydata_sphinx_theme'
+
+# Use the version set in CI as necessary, which allows building "release" docs on a
+# maintenance branch--strip leading 'v' since our json file doesn't have the v on the 'version'
+doc_version = os.environ.get('DOC_VERSION', 'dev' if 'dev' in version else version).lstrip('v')
 html_theme_options = {
     'external_links': [
         {'name': 'Release Notes', 'url': 'https://github.com/Unidata/MetPy/releases'},
@@ -240,7 +244,7 @@ html_theme_options = {
     'navbar_end': ['navbar-icon-links', 'theme-switcher'],
     'switcher': {
         'json_url': 'https://unidata.github.io/MetPy/pst-versions.json',
-        'version_match': 'dev' if 'dev' in version else f'v{version}',
+        'version_match': doc_version
     },
     'navigation_with_keys': False
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
1. Make use of the `DOC_VERSION` variable we already set in CI, and use this to override what `conf.py` finds from version. CI can determine, based on being on not-a-PR and not-on-main that it's not a dev build.
2. The version switcher should not have a leading "v" on the match, because we put the "v" only on the name (not matched), not the version.
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
