### PR TITLE
Fix xarray support with decode_coords='all'

### DIFF
--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -835,9 +835,10 @@ class MetPyDatasetAccessor:
 
         # Attempt to build the crs coordinate
         crs = None
-        if 'grid_mapping' in var.attrs:
-            # Use given CF grid_mapping
-            proj_name = var.attrs['grid_mapping']
+
+        # Check both raw attribute and xarray-handled and moved to encoding
+        proj_name = var.encoding.get('grid_mapping', var.attrs.get('grid_mapping'))
+        if proj_name is not None:
             try:
                 proj_var = self._dataset.variables[proj_name]
             except KeyError:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This support was added in pydata/xarray#2844 and handles converting the `grid_mapping` variable to a coordinate in xarray itself, which was incompatible with some assumptions in `parse_cf()`. Add some handling for the case where the grid_mapping. Also add `decode_coords='all'` to our full test suite (parametrized) and adjust a few tests as necessary; this includes removing a test for not removing `grid_mapping` attribute since that's not a universal truth any more (beyond our control).

This is motivated by being compatible with rioxarray, which relies on `decode_coords='all'` for its own projection handling, and can be used to load GOES data and do direct image remapping.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Tests added