### PR TITLE
add_station_lat_lon: insert columns respectfully

### DIFF
--- a/src/metpy/io/station_data.py
+++ b/src/metpy/io/station_data.py
@@ -191,8 +191,8 @@ def add_station_lat_lon(df, stn_var=None):
         raise KeyError('Second argument not provided to add_station_lat_lon, but none of '
                        f'{names_to_try} were found.')
 
-    df['latitude'] = np.nan
-    df['longitude'] = np.nan
+    df.insert(len(df.columns), 'latitude', np.nan)
+    df.insert(len(df.columns), 'longitude', np.nan)
 
     if stn_var is None:
         stn_var = key_finder(df)

--- a/tests/io/test_station_data.py
+++ b/tests/io/test_station_data.py
@@ -42,6 +42,15 @@ def test_add_lat_lon_station_data_not_found():
         add_station_lat_lon(df)
 
 
+def test_add_lat_lon_station_data_existing_col():
+    """Test will fail if one of these columns exists already."""
+    df = pd.DataFrame({'station': ['KOUN', 'KVPZ'],
+                       'latitude': [44, 42]})
+
+    with pytest.raises(ValueError, match='cannot insert'):
+        add_station_lat_lon(df)
+
+
 def test_station_lookup_get_station():
     """Test that you can get a station by ID from the lookup."""
     assert station_info['KOUN'].id == 'KOUN'


### PR DESCRIPTION
Assuming this works across our entire matrix, this eliminates another lingering Pandas SettingWithCopyWarning that I was encountering in metpy-cookbook. Those will disappear eventually in Pandas 3.0, but this should generally be more respecting of whatever DataFrame we see. Small win of failing if latitude or longitude column already exists, as well.


#### Checklist

- [X] Tests added
