### PR TITLE
Update Jenkinsfile - using withCredentials correctly for a deploy key

### DIFF
--- a/benchmarks/Jenkinsfile
+++ b/benchmarks/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
         // Pushes to the git repo if there have been changes
 		stage('Update results repo') {
 			steps {
-				withCredentials([sshUserPrivateKey(credentialsId: 'GH_DEPLOY_KEY_METPY_BENCH_RESULTS', gitToolName: 'Default')]) {
+				withCredentials([sshUserPrivateKey(credentialsId: 'GH_DEPLOY_KEY_METPY_BENCH_RESULTS', keyFileVariable: 'deploy_key')]) { {
                     sh '''
 				   	if [ -n "$(git status --porcelain)" ]; then 
 						cd ${CLONE_DIR} 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
The argument for the deploy key was incorrect in the last version of the Jenkinsfile. This should be correct
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

