### PR TITLE
Change backport PR workflow token

### DIFF
--- a/.github/workflows/backport-prs.yml
+++ b/.github/workflows/backport-prs.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   Backport:
+    environment:
+      name: PR Backport
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged && contains( github.event.pull_request.labels.*.name, 'backport' )
     permissions:
@@ -18,6 +20,24 @@ jobs:
       GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
     steps:
+      - name: Create App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
       - name: Checkout PR HEAD
         uses: actions/checkout@v4
         with:
@@ -26,11 +46,6 @@ jobs:
 
       - name: Fetch PR merge base
         run: git fetch --no-tags --depth=100 origin "$GH_BASE_SHA"
-
-      - name: Set up git
-        run: |
-          git config --global user.email github-actions[bot]@users.noreply.github.com
-          git config --global user.name github-actions[bot]
 
       - name: Get backport branch
         id: get-branch
@@ -47,6 +62,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.app-token.outputs.token }}
           title: '${{ github.event.pull_request.title }} (backport)'
           body: >
             Backport \#${{ github.event.number }} onto the


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
This changes to use a custom GitHub App-generated token. This allows our general CI workflows to run on the backported PR since it's using a newly created token rather than the GHA-provided token, which is prohibited from triggering new workflows. No change to the actual workflow steps/process, just the provision of the token.

@dcamron Looks like you were right, this was a pretty easy solution to implement.
