### PR TITLE
GHA security cleanup

### DIFF
--- a/.github/workflows/assign-milestone.yml
+++ b/.github/workflows/assign-milestone.yml
@@ -6,12 +6,12 @@ on:
     types: [closed]
     branches: [main]
 
-permissions:
-  pull-requests: write
-  issues: write
-
 jobs:
   sync:
+    permissions:
+      pull-requests: write
+      issues: write
+
     name: Assign Latest Milestone
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -2,6 +2,7 @@ name: Auto-merge Dependabot PRs
 
 on:
   pull_request_target:
+    branches: [main]
 
 jobs:
   #
@@ -12,6 +13,8 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     env:
       GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      GH_PR: ${{ github.event.pull_request.number }}
 
     permissions:
       contents: write
@@ -19,6 +22,6 @@ jobs:
 
     steps:
     - name: Set auto-merge
-      run: gh pr merge -R ${{ github.repository }} --merge --auto ${{ github.event.pull_request.number }}
+      run: gh pr merge -R "$GH_REPO" --merge --auto "$GH_PR"
     - name: Review PR
-      run: gh pr review -R ${{ github.repository }} --approve ${{ github.event.pull_request.number }}
+      run: gh pr review -R "$GH_REPO" --approve "$GH_PR"

--- a/.github/workflows/backport-prs.yml
+++ b/.github/workflows/backport-prs.yml
@@ -13,6 +13,9 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
+    env:
+      GH_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
     steps:
       - name: Checkout PR HEAD
@@ -22,7 +25,7 @@ jobs:
           fetch-depth: 100
 
       - name: Fetch PR merge base
-        run: git fetch --no-tags --depth=100 origin ${{ github.event.pull_request.base.sha }}
+        run: git fetch --no-tags --depth=100 origin "$GH_BASE_SHA"
 
       - name: Set up git
         run: |
@@ -38,7 +41,7 @@ jobs:
       - name: Apply PR commits to ${{ steps.get-branch.outputs.backport-branch}} branch
         run: |
           git checkout -b ${{ steps.get-branch.outputs.backport-branch}} origin/${{ steps.get-branch.outputs.backport-branch}}
-          git cherry-pick -x ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+          git cherry-pick -x "$GH_BASE_SHA".."$GH_HEAD_SHA"
 
       - name: Create backport PR
         id: create-pr

--- a/.github/workflows/backport-prs.yml
+++ b/.github/workflows/backport-prs.yml
@@ -1,9 +1,5 @@
 name: Backport PRs
 
-permissions:
-  pull-requests: write
-  contents: write
-
 on:
   pull_request_target:
     types:
@@ -14,6 +10,10 @@ jobs:
   Backport:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged && contains( github.event.pull_request.labels.*.name, 'backport' )
+    permissions:
+      pull-requests: write
+      contents: write
+
     steps:
       - name: Checkout PR HEAD
         uses: actions/checkout@v4

--- a/.github/workflows/cffcheck.yml
+++ b/.github/workflows/cffcheck.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Check out a copy of the repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Check validity of CITATION.cff
         uses: citation-file-format/cffconvert-github-action@2.0.0

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -18,13 +18,13 @@ on:
   schedule:
     - cron: '0 8 * * 6'
 
-permissions:
-  contents: read
-  security-events: write
 
 jobs:
   CodeQL:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/docs-conda.yml
+++ b/.github/workflows/docs-conda.yml
@@ -37,6 +37,7 @@ jobs:
       with:
         fetch-depth: 150
         fetch-tags: true
+        persist-credentials: false
 
     - name: Install from Conda
       uses: ./.github/actions/install-conda

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,9 +10,6 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
   pull_request:
 
-permissions:
-  contents: write
-
 concurrency:
   group: ${{ github.workflow}}-${{ github.head_ref }}
   cancel-in-progress: true
@@ -66,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOC_VERSION: dev
+    permissions:
+      contents: write
 
     steps:
     - name: Download doc build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,9 +40,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 150
-
-    - name: Get tags
-      run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+        fetch-tags: true
+        persist-credentials: false
 
     - name: Install using PyPI
       uses: ./.github/actions/install-pypi

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3
         uses: actions/setup-python@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       id: setup

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -42,6 +42,7 @@ jobs:
       with:
         fetch-depth: 150
         fetch-tags: true
+        persist-credentials: false
 
     - name: Install from Conda
       uses: ./.github/actions/install-conda
@@ -66,6 +67,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -44,6 +44,7 @@ jobs:
       with:
         fetch-depth: 150
         fetch-tags: true
+        persist-credentials: false
 
     - name: Generate minimum dependencies
       if: ${{ matrix.dep-versions == 'Minimum' }}
@@ -94,6 +95,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/unstable-builds.yml
+++ b/.github/workflows/unstable-builds.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         fetch-depth: 150
         fetch-tags: true
+        persist-credentials: false
 
     - name: Assemble test requirements
       run: |
@@ -61,6 +62,7 @@ jobs:
       with:
         fetch-depth: 150
         fetch-tags: true
+        persist-credentials: false
 
     - name: Assemble doc requirements
       run: |


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
In light of a recent supply chain attack on Ultralytics that leveraged some template expansion vulnerabilities in some GitHub Actions, this addresses some issues found by the zizmor tool:
* Drop credentials after running `actions/checkout` whenever we don't need more git work
* Move permissions into individual jobs, rather than at the top of the workflow. Most using special permissions only have a single job, but this does change the docs workflow to only have `contents: write` for deploy (removing from build)
* Expand some PR parameters into intermediate environment variables to avoid template injection attacks

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
