### PR TITLE
BUG: UDUnits-style powers must not be followed by a letter

### DIFF
--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -56,7 +56,7 @@ def _fix_udunits_div(string):
 
 # Fix UDUNITS-style powers, percent signs, and ill-defined units
 _UDUNIT_POWER = re.compile(r'(?<=[A-Za-z\)])(?![A-Za-z\)])'
-                           r'(?<![0-9\-][eE])(?<![0-9\-])(?=-?[0-9]+( |$))')
+                           r'(?<![0-9\-][eE])(?<![0-9\-])(?=-?[0-9]+([ )]|$))')
 _unit_preprocessors = [_fix_udunits_powers, lambda string: string.replace('%', 'percent'),
                        _fix_udunits_div]
 

--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -55,8 +55,7 @@ def _fix_udunits_div(string):
 
 
 # Fix UDUNITS-style powers, percent signs, and ill-defined units
-_UDUNIT_POWER = re.compile(r'(?<=[A-Za-z\)])(?![A-Za-z\)])'
-                           r'(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])')
+_UDUNIT_POWER = re.compile(r'(?<=[A-Za-z\)])(?<![0-9\.][eE])(?=-?[0-9]+( |$))')
 _unit_preprocessors = [_fix_udunits_powers, lambda string: string.replace('%', 'percent'),
                        _fix_udunits_div]
 

--- a/src/metpy/units.py
+++ b/src/metpy/units.py
@@ -55,7 +55,8 @@ def _fix_udunits_div(string):
 
 
 # Fix UDUNITS-style powers, percent signs, and ill-defined units
-_UDUNIT_POWER = re.compile(r'(?<=[A-Za-z\)])(?<![0-9\.][eE])(?=-?[0-9]+( |$))')
+_UDUNIT_POWER = re.compile(r'(?<=[A-Za-z\)])(?![A-Za-z\)])'
+                           r'(?<![0-9\-][eE])(?<![0-9\-])(?=-?[0-9]+( |$))')
 _unit_preprocessors = [_fix_udunits_powers, lambda string: string.replace('%', 'percent'),
                        _fix_udunits_div]
 

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -10,7 +10,7 @@ import pytest
 
 from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal,
                            assert_nan)
-from metpy.units import (check_units, concatenate, is_quantity,
+from metpy.units import (UndefinedUnitError, check_units, concatenate, is_quantity,
                          pandas_dataframe_to_unit_arrays, units)
 
 
@@ -231,9 +231,18 @@ def test_percent_units():
             marks=pytest.mark.xfail(reason='hgrecco/pint#1485')
         ),
         ('(J kg-1)(m s-1)(-1)', units.m ** 3 / units.s ** 3),
-        ('/s', units.s ** -1)
+        ('/s', units.s ** -1),
+        ('feet_H2O', units.kg / units.m / units.s ** 2)
     )
 )
 def test_udunits_power_syntax(unit_str, pint_unit):
     """Test that UDUNITS style powers are properly parsed and interpreted."""
     assert units(unit_str).to_base_units().units == pint_unit
+
+def test_unsupported_udunits_power_fails():
+    """Test that removing the spaces between factors causes parsing to fail.
+
+    UDUnits does not support this either.
+    """
+    with pytest.raises(UndefinedUnitError):
+        assert units('m2s-2').to_base_units.units == units.m ** 2 / units.s ** 2

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -10,8 +10,8 @@ import pytest
 
 from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal,
                            assert_nan)
-from metpy.units import (UndefinedUnitError, check_units, concatenate, is_quantity,
-                         pandas_dataframe_to_unit_arrays, units)
+from metpy.units import (UndefinedUnitError, check_units, concatenate,
+                         is_quantity, pandas_dataframe_to_unit_arrays, units)
 
 
 def test_concatenate():
@@ -238,6 +238,7 @@ def test_percent_units():
 def test_udunits_power_syntax(unit_str, pint_unit):
     """Test that UDUNITS style powers are properly parsed and interpreted."""
     assert units(unit_str).to_base_units().units == pint_unit
+
 
 def test_unsupported_udunits_power_fails():
     """Test that removing the spaces between factors causes parsing to fail.

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -10,8 +10,8 @@ import pytest
 
 from metpy.testing import (assert_almost_equal, assert_array_almost_equal, assert_array_equal,
                            assert_nan)
-from metpy.units import (UndefinedUnitError, check_units, concatenate,
-                         is_quantity, pandas_dataframe_to_unit_arrays, units)
+from metpy.units import (check_units, concatenate, is_quantity,
+                         pandas_dataframe_to_unit_arrays, UndefinedUnitError, units)
 
 
 def test_concatenate():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/MetPy/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

Change the regex transforming the UDUnits-style power specification (sticking the power right after the unit with no spaces) to pint-style units so that it doesn't also change chemical species: the change requires the factors be separated by spaces.  That is, 'm2 s-2' is fine (`m**2 s**-2`), 'm2s-2' is not (`m2s**-2`; `m2s` is not found in the registry).

I think most places strongly discourage the second.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [ ] Closes #4052
- [ ] Tests added
- [X] Fully documented
