### PR TITLE
fix wrong input to function

### DIFF
--- a/examples/Advanced_Sounding_With_Complex_Layout.py
+++ b/examples/Advanced_Sounding_With_Complex_Layout.py
@@ -214,7 +214,7 @@ total_totals = mpcalc.total_totals_index(p, T, Td)
 # mixed layer parcel properties!
 ml_t, ml_td = mpcalc.mixed_layer(p, T, Td, depth=50 * units.hPa)
 ml_p, _, _ = mpcalc.mixed_parcel(p, T, Td, depth=50 * units.hPa)
-mlcape, mlcin = mpcalc.mixed_layer_cape_cin(p, T, prof, depth=50 * units.hPa)
+mlcape, mlcin = mpcalc.mixed_layer_cape_cin(p, T, Td, depth=50 * units.hPa)
 
 # most unstable parcel properties!
 mu_p, mu_t, mu_td, _ = mpcalc.most_unstable_parcel(p, T, Td, depth=50 * units.hPa)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

As I was working with someone on creating a sounding and calculating the different CAPE values who had started with this example code, we noticed that the MLCAPE value seemed off. It turns out that in this example, the parcel profile was used for the dew point temperature in the mixed-layer calculation. In the example itself there would not be much difference in the computed value (likely why it was missed), but happen to be fairly large in the case they were looking at.

Anyway, simple fix to update this wonderful example.
