### PR TITLE
Forcing Jenkins to actually use the ssh key

### DIFF
--- a/benchmarks/Jenkinsfile
+++ b/benchmarks/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
 						git add --all
 						git commit -m "Jenkins Updating Benchmark Results BUILD-NUMBER:${BUILD_NUMBER}" || echo "-----no changes to commit-----"
 						export GIT_SSH_COMMAND="ssh -i ${deploy_key}"
-                        git push origin HEAD:main --force
+                        			git push origin HEAD:main --force
 					fi
 					'''
 				}

--- a/benchmarks/Jenkinsfile
+++ b/benchmarks/Jenkinsfile
@@ -69,7 +69,8 @@ pipeline {
 						cd ${CLONE_DIR} 
 						git add --all
 						git commit -m "Jenkins Updating Benchmark Results BUILD-NUMBER:${BUILD_NUMBER}" || echo "-----no changes to commit-----"
-						git push origin HEAD:main --force
+						export GIT_SSH_COMMAND="ssh -i ${deploy_key}"
+                        git push origin HEAD:main --force
 					fi
 					'''
 				}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Ok, we tested this one on a fake pipeline so this should really probably maybe if we're lucky work.
Long story short, Jenkins knew the SSH key but wasn't actually using it in the push which made GitHub think it was an imposter. This has been fixed with this PR. 
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
