### PR TITLE
Handle text-mode file objects in parse_wpc_surface_bulletin

### DIFF
--- a/src/metpy/io/text.py
+++ b/src/metpy/io/text.py
@@ -83,23 +83,28 @@ def parse_wpc_surface_bulletin(bulletin, year=None):
     bulletin : str or file-like object
         If str, the name of the file to be opened. If `bulletin` is a file-like object,
         this will be read from directly.
+    year : int, optional
+        Year to assume when parsing the timestamp from the bulletin. Defaults to `None`,
+        which results in the parser trying to find a year in the product header; if this
+        search fails, the current year is assumed.
 
     Returns
     -------
     dataframe : pandas.DataFrame
         A `DataFrame` where each row represents a pressure center or front. The `DataFrame`
         has four columns: 'valid', 'feature', 'strength', and 'geometry'.
-    year : int
-        Year to assume when parsing the timestamp from the bulletin. Defaults to `None`,
-        which results in the parser trying to find a year in the product header; if this
-        search fails, the current year is assumed.
 
     """
     from shapely.geometry import LineString, Point
 
     # Create list with lines of text from file
     with contextlib.closing(open_as_needed(bulletin)) as file:
-        text = file.read().decode('utf-8')
+        text = file.read()
+        # ``open_as_needed`` opens filename paths in binary mode, but a file-like object
+        # passed in directly (e.g. ``StringIO``) may already be text. Only decode bytes so
+        # that both binary and text sources work, as the docstring promises.
+        if isinstance(text, bytes):
+            text = text.decode('utf-8')
 
     parsed_text = []
     valid_time = datetime.now(UTC).replace(tzinfo=None)

--- a/tests/io/test_text.py
+++ b/tests/io/test_text.py
@@ -5,6 +5,7 @@
 from datetime import datetime
 
 import numpy as np
+import pandas as pd
 
 from metpy.cbook import get_test_data
 from metpy.io import parse_wpc_surface_bulletin
@@ -98,3 +99,22 @@ HIGHS -351 -3985 -4046 -38117 -7510
  """)
     df = parse_wpc_surface_bulletin(sample)
     assert df.geometry[0] == sgeom.Point([-51, -3])
+
+
+@needs_module('shapely')
+def test_parse_wpc_surface_bulletin_text_file_object():
+    """Test parsing a text-mode file-like object (e.g. StringIO), not just bytes."""
+    from io import BytesIO, StringIO
+
+    text = """VALID 062818Z
+HIGHS 1022 3961069 1020 3851069 1026 3750773
+LOWS 1016 4510934 1002 3441145 1003 4271229
+TROF 2971023 2831018 2691008
+ """
+    # A text-mode file object (read() -> str) must parse identically to a binary one
+    df_text = parse_wpc_surface_bulletin(StringIO(text), year=2000)
+    df_bytes = parse_wpc_surface_bulletin(BytesIO(text.encode('utf-8')), year=2000)
+
+    pd.testing.assert_frame_equal(df_text, df_bytes)
+    assert len(df_text) == 7
+    assert all(df_text.valid == datetime(2000, 6, 28, 18, 0, 0))


### PR DESCRIPTION
## Description

`parse_wpc_surface_bulletin` documents accepting a "str or file-like object", but it unconditionally calls `.decode('utf-8')` on the result of `file.read()`. `open_as_needed` opens *filename* paths in binary mode, but a file-like object passed in directly is returned untouched — so a text-mode object such as `io.StringIO` makes `read()` return `str`, and the `.decode()` call raises:

```
AttributeError: 'str' object has no attribute 'decode'
```

Fixes #3923.

### Reproduction

```python
from io import StringIO
from metpy.io import parse_wpc_surface_bulletin

sio = StringIO('''VALID 062818Z
HIGHS 1022 3961069 1020 3851069 1026 3750773
LOWS 1016 4510934 1002 3441145 1003 4271229
TROF 2971023 2831018 2691008
 ''')
parse_wpc_surface_bulletin(sio, year=2000)   # AttributeError before this PR
```

## Fix

Only decode when `read()` returns `bytes`:

```python
text = file.read()
if isinstance(text, bytes):
    text = text.decode('utf-8')
```

I went with an explicit `isinstance(text, bytes)` check rather than a broad `try/except AttributeError` (discussed in the issue): it handles exactly the two things the docstring promises — binary sources (`'rb'` file paths, `BytesIO`) and text sources (`StringIO`, text-mode files) — without swallowing unrelated `AttributeError`s or revisiting the Python 2→3 byte-handling story more broadly.

## Tests / docs

- Added `test_parse_wpc_surface_bulletin_text_file_object`, asserting a `StringIO` parses identically (`pd.testing.assert_frame_equal`) to the equivalent `BytesIO`.
- Moved the misplaced `year` entry from the **Returns** section to **Parameters** in the docstring (it is a parameter, not a return value).

`tests/io/test_text.py` (all 5), the `text.py` doctest, and `ruff` pass locally.