### PR TITLE
Use unidata/pinned-actions-verifier v1.0.0

### DIFF
--- a/.github/workflows/verify-pinned-workflows.yml
+++ b/.github/workflows/verify-pinned-workflows.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: lesserwhirls/pinned-actions-verifier@ec04596d2fb5dfff128633b505a274a2d48bb298
+      - uses: unidata/pinned-actions-verifier@f35d45122e5b5db9d5c1726cbf890d3d4d980568 # v1.0.0


### PR DESCRIPTION
#### Description Of Changes

Update from lesserwhirls/pinned-actions-verifier to unidata/pinned-actions-verifier v1.0.0, which includes fixes for checking local actions.
