### PR TITLE
Silence FututreWarning raised by xarray v2025.08.0

### DIFF
--- a/src/metpy/xarray.py
+++ b/src/metpy/xarray.py
@@ -810,7 +810,7 @@ class MetPyDatasetAccessor:
         if np.iterable(varname) and not isinstance(varname, str):
             # If non-string iterable is given, apply recursively across the varnames
             subset = xr.merge([self.parse_cf(single_varname, coordinates=coordinates)
-                               for single_varname in varname])
+                               for single_varname in varname], compat='no_conflicts')
             subset.attrs = self._dataset.attrs
             return subset
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

In xarray v2025.08.0 a `FutureWarning` has been introduced in the `xarray.merge` function to inform the users that the default value for the `compat` keyword argument will change in the future.

See https://github.com/pydata/xarray/commit/d237a712b7cbebf99ae8bc3149cd0c5f9dbddc6e.

The patch just modifies the current call to `xarray.merge` to pass explicitly the the current default value of `compat`.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [X] Closes #3870
- [ ] Tests added
- [ ] Fully documented
