### PR TITLE
MNT: make matplotlib an optional dependency

### DIFF
--- a/ci/extra_requirements.txt
+++ b/ci/extra_requirements.txt
@@ -1,3 +1,4 @@
+matplotlib==3.10.0
 cartopy==0.24.0
 dask==2025.1.0
 shapely==2.0.7

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,4 +1,3 @@
-matplotlib==3.10.0
 numpy==2.2.2
 pandas==2.2.3
 pooch==1.8.2

--- a/docs/userguide/installguide.rst
+++ b/docs/userguide/installguide.rst
@@ -10,7 +10,7 @@ years. For Python itself, that generally means supporting the last two minor rel
 currently supports Python >= 3.10.
 
 .. literalinclude:: ../../pyproject.toml
-   :start-at: matplotlib
+   :start-at: numpy 
    :end-at: xarray
 
 ------------
@@ -36,6 +36,11 @@ the base of the source directory, run:
     pip install .
 
 This will build and install MetPy into your current Python installation.
+
+To include the plotting features run:
+
+.. parsed-literal::
+   pip install .[plot]
 
 ------------------
 Working With Conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "matplotlib>=3.5.0",
     "numpy>=1.22.0",
     "pandas>=1.4.0",
     "pint>=0.17",
@@ -63,7 +62,11 @@ test = [
 extras = [
     "cartopy>=0.21.0",
     "dask>=2020.12.0",
-    "shapely>=1.6.4"
+    "shapely>=1.6.4",
+    "metpy[plot]"
+]
+plot = [
+    "matplotlib>=3.5.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
Applications that make use of the metpy analytical tools without the need for visualization may avoid importing matplotlib due to large import size.

In response to [MetPy#2163](https://github.com/Unidata/MetPy/issues/2163)

#### Description Of Changes

- matplotlib removed from base dependencies
- matplotlib added to "plot" optional group
- "plot" optional group added to "extras" optional group
- ci requirements files updated
- installation guide updated

#### Checklist

- [ x] Closes #2163
- [x ] Fully documented
