### PR TITLE
Add relative and absolute tolerance support to testing utilities (#3244)

### DIFF
--- a/src/metpy/testing.py
+++ b/src/metpy/testing.py
@@ -302,23 +302,29 @@ def assert_nan(value, value_units):
     assert np.isnan(value)
 
 
-def assert_almost_equal(actual, desired, decimal=7):
+def assert_almost_equal(actual, desired, decimal=7, rtol=None, atol=None):
     """Check that values are almost equal, including units.
 
     Wrapper around :func:`numpy.testing.assert_almost_equal`
     """
     actual, desired = check_and_drop_units(actual, desired)
-    numpy.testing.assert_almost_equal(actual, desired, decimal)
+    if rtol is not None or atol is not None:
+        numpy.testing.assert_allclose(actual, desired, rtol=rtol or 0, atol=atol or 0)
+    else:
+        numpy.testing.assert_almost_equal(actual, desired, decimal)
 
 
-def assert_array_almost_equal(actual, desired, decimal=7):
+def assert_array_almost_equal(actual, desired, decimal=7, rtol=None, atol=None):
     """Check that arrays are almost equal, including units.
 
     Wrapper around :func:`numpy.testing.assert_array_almost_equal`
     """
     actual, desired = check_and_drop_units(actual, desired)
     check_mask(actual, desired)
-    numpy.testing.assert_array_almost_equal(actual, desired, decimal)
+    if rtol is not None or atol is not None:
+        numpy.testing.assert_allclose(actual, desired, rtol=rtol or 0, atol=atol or 0)
+    else:    
+        numpy.testing.assert_array_almost_equal(actual, desired, decimal)
 
 
 def assert_array_equal(actual, desired):
@@ -331,9 +337,9 @@ def assert_array_equal(actual, desired):
     numpy.testing.assert_array_equal(actual, desired)
 
 
-def assert_xarray_allclose(actual, desired):
+def assert_xarray_allclose(actual, desired, rtol=1e-05, atol=1e-08):
     """Check that the xarrays are almost equal, including coordinates and attributes."""
-    xr.testing.assert_allclose(actual, desired)
+    xr.testing.assert_allclose(actual, desired, rtol=rtol, atol=atol)
     assert desired.metpy.coordinates_identical(actual)
     assert desired.attrs == actual.attrs
 

--- a/src/metpy/testing.py
+++ b/src/metpy/testing.py
@@ -323,7 +323,7 @@ def assert_array_almost_equal(actual, desired, decimal=7, rtol=None, atol=None):
     check_mask(actual, desired)
     if rtol is not None or atol is not None:
         numpy.testing.assert_allclose(actual, desired, rtol=rtol or 0, atol=atol or 0)
-    else:    
+    else:
         numpy.testing.assert_array_almost_equal(actual, desired, decimal)
 
 

--- a/tests/calc/test_basic.py
+++ b/tests/calc/test_basic.py
@@ -510,7 +510,7 @@ def test_smooth_gaussian(array_type):
                          [9.00900782, 10.20038736, 13.20489127, 18.20489127, 25.20489127,
                           34.20489127, 45.20489127, 58.20489127, 73.11931702, 86.48310568]],
                         '', mask=mask)
-    assert_array_almost_equal(s_actual, s_true)
+    assert_array_almost_equal(s_actual, s_true, rtol=1e-5)
 
 
 def test_smooth_gaussian_small_n():

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -66,3 +66,12 @@ def test_module_version_check_invalid_comparison():
     """Test invalid operator in version comparison."""
     with pytest.raises(ValueError, match='Comparison operator << '):
         version_check('numpy << 36')
+
+
+def test_coverage_for_rtol_atol():
+    """Test to ensure the rtol/atol logic paths are covered."""
+    a = np.array([1.0, 2.0])
+    b = np.array([1.00001, 2.00001])
+    
+    assert_array_almost_equal(a, b, rtol=1e-4)
+    assert_array_almost_equal(a, b, atol=1e-4)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -72,6 +72,6 @@ def test_coverage_for_rtol_atol():
     """Test to ensure the rtol/atol logic paths are covered."""
     a = np.array([1.0, 2.0])
     b = np.array([1.00001, 2.00001])
-    
+
     assert_array_almost_equal(a, b, rtol=1e-4)
     assert_array_almost_equal(a, b, atol=1e-4)


### PR DESCRIPTION
## Description of Changes
Addresses #3244 by adding **relative (`rtol`)** and **absolute (`atol`)** tolerance support to MetPy's testing utilities. This enables more precise scientific testing across varying magnitudes where fixed decimal precision is insufficient.

## Proposed Changes

### `metpy/testing.py` Updates
* **`assert_almost_equal` & `assert_array_almost_equal`**: Added `rtol` and `atol` parameters. Now wraps `numpy.testing.assert_allclose` when these are provided.
* **`assert_xarray_allclose`**: Updated to pass `rtol` and `atol` through to `xarray.testing.assert_allclose`.
* **Backward Compatibility**: Maintained `decimal` as the default behavior.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review performed
- [x] No new warnings generated

Fixes #3244