### PR TITLE
Bump to numpy 2

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib==3.9.2
-numpy==1.26.4
+numpy==2.0.1
 pandas==2.2.2
 pooch==1.8.2
 pint==0.24.3

--- a/examples/meteogram_metpy.py
+++ b/examples/meteogram_metpy.py
@@ -181,7 +181,7 @@ hgt_example = 292.
 
 # Parse dates from .csv file, knowing their format as a string and convert to datetime
 def parse_date(date):
-    return dt.datetime.strptime(date.decode('ascii'), '%Y-%m-%d %H:%M:%S')
+    return dt.datetime.strptime(date, '%Y-%m-%d %H:%M:%S')
 
 
 testdata = np.genfromtxt(get_test_data('timeseries.csv', False), names=True, dtype=None,

--- a/src/metpy/calc/thermo.py
+++ b/src/metpy/calc/thermo.py
@@ -2588,7 +2588,7 @@ def most_unstable_parcel(pressure, temperature, dewpoint, height=None, bottom=No
     >>> # find most unstable parcel of depth 50 hPa
     >>> most_unstable_parcel(p, T, Td, depth=50*units.hPa)
     (<Quantity(1008.0, 'hectopascal')>, <Quantity(29.3, 'degree_Celsius')>,
-    <Quantity(26.5176931, 'degree_Celsius')>, 0)
+    <Quantity(26.5176931, 'degree_Celsius')>, np.int64(0))
 
     See Also
     --------

--- a/src/metpy/plots/declarative.py
+++ b/src/metpy/plots/declarative.py
@@ -1012,7 +1012,9 @@ class ImagePlot(PlotScalar, ColorfillTraits, ValidationMixin):
         # If we're on a map, we use min/max for y and manually figure out origin to try to
         # avoid upside down images created by images where y[0] > y[-1], as well as
         # specifying the transform
-        kwargs['extent'] = (x_like[0], x_like[-1], y_like.min(), y_like.max())
+        # TODO item() shouldn't be necessary, but is until pydata/xarray#9043 is fixed.
+        kwargs['extent'] = (x_like[0].item(), x_like[-1].item(),
+                            y_like.min().item(), y_like.max().item())
         kwargs['origin'] = 'upper' if y_like[0] > y_like[-1] else 'lower'
         kwargs.setdefault('cmap', self._cmap_obj)
         kwargs.setdefault('norm', self._norm_obj)

--- a/tests/plots/test_declarative.py
+++ b/tests/plots/test_declarative.py
@@ -285,7 +285,7 @@ def test_declarative_figsize():
 
 
 @pytest.mark.mpl_image_compare(remove_text=True,
-                               tolerance=0.104 if version_check('cartopy<0.23') else 0.031)
+                               tolerance=0.104 if version_check('cartopy<0.23') else 0.033)
 @needs_cartopy
 def test_declarative_smooth_field():
     """Test the smoothing of the field with smooth_field trait."""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
As it says above.
* One last commit to clean up a problem with `DataArray` "scalars" not working with linspace (done by cartopy for imshow).
* Fix `meteogram_metpy.py` for numpy 2--no longer need manual `decode()` call
* Tweak image threshold ever so slightly (0.031->0.033) due to some small change with numpy2
* Adjust example expected text output for numpy 2 (include `np.int64()`).


<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

