### PR TITLE
Strip inherited attributes from absolute_momentum result

### DIFF
--- a/src/metpy/calc/cross_sections.py
+++ b/src/metpy/calc/cross_sections.py
@@ -325,4 +325,14 @@ def absolute_momentum(u, v, index='index'):
     _, x, y = xr.broadcast(norm_wind, x, y)
     distance = np.hypot(x.metpy.quantify(), y.metpy.quantify())
 
-    return (norm_wind + f * distance).metpy.convert_units('m/s')
+    momentum = (norm_wind + f * distance).metpy.convert_units('m/s')
+
+    # The arithmetic above can carry through attributes that do not describe
+    # absolute momentum (e.g. the cross-section's x-coordinate metadata picked
+    # up via ``distance``, or the input wind's attributes), and whether they
+    # propagate at all depends on xarray's ``keep_attrs`` default. Absolute
+    # momentum is a newly derived quantity, so return it without these
+    # inherited attributes.
+    momentum.attrs = {}
+
+    return momentum


### PR DESCRIPTION
Addresses the `calc` test failures reported in the nightly build (#3933).

### Problem
`absolute_momentum` builds its result as `norm_wind + f * distance`, where `distance` is derived from the cross-section **x-coordinate** (`cross.metpy.x`) in the projection (`x`/`y`) branch of `distances_from_cross_section`. That coordinate carries descriptive attributes (`long_name="x coordinate of projection"`, `standard_name="projection_x_coordinate"`, `_metpy_axis`, `grid_spacing`, `_CoordinateAxisType`), and `np.hypot` (a NumPy ufunc) preserves them onto `distance`. Combined with the input wind's own attributes on `norm_wind`, the final arithmetic can return a DataArray whose `.attrs` are populated with metadata that does not describe absolute momentum.

Whether these attributes survive the arithmetic depends on xarray's `keep_attrs` default, which is why this only shows up against recent xarray (the nightly build), not the pinned CI. With `xarray==2026.4.x` the two affected tests fail:

```
FAILED tests/calc/test_cross_sections.py::test_absolute_momentum_given_xy           - assert desired.attrs == actual.attrs
FAILED tests/calc/test_cross_sections.py::test_absolute_momentum_xarray_units_attr  - assert desired.attrs == actual.attrs
```

Both build their expected result with no attributes, so the contract is that `absolute_momentum` returns a clean DataArray. (`test_absolute_momentum_given_lonlat` passes today only because its synthetic inputs and the lon/lat branch happen to be attribute-free.)

### Fix
Absolute momentum is a newly derived quantity, so explicitly clear the inherited attributes on the result. This makes the behavior robust to xarray's `keep_attrs` default and matches both the existing test contract and the historical behavior these tests were written against. It mirrors the way the sibling `normal_component` / `tangential_component` already manage attributes after their cross-section arithmetic.

```python
momentum = (norm_wind + f * distance).metpy.convert_units('m/s')
momentum.attrs = {}
return momentum
```

### Verification
Local env: `xarray==2026.4.0`, `numpy==2.4.6`, `scipy==1.17.1` (matching the nightly that surfaced this).

- All three `absolute_momentum` tests pass (with cartopy installed so the `@needs_cartopy` cases run):
  ```
  test_absolute_momentum_given_xy PASSED
  test_absolute_momentum_given_lonlat PASSED
  test_absolute_momentum_xarray_units_attr PASSED
  ```
- `momentum.attrs` is now `{}` for the NARR example.
- Full `tests/calc` suite: 646 passed, 37 skipped (was 645 passed / 1 failed before the change) — no regressions.
- `tests/calc/test_cross_sections.py`: 13 passed.
- `ruff check` clean on the changed file.

### Scope
This addresses only the `absolute_momentum` (`calc`) failures in #3933. The `test_declarative_*` image-comparison failures in that same nightly run are unrelated (Matplotlib 3.11 rc baseline image diffs) and are not touched here.