### PR TITLE
Fix q_vector units w/ default static stability

### DIFF
--- a/examples/calculations/QVector.py
+++ b/examples/calculations/QVector.py
@@ -23,8 +23,10 @@ ds = example_data()
 # Calculate the temperature advection of the flow
 tadv = mpcalc.advection(ds.temperature, ds.uwind, ds.vwind)
 
-# Calculate the q-vectors
-u_qvect, v_qvect = mpcalc.q_vector(ds.uwind, ds.vwind, ds.temperature, 850 * units.hPa)
+# Calculate the q-vectors. Passing in a fixed value of static stability, but could also
+# use `mpcalc.static_stability()`.
+u_qvect, v_qvect = mpcalc.q_vector(ds.uwind, ds.vwind, ds.temperature, 850 * units.hPa,
+                                   static_stability=0.02 * units('J / kg / Pa^2'))
 
 # start figure and set axis
 fig, ax = plt.subplots(figsize=(5, 5))

--- a/src/metpy/calc/kinematics.py
+++ b/src/metpy/calc/kinematics.py
@@ -1275,7 +1275,8 @@ def inertial_advective_wind(
     broadcast=('u', 'v', 'temperature', 'pressure', 'static_stability', 'parallel_scale',
                'meridional_scale')
 )
-@check_units('[speed]', '[speed]', '[temperature]', '[pressure]', '[length]', '[length]')
+@check_units('[speed]', '[speed]', '[temperature]', '[pressure]', '[length]', '[length]',
+             '[energy] / [mass] / [pressure]**2')
 def q_vector(
     u,
     v,
@@ -1306,6 +1307,12 @@ def q_vector(
                   \right) \omega =
               - 2 \nabla_p \cdot \vec{Q} -
                   \frac{R}{\sigma p} \beta \frac{\partial T}{\partial x}
+
+    By default, this function uses a unitless value of 1 for ``static_stability``, which
+    replicates the functionality of the GEMPAK ``QVEC`` function. If a value is given for
+    ``static_stability``, it should have dimensionality of ``energy / mass / pressure^2``, and
+    will result in behavior that matches that of GEMPAK's ``QVCL`` function;
+    `static_stability` can be used to calculate this value if desired.
 
     Parameters
     ----------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

With the final discussion in #3689, this tries to improve the documentation to make clear the option to pass in `static_stability`, as well as the relationship to various GEMPAK functions.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #3689
- [x] Tests updated
- [x] Fully documented
