### PR TITLE
Reduce dependabot frequency to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,7 @@ updates:
   - package-ecosystem: pip
     directory: "/ci"
     schedule:
-      interval: daily
-      time: "06:00"
-      timezone: "America/Denver"
+      interval: weekly
     allow:
       - dependency-type: all
     open-pull-requests-limit: 10
@@ -35,7 +33,7 @@ updates:
       - "/.github/actions/install-pypi"
       - "/.github/actions/run-tests"
     schedule:
-      interval: "daily"
+      interval: weekly
     allow:
       - dependency-type: all
     open-pull-requests-limit: 10


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Weekly will still get us updates frequently enough, but might hopefully reduce some noise around quick point releases, as well as give more time for conda-forge to update and avoid false fails and associated CI re-runs.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
