### PR TITLE
Update packaging metadata for license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=77", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,8 @@ description = "Collection of tools for reading, visualizing and performing calcu
 readme = "README.md"
 dynamic = ["version"]
 maintainers = [{name = "MetPy Developers", email = "support-python@unidata.ucar.edu"}]
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE", "AUTHORS.txt"]
 keywords = ["meteorology", "weather"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -21,8 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Atmospheric Science",
     "Intended Audience :: Science/Research",
-    "Operating System :: OS Independent",
-    "License :: OSI Approved :: BSD License"
+    "Operating System :: OS Independent"
 ]
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This addresses a deprecation in Setuptools >=77. This is definitely an improvement, but it also requires a version of setuptools that was only released 19 March 2025, but the deprecation becomes an error 18 February 2026. 

Leaving as a draft for now until we're ready to merge, just in case we want to cut any releases (especially bugfixes) before then.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #3802
