### PR TITLE
BUG: Fix handling rotated pole (lat/lon) parsing

### DIFF
--- a/src/metpy/plots/mapping.py
+++ b/src/metpy/plots/mapping.py
@@ -106,6 +106,10 @@ class CFProjection:
         """Return a given attribute."""
         return self._attrs[item]
 
+    def __contains__(self, item):
+        """Return whether a given attribute is present."""
+        return item in self._attrs
+
     def __eq__(self, other):
         """Test equality (CFProjection with matching attrs)."""
         return self.__class__ == other.__class__ and self.to_dict() == other.to_dict()

--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -45,9 +45,9 @@ coordinate_criteria = {
                      'atmosphere_hybrid_height_coordinate', 'atmosphere_sleve_coordinate',
                      'height_above_geopotential_datum', 'height_above_reference_ellipsoid',
                      'height_above_mean_sea_level'},
-        'y': 'projection_y_coordinate',
+        'y': {'projection_y_coordinate', 'grid_latitude'},
         'latitude': 'latitude',
-        'x': 'projection_x_coordinate',
+        'x': {'projection_x_coordinate', 'grid_longitude'},
         'longitude': 'longitude'
     },
     '_CoordinateAxisType': {
@@ -885,8 +885,10 @@ class MetPyDatasetAccessor:
                 try:
                     var = var.metpy.convert_coordinate_units(coord_name, 'meters')
                 except DimensionalityError:
-                    # Radians! Attempt to use perspective point height conversion
-                    if crs is not None:
+                    # Not strictly a length coordinate, so angle of some kind, either rotated
+                    # lat/lon or some satellite projection. Guess if we should convert to
+                    # length using the perspective point height
+                    if crs is not None and 'perspective_point_height' in crs:
                         height = crs['perspective_point_height']
                         new_coord_var = coord_var.copy(
                             data=(

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -253,6 +253,25 @@ def test_radian_projection_coords():
     assert data_var.coords['y'].metpy.unit_array[1] == 3 * units.meter
 
 
+def test_rotated_lat_lon():
+    """Test fallback code for radian units in projection coordinate variables."""
+    proj = xr.DataArray(0, attrs={'grid_mapping_name': 'rotated_latitude_longitude',
+                                  'grid_north_pole_latitude': 42.5,
+                                  'grid_north_pole_longitude': -277})
+    rlon = xr.DataArray(np.linspace(-33, 33, 3),
+                        attrs={'standard_name': 'grid_longitude', 'units': 'degrees'})
+    rlat = xr.DataArray(np.linspace(-27, 27, 2),
+                        attrs={'standard_name': 'grid_latitude', 'units': 'degrees'})
+    data = xr.DataArray(np.arange(6).reshape(3, 2), coords=(rlon, rlat), dims=('rlon', 'rlat'),
+                        attrs={'grid_mapping': 'rotated_pole'})
+    ds = xr.Dataset({'data': data, 'rotated_pole': proj})
+
+    # Check that the coordinates in this case are left alone
+    data_var = ds.metpy.parse_cf('data')
+    assert_array_equal(data_var.coords['rlon'], rlon)
+    assert_array_equal(data_var.coords['rlat'], rlat)
+
+
 def test_missing_grid_mapping_valid():
     """Test falling back to implicit lat/lon projection when valid."""
     lon = xr.DataArray(-np.arange(3),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Instead of just assuming we should fall back to the geostationary perspective_point_height support, check to see if that attribute is even available, otherwise there's no point in trying.

This wasn't done in the first place because it wasn't clear there were other projections with valid coordinates that couldn't be converted to meters.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #3814
- [x] Tests added
