### PR TITLE
Changing from https to ssh authentication in the Jenkinsfile

### DIFF
--- a/benchmarks/Jenkinsfile
+++ b/benchmarks/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
 			steps {
 				sh 'git config --global credential.helper cache'
 				sh 'git config --global push.default simple'
-				checkout scmGit(branches: [[name: '*/main']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'temp_repo_results'], cloneOption(depth: 1, noTags: false, reference: '', shallow: true)], userRemoteConfigs: [[credentialsId: 'GH_DEPLOY_KEY_METPY_BENCH_RESULTS', url: 'https://github.com/unidata/metpy-benchmark.git']])
+				checkout scmGit(branches: [[name: '*/main']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'temp_repo_results'], cloneOption(depth: 1, noTags: false, reference: '', shallow: true)], userRemoteConfigs: [[credentialsId: 'GH_DEPLOY_KEY_METPY_BENCH_RESULTS', url: 'git@github.com:Unidata/MetPy-benchmark.git']])
 			}
 		}
         // copies past results into the asv/results folder on the main repo


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Because we changed from using a PAT to a deploy key in the Jenkinsfile, we needed to switch from the https to git@ format of credentials in order to push.
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
