### PR TITLE
Fix doc version handling on deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -82,6 +82,9 @@ jobs:
       if: ${{ github.event_name != 'push' || !contains(github.ref, 'main') }}
       run: echo "DOC_VERSION=v${{ needs.Docs.outputs.doc-version }}" >> $GITHUB_ENV
 
+    - name: Export doc version
+      run: echo "doc-version=${{ env.DOC_VERSION }}" >> $GITHUB_OUTPUT
+
     - name: Upload to GitHub Pages
       uses: peaceiris/actions-gh-pages@v4
       with:
@@ -91,3 +94,58 @@ jobs:
         destination_dir: ./${{ env.DOC_VERSION }}
         keep_files: false
         full_commit_message: Deploy ${{ env.DOC_VERSION }} to GitHub Pages
+
+  UpdateVersions:
+    needs: Deploy
+    if: ${{ needs.Deploy.outputs.doc-version != 'dev' }}
+    name: "Manage doc versions"
+    environment:
+      name: github-pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout docs
+      uses: actions/checkout@v4
+      with:
+        ref: "gh-pages"
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+
+    - name: Install packaging
+      run: python -m pip install packaging
+
+    - name: Update listing of versions
+      run: |
+        python << EOF
+        import json
+        from pathlib import Path
+        from packaging import version
+
+        # Get all paths that are versions
+        vers = sorted(version.parse(str(p)) for p in Path().glob('v[0-9]*'))
+
+        # Set up our version dictionary
+        versions = dict(versions=['latest', 'dev'],
+                        latest=f'v{vers[-1].major}.{vers[-1].minor}', prereleases=[])
+        versions['versions'].extend(f'v{v.major}.{v.minor}' for v in vers[-4:])
+
+        # Write to JSON file
+        with open('versions.json', 'wt') as verfile:
+            json.dump(versions, verfile)
+
+        # Update the 'latest' symlink
+        latest = Path('latest')
+        latest.unlink(missing_ok=True)
+        latest.symlink_to(versions['latest'], target_is_directory=True)
+        EOF
+
+    - name: Commit changes
+      run: |
+        git config user.name $GITHUB_ACTOR
+        git config user.email $GITHUB_ACTOR@users.noreply.github.com
+        git add latest versions.json
+        git commit -am "Update version listing and latest link" || true
+        git push


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
We were handling management of latest symlink and version information for docs using a workflow on gh-pages directly. This unfortunately does not automatically work due to GHA limitations on actions triggering more actions. Instead, just add version management to our docs workflow and run after deployment on appropriate versions.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
