### PR TITLE
Numpy 2 compatibility

### DIFF
--- a/src/metpy/calc/indices.py
+++ b/src/metpy/calc/indices.py
@@ -4,6 +4,12 @@
 """Contains calculation of various derived indices."""
 import numpy as np
 
+# Can drop fallback once we rely on numpy>=2
+try:
+    from numpy import trapezoid
+except ImportError:
+    from numpy import trapz as trapezoid
+
 from .basic import wind_speed
 from .thermo import mixing_ratio, saturation_vapor_pressure
 from .tools import _remove_nans, get_layer
@@ -90,7 +96,7 @@ def precipitable_water(pressure, dewpoint, *, bottom=None, top=None):
     w = mixing_ratio(saturation_vapor_pressure(dewpoint_layer), pres_layer)
 
     # Since pressure is in decreasing order, pw will be the opposite sign of that expected.
-    pw = -np.trapz(w, pres_layer) / (mpconsts.g * mpconsts.rho_l)
+    pw = -trapezoid(w, pres_layer) / (mpconsts.g * mpconsts.rho_l)
     return pw.to('millimeters')
 
 
@@ -168,7 +174,7 @@ def mean_pressure_weighted(pressure, *args, height=None, bottom=None, depth=None
     pres_int = 0.5 * (pres_prof[-1] ** 2 - pres_prof[0] ** 2)
 
     # Perform integration on the profile for each variable
-    return [np.trapz(var_prof * pres_prof, x=pres_prof) / pres_int for var_prof in others]
+    return [trapezoid(var_prof * pres_prof, x=pres_prof) / pres_int for var_prof in others]
 
 
 @exporter.export
@@ -228,7 +234,7 @@ def weighted_continuous_average(pressure, *args, height=None, bottom=None, depth
         pressure, *args, height=height, bottom=bottom, depth=depth
     )
 
-    return [np.trapz(var_prof, x=pres_prof) / (pres_prof[-1] - pres_prof[0])
+    return [trapezoid(var_prof, x=pres_prof) / (pres_prof[-1] - pres_prof[0])
             for var_prof in others]
 
 

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -5,6 +5,13 @@
 from inspect import Parameter, Signature, signature
 
 import numpy as np
+
+# Can drop fallback once we rely on numpy>=2
+try:
+    from numpy import trapezoid
+except ImportError:
+    from numpy import trapz as trapezoid
+
 import scipy.integrate as si
 import scipy.optimize as so
 import xarray as xr
@@ -2455,7 +2462,7 @@ def cape_cin(pressure, temperature, dewpoint, parcel_profile, which_lfc='bottom'
     x_clipped = x[p_mask].magnitude
     y_clipped = y[p_mask].magnitude
     cape = (mpconsts.Rd
-            * units.Quantity(np.trapz(y_clipped, np.log(x_clipped)), 'K')).to(units('J/kg'))
+            * units.Quantity(trapezoid(y_clipped, np.log(x_clipped)), 'K')).to(units('J/kg'))
 
     # CIN
     # Only use data between the surface and LFC for calculation
@@ -2463,7 +2470,7 @@ def cape_cin(pressure, temperature, dewpoint, parcel_profile, which_lfc='bottom'
     x_clipped = x[p_mask].magnitude
     y_clipped = y[p_mask].magnitude
     cin = (mpconsts.Rd
-           * units.Quantity(np.trapz(y_clipped, np.log(x_clipped)), 'K')).to(units('J/kg'))
+           * units.Quantity(trapezoid(y_clipped, np.log(x_clipped)), 'K')).to(units('J/kg'))
 
     # Set CIN to 0 if it's returned as a positive value (#1190)
     if cin > units.Quantity(0, 'J/kg'):
@@ -3240,7 +3247,7 @@ def downdraft_cape(pressure, temperature, dewpoint):
 
     # Find DCAPE
     dcape = -(mpconsts.Rd
-              * units.Quantity(np.trapz(diff, lnp), 'K')
+              * units.Quantity(trapezoid(diff, lnp), 'K')
               ).to(units('J/kg'))
 
     return dcape, down_pressure, down_parcel_trace
@@ -3439,7 +3446,7 @@ def mixed_layer(pressure, *args, height=None, bottom=None, depth=None, interpola
     ret = []
     for datavar_layer in datavars_layer:
         actual_depth = abs(p_layer[0] - p_layer[-1])
-        ret.append(units.Quantity(np.trapz(datavar_layer.m, p_layer.m) / -actual_depth.m,
+        ret.append(units.Quantity(trapezoid(datavar_layer.m, p_layer.m) / -actual_depth.m,
                    datavar_layer.units))
     return ret
 
@@ -3691,7 +3698,7 @@ def thickness_hydrostatic(pressure, temperature, mixing_ratio=None,
     # Take the integral
     return (
         -mpconsts.nounit.Rd / mpconsts.nounit.g
-        * np.trapz(layer_virttemp, np.log(layer_p))
+        * trapezoid(layer_virttemp, np.log(layer_p))
     )
 
 

--- a/src/metpy/calc/tools.py
+++ b/src/metpy/calc/tools.py
@@ -8,7 +8,13 @@ from inspect import Parameter, signature
 from operator import itemgetter
 
 import numpy as np
-from numpy.core.numeric import normalize_axis_index
+
+# Can drop fallback once we rely on numpy>=2
+try:
+    from numpy.lib.array_utils import normalize_axis_index
+except ImportError:
+    from numpy.core.numeric import normalize_axis_index
+
 import numpy.ma as ma
 from pyproj import CRS, Geod, Proj
 from scipy.spatial import cKDTree

--- a/src/metpy/testing.py
+++ b/src/metpy/testing.py
@@ -84,7 +84,7 @@ def _parse_version_spec(version_spec):
         tuple of str : Parsed specification groups of package name, comparison, and version
 
     """
-    pattern = re.compile(r'(\w+)\s*([<>!=]+)\s*([\d.]+)')
+    pattern = re.compile(r'(\w+)\s*([<>!=]+)\s*([\d\w.]+)')
     match = pattern.match(version_spec)
 
     if not match:

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -1299,7 +1299,7 @@ def test_isentropic_pressure_interp(press_3d):
     """Test calculation of isentropic pressure function."""
     lev = [100000., 95000., 90000., 85000.] * units.Pa
     if press_3d:
-        lev = np.lib.stride_tricks.broadcast_to(lev[:, None, None], (4, 5, 5))
+        lev = np.broadcast_to(lev[:, None, None], (4, 5, 5))
     tmp = np.ones((4, 5, 5))
     tmp[0, :] = 296.
     tmp[1, :] = 292.

--- a/tests/plots/test_declarative.py
+++ b/tests/plots/test_declarative.py
@@ -2115,7 +2115,7 @@ def test_declarative_plot_geometry_lines(ccrs):
     geo.stroke = 'green'
     geo.labels = ['Irma', '+/- 0.25 deg latitude']
     geo.label_facecolor = None
-    geo.mpl_args = {'linewidth': 1}
+    geo.mpl_args = {'linewidths': 1}
 
     # Place plot in a panel and container
     panel = MapPanel()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Various changes to get things to work without warnings/errors on numpy 2 since I was able to put together a local pip-based numpy 2 environment. Mostly avoiding a `DeprecationWarning` for using `trapz` instead of `trapezoid`, otherwise a bunch of silly stuff. This includes an error caught by Matplotlib 3.9.0rc2, which I'm not at all clear why didn't flag on the nightly build (though it had other image-based failures). 

This PR (plus hgrecco/pint#1971) leaves us with 4 failing tests. 2 seemingly due to some xarray+cartopy challenges:
<details><pre>
___________________________________________________________________________________________________________ test_declarative_events ___________________________________________________________________________________________________________

args = (), kwargs = {}

    def wrapper(*args, **kwargs):
>       store.return_value[test_name] = obj(*args, **kwargs)

../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/pytest_mpl/plugin.py:125: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/metpy/testing.py:122: in wrapped
    return test_func(*args, **kwargs)
tests/plots/test_declarative.py:495: in test_declarative_events
    pc.draw()
src/metpy/plots/declarative.py:187: in draw
    panel.draw()
src/metpy/plots/declarative.py:511: in draw
    p.draw()
src/metpy/plots/declarative.py:891: in draw
    self._build()
src/metpy/plots/declarative.py:1020: in _build
    self.handle = self.parent.ax.imshow(imdata, **kwargs)
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/cartopy/mpl/geoaxes.py:307: in wrapper
    return func(self, *args, **kwargs)
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/cartopy/mpl/geoaxes.py:1314: in imshow
    img, extent = warp_array(img,
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/cartopy/img_transform.py:182: in warp_array
    source_native_xy = mesh_projection(source_proj, nx, ny,
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/cartopy/img_transform.py:77: in mesh_projection
    x, xstep = np.linspace(x_lower, x_upper, nx, retstep=True,
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/numpy/_core/function_base.py:189: in linspace
    y = conv.wrap(y.astype(dtype, copy=False))
../xarray/xarray/core/dataarray.py:4674: in __array_wrap__
    new_var = self.variable.__array_wrap__(obj, context)
../xarray/xarray/core/variable.py:2290: in __array_wrap__
    return Variable(self.dims, obj)
../xarray/xarray/core/variable.py:397: in __init__
    super().__init__(
../xarray/xarray/namedarray/core.py:264: in __init__
    self._dims = self._parse_dimensions(dims)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <[AttributeError("'Variable' object has no attribute '_dims'") raised in repr()] Variable object at 0x16c0ea740>, dims = ()

    def _parse_dimensions(self, dims: _DimsLike) -> _Dims:
        dims = (dims,) if isinstance(dims, str) else tuple(dims)
        if len(dims) != self.ndim:
>           raise ValueError(
                f"dimensions {dims} must have the same length as the "
                f"number of data dimensions, ndim={self.ndim}"
            )
E           ValueError: dimensions () must have the same length as the number of data dimensions, ndim=1

../xarray/xarray/namedarray/core.py:490: ValueError
_________________________________________________________________________________________________________________ test_latlon _________________________________________________________________________________________________________________

args = (), kwargs = {}

    def wrapper(*args, **kwargs):
>       store.return_value[test_name] = obj(*args, **kwargs)

../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/pytest_mpl/plugin.py:125: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/metpy/testing.py:122: in wrapped
    return test_func(*args, **kwargs)
tests/plots/test_declarative.py:838: in test_latlon
    pc.draw()
src/metpy/plots/declarative.py:187: in draw
    panel.draw()
src/metpy/plots/declarative.py:511: in draw
    p.draw()
src/metpy/plots/declarative.py:891: in draw
    self._build()
src/metpy/plots/declarative.py:1020: in _build
    self.handle = self.parent.ax.imshow(imdata, **kwargs)
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/cartopy/mpl/geoaxes.py:307: in wrapper
    return func(self, *args, **kwargs)
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/cartopy/mpl/geoaxes.py:1314: in imshow
    img, extent = warp_array(img,
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/cartopy/img_transform.py:182: in warp_array
    source_native_xy = mesh_projection(source_proj, nx, ny,
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/cartopy/img_transform.py:79: in mesh_projection
    y, ystep = np.linspace(y_lower, y_upper, ny, retstep=True,
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/numpy/_core/function_base.py:189: in linspace
    y = conv.wrap(y.astype(dtype, copy=False))
../xarray/xarray/core/dataarray.py:4674: in __array_wrap__
    new_var = self.variable.__array_wrap__(obj, context)
../xarray/xarray/core/variable.py:2290: in __array_wrap__
    return Variable(self.dims, obj)
../xarray/xarray/core/variable.py:397: in __init__
    super().__init__(
../xarray/xarray/namedarray/core.py:264: in __init__
    self._dims = self._parse_dimensions(dims)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <[AttributeError("'Variable' object has no attribute '_dims'") raised in repr()] Variable object at 0x31f3c03a0>, dims = ()

    def _parse_dimensions(self, dims: _DimsLike) -> _Dims:
        dims = (dims,) if isinstance(dims, str) else tuple(dims)
        if len(dims) != self.ndim:
>           raise ValueError(
                f"dimensions {dims} must have the same length as the "
                f"number of data dimensions, ndim={self.ndim}"
            )
E           ValueError: dimensions () must have the same length as the number of data dimensions, ndim=1

../xarray/xarray/namedarray/core.py:490: ValueError
</pre></details>

Two more that are coming from Cartopy 0.23:
<details><pre>
______________________________________________________________________________________________________________ test_lcc_minimal _______________________________________________________________________________________________________________

    def test_lcc_minimal():
        """Test handling lambert conformal conic projection with minimal attributes."""
        attrs = {'grid_mapping_name': 'lambert_conformal_conic'}
>       crs = CFProjection(attrs).to_cartopy()

tests/plots/test_mapping.py:153: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/metpy/plots/mapping.py:89: in to_cartopy
    return proj_handler(self._attrs, globe)
src/metpy/plots/mapping.py:148: in make_lcc
    return ccrs.LambertConformal(globe=globe, **kwargs)
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/cartopy/crs.py:1795: in __init__
    self._boundary = sgeom.LinearRing(points)
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/shapely/geometry/polygon.py:104: in __new__
    geom = shapely.linearrings(coordinates)
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/shapely/decorators.py:77: in wrapped
    return func(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

coords = array([[               nan,                nan,                nan],
       [-16165309.26647638,  14814526.9736842 ,  ...4047416,  14776231.67371788,         0.        ],
       [               nan,                nan,                nan]])
y = None, z = None, indices = None, out = None, kwargs = {}

    @multithreading_enabled
    def linearrings(coords, y=None, z=None, indices=None, out=None, **kwargs):
        """Create an array of linearrings.
    
        If the provided coords do not constitute a closed linestring, or if there
        are only 3 provided coords, the first
        coordinate is duplicated at the end to close the ring. This function will
        raise an exception if a linearring contains less than three points or if
        the terminal coordinates contain NaN (not-a-number).
    
        Parameters
        ----------
        coords : array_like
            An array of lists of coordinate tuples (2- or 3-dimensional) or, if ``y``
            is provided, an array of lists of x coordinates
        y : array_like, optional
        z : array_like, optional
        indices : array_like, optional
            Indices into the target array where input coordinates belong. If
            provided, the coords should be 2D with shape (N, 2) or (N, 3) and
            indices should be an array of shape (N,) with integers in increasing
            order. Missing indices result in a ValueError unless ``out`` is
            provided, in which case the original value in ``out`` is kept.
        out : ndarray, optional
            An array (with dtype object) to output the geometries into.
        **kwargs
            See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
            Ignored if ``indices`` is provided.
    
        See also
        --------
        linestrings
    
        Examples
        --------
        >>> linearrings([[0, 0], [0, 1], [1, 1], [0, 0]])
        <LINEARRING (0 0, 0 1, 1 1, 0 0)>
        >>> linearrings([[0, 0], [0, 1], [1, 1]])
        <LINEARRING (0 0, 0 1, 1 1, 0 0)>
    
        Notes
        -----
        - Usage of the ``y`` and ``z`` arguments will prevents lazy evaluation in ``dask``.
          Instead provide the coordinates as a ``(..., 2)`` or ``(..., 3)`` array using only ``coords``.
        """
        coords = _xyz_to_coords(coords, y, z)
        if indices is None:
>           return lib.linearrings(coords, out=out, **kwargs)
E           shapely.errors.GEOSException: IllegalArgumentException: Points of LinearRing do not form a closed linestring

../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/shapely/creation.py:171: GEOSException
________________________________________________________________________________________________________ test_lcc_single_std_parallel _________________________________________________________________________________________________________

    def test_lcc_single_std_parallel():
        """Test lambert conformal projection with one standard parallel."""
        attrs = {'grid_mapping_name': 'lambert_conformal_conic', 'standard_parallel': 25}
>       crs = CFProjection(attrs).to_cartopy()

tests/plots/test_mapping.py:160: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/metpy/plots/mapping.py:89: in to_cartopy
    return proj_handler(self._attrs, globe)
src/metpy/plots/mapping.py:148: in make_lcc
    return ccrs.LambertConformal(globe=globe, **kwargs)
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/cartopy/crs.py:1795: in __init__
    self._boundary = sgeom.LinearRing(points)
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/shapely/geometry/polygon.py:104: in __new__
    geom = shapely.linearrings(coordinates)
../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/shapely/decorators.py:77: in wrapped
    return func(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

coords = array([[            nan,             nan,             nan],
       [-2.02394033e+07,  7.05542455e+06,  0.00000000e+00]...      [ 2.02313877e+07,  7.02330796e+06,  0.00000000e+00],
       [            nan,             nan,             nan]])
y = None, z = None, indices = None, out = None, kwargs = {}

    @multithreading_enabled
    def linearrings(coords, y=None, z=None, indices=None, out=None, **kwargs):
        """Create an array of linearrings.
    
        If the provided coords do not constitute a closed linestring, or if there
        are only 3 provided coords, the first
        coordinate is duplicated at the end to close the ring. This function will
        raise an exception if a linearring contains less than three points or if
        the terminal coordinates contain NaN (not-a-number).
    
        Parameters
        ----------
        coords : array_like
            An array of lists of coordinate tuples (2- or 3-dimensional) or, if ``y``
            is provided, an array of lists of x coordinates
        y : array_like, optional
        z : array_like, optional
        indices : array_like, optional
            Indices into the target array where input coordinates belong. If
            provided, the coords should be 2D with shape (N, 2) or (N, 3) and
            indices should be an array of shape (N,) with integers in increasing
            order. Missing indices result in a ValueError unless ``out`` is
            provided, in which case the original value in ``out`` is kept.
        out : ndarray, optional
            An array (with dtype object) to output the geometries into.
        **kwargs
            See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
            Ignored if ``indices`` is provided.
    
        See also
        --------
        linestrings
    
        Examples
        --------
        >>> linearrings([[0, 0], [0, 1], [1, 1], [0, 0]])
        <LINEARRING (0 0, 0 1, 1 1, 0 0)>
        >>> linearrings([[0, 0], [0, 1], [1, 1]])
        <LINEARRING (0 0, 0 1, 1 1, 0 0)>
    
        Notes
        -----
        - Usage of the ``y`` and ``z`` arguments will prevents lazy evaluation in ``dask``.
          Instead provide the coordinates as a ``(..., 2)`` or ``(..., 3)`` array using only ``coords``.
        """
        coords = _xyz_to_coords(coords, y, z)
        if indices is None:
>           return lib.linearrings(coords, out=out, **kwargs)
E           shapely.errors.GEOSException: IllegalArgumentException: Points of LinearRing do not form a closed linestring

../../miniconda3/envs/numpy-dev-pip/lib/python3.12/site-packages/shapely/creation.py:171: GEOSException
</pre></details>
I'll hit the latter 2 in #3474/upstream PR. Not sure where the problem exists for the first two yet.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->