### PR TITLE
DOC: Clarify temperature units in NARR cross section example

### DIFF
--- a/examples/cross_section.py
+++ b/examples/cross_section.py
@@ -50,6 +50,7 @@ print(cross)
 # For this example, we will be plotting potential temperature, relative humidity, and
 # tangential/normal winds. And so, we need to calculate those, and add them to the dataset:
 
+# Temperature is in Kelvin for NARR data
 cross['Potential_temperature'] = mpcalc.potential_temperature(
     cross['isobaric'],
     cross['Temperature']


### PR DESCRIPTION
This PR adds a comment to clarify that the temperature variable in the NARR example is in Kelvin. The change is in `examples/cross_section.py` where `cross['Temperature']` is used for calculating potential temperature and relative humidity. Adding the comment helps users understand the units of the data, especially those new to the NARR dataset.