### PR TITLE
Replace flake8-continuation with flake8-broken-line

### DIFF
--- a/ci-dev/linting_requirements.txt
+++ b/ci-dev/linting_requirements.txt
@@ -4,7 +4,7 @@ flake8==7.3.0
 pycodestyle==2.14.0
 pyflakes==3.4.0
 
-flake8-continuation==1.0.5
+flake8-broken-line==1.0.0
 flake8-isort==6.1.2
 isort==6.0.1
 flake8-requirements==2.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ rst-roles = class, data, doc, func, meth, mod
 rst-directives = plot, versionchanged
 known-modules = matplotlib:[matplotlib,mpl_toolkits],netcdf4:[netCDF4]
 exclude = docs build src/metpy/io/_metar_parser/metar_parser.py
-select = E301 E302 E303 E304 E305 E306 I R
+select = E301 E302 E303 E304 E305 E306 I N400 R
 ignore = F405 W503 RST902 SIM106
 per-file-ignores = examples/*.py: D MPY001
                    tutorials/*.py: D MPY001


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
flake8-continuation seems unmaintained and is now spewing a bunch of warnings due to its use of the deprecated pkg_resources module. flake8-requirements is also issuing the warning, but seems better maintained. We can also elect not to use it since IIRC, there were limitations in the overall utility of that plugin.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #3866 
