### PR TITLE
Fix galvez_davison_index error: invalid index to scalar variable

### DIFF
--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -4602,7 +4602,7 @@ def galvez_davison_index(pressure, temperature, mixing_ratio, surface_pressure,
             f'elevation regions.\nIndices without a 950hPa or higher datapoint'
             f':\n{indices_without_950}'
             f'\nMax provided pressures:'
-            f'\n{np.max(pressure, axis=0)[indices_without_950]}'
+            f'\n{np.max(pressure, axis=0)}'
         )
 
     potential_temp = potential_temperature(pressure, temperature)

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -4591,16 +4591,12 @@ def galvez_davison_index(pressure, temperature, mixing_ratio, surface_pressure,
     <Quantity(-8.78797532, 'dimensionless')>
     """
     if np.any(np.max(pressure, axis=vertical_dim) < 950 * units.hectopascal):
-        indices_without_950 = np.where(
-            np.max(pressure, axis=vertical_dim) < 950 * units.hectopascal
-        )
         raise ValueError(
             f'Data not provided for 950hPa or higher pressure. '
             f'GDI requires 950hPa temperature and dewpoint data, '
             f'see referenced paper section 3.d. in docstring for discussion of'
             f' extrapolating sounding data below terrain surface in high-'
             f'elevation regions.\nIndices without a 950hPa or higher datapoint'
-            f':\n{indices_without_950}'
             f'\nMax provided pressures:'
             f'\n{np.max(pressure, axis=0)}'
         )

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -2551,7 +2551,7 @@ def test_gdi_no_950_by_simplevalue():
         pressure = np.array([922., 850., 700., 600., 500., 400., 300., 250.,
                              200., 150.]) * units.hPa
         temperature = np.array([22.6, 18.6, 8.6, 2.8, -4.6, -15.5, -30.6, -40.4,
-                                -52.9, -67.8,]) * units.degC
+                                -52.9, -67.8]) * units.degC
         relative_humidity = np.array([71.12, 71.16, 70.79, 50.33, 28.22, 4.80, 3.68, 5.82,
                                       18.18, 27.33]) * units.percent
         mixrat = mixing_ratio_from_relative_humidity(pressure, temperature, relative_humidity)

--- a/tests/calc/test_thermo.py
+++ b/tests/calc/test_thermo.py
@@ -2545,6 +2545,24 @@ def test_gdi_no_950_raises_valueerror(index_xarray_data):
         )
 
 
+def test_gdi_no_950_by_simplevalue():
+    """GDI requires a 950hPa or higher measurement."""
+    with pytest.raises(ValueError):
+        pressure = np.array([922., 850., 700., 600., 500., 400., 300., 250.,
+                             200., 150.]) * units.hPa
+        temperature = np.array([22.6, 18.6, 8.6, 2.8, -4.6, -15.5, -30.6, -40.4,
+                                -52.9, -67.8,]) * units.degC
+        relative_humidity = np.array([71.12, 71.16, 70.79, 50.33, 28.22, 4.80, 3.68, 5.82,
+                                      18.18, 27.33]) * units.percent
+        mixrat = mixing_ratio_from_relative_humidity(pressure, temperature, relative_humidity)
+        galvez_davison_index(
+            pressure,
+            temperature,
+            mixrat,
+            pressure[0]
+        )
+
+
 def test_gradient_richardson_number():
     """Test gradient Richardson number calculation."""
     theta = units('K') * np.asarray([254.5, 258.3, 262.2])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Fix galvez_davison_index error when missing data at 950 hPa. In raise ValueError at:
`f'\n{np.max(pressure, axis=0)[indices_without_950]}'` 
It show error message: "invalid index to scalar variable". This cause from [indices_without_950] behind the np.max().
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [ ] Closes #xxxx
- [X] Tests added (Re-test already)
- [X] Fully documented (Didn't edit any documents.)
